### PR TITLE
feat/Add a config field for the relay server plugin address

### DIFF
--- a/alumet/src/units.rs
+++ b/alumet/src/units.rs
@@ -276,13 +276,13 @@ impl FromStr for UnitPrefix {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let res = match s {
-            "n" => UnitPrefix::Nano,
-            "μ" => UnitPrefix::Micro,
-            "m" => UnitPrefix::Milli,
+            "nano" | "n" => UnitPrefix::Nano,
+            "micro" | "μ" => UnitPrefix::Micro,
+            "milli" | "m" => UnitPrefix::Milli,
             "" => UnitPrefix::Plain,
-            "k" => UnitPrefix::Kilo,
-            "M" => UnitPrefix::Mega,
-            "G" => UnitPrefix::Giga,
+            "kilo" | "k" => UnitPrefix::Kilo,
+            "mega" | "M" => UnitPrefix::Mega,
+            "giga" | "G" => UnitPrefix::Giga,
             _ => return Err(anyhow!("Unknown prefix")),
         };
         Ok(res)

--- a/plugin-relay/README.md
+++ b/plugin-relay/README.md
@@ -3,5 +3,6 @@
 The relay plugin allows to send and receive measurements over the network with the efficient gRPC protocol.
 
 This plugin is made of two parts, enabled by cargo features:
+
 - `client`: sends all measurements to the relay server
 - `server`: receives measurements from one or multiple clients

--- a/plugin-relay/src/client.rs
+++ b/plugin-relay/src/client.rs
@@ -28,7 +28,7 @@ struct Config {
     /// Defaults to the hostname.
     #[serde(default = "default_client_name")]
     client_name: String,
-    
+
     /// The URI of the collector, for instance `http://127.0.0.1:50051`.
     #[serde(default = "default_collector_uri")]
     collector_uri: String,

--- a/plugin-relay/src/lib.rs
+++ b/plugin-relay/src/lib.rs
@@ -4,5 +4,5 @@ pub mod client;
 pub mod server;
 
 pub mod protocol {
-    tonic::include_proto!("alumet_relay");   
+    tonic::include_proto!("alumet_relay");
 }


### PR DESCRIPTION
- fix(alumet): Add the name of the prefix symbols to UnitPrefix::from_str:
   When receiving a `MeasurementPoint` from a `RelayClientPlugin` by the
`RelayServerPlugin`, the `PrefixedUnit` may have a non empty prefix,
which would be equal to its `unique_name`. But the `from_str` was only
able to convert the `display_name` into the corresponding `UnitPrefix`.
It's now fixed by taking both names into account in the `from_str` match-case.


- feat(plugin-relay): Add a config field for the server listening address:
   It is now possible to give an address to listen on in the config
of the relay server plugin. The address can be an IP or any domain
name.