### PR TITLE
feat(alumet): Add environment variable interpolation for config files

### DIFF
--- a/alumet/Cargo.toml
+++ b/alumet/Cargo.toml
@@ -24,6 +24,7 @@ smallvec = { version = "1.13.2", features = ["union"] }
 tokio-util = "0.7.10"
 indoc = "2.0.5"
 thiserror = "1.0.62"
+fancy-regex = "0.13.0"
 
 # Dependencies for Linux builds only.
 [target.'cfg(target_os = "linux")'.dependencies]


### PR DESCRIPTION
# Description

It is now possible to any linux environment variable in the config files if the variable does exist and isn't empty. You can obviously escape the `$` symbol with a backslash to use it.

Some tests has been added to ensure that the regex is working correctly and that a breaking change will never be able to happen.