### PR TITLE
Improvements for the relay mode

### DIFF
--- a/alumet-api-dynamic/Cargo.toml
+++ b/alumet-api-dynamic/Cargo.toml
@@ -9,4 +9,4 @@ description = "Rust sugar on top of the C API, to make dynamic ALUMET plugins in
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.69.4"
+bindgen = "0.70.1"

--- a/alumet/Cargo.toml
+++ b/alumet/Cargo.toml
@@ -15,7 +15,7 @@ toml = { version = "0.8.19", features = ["preserve_order"] }
 libc = "0.2.158"
 log = "0.4.22"
 tokio = { version = "1.40.0", features = ["time", "rt", "rt-multi-thread", "macros", "signal"] }
-tokio-stream = "0.1.16"
+tokio-stream = { version = "0.1.16", features = ["sync"] }
 libloading = { version = "0.8.5", optional = true }
 anyhow = "1.0.88"
 fxhash = "0.2.1"

--- a/alumet/Cargo.toml
+++ b/alumet/Cargo.toml
@@ -25,6 +25,7 @@ tokio-util = "0.7.12"
 indoc = "2.0.5"
 thiserror = "1.0.63"
 fancy-regex = "0.13.0"
+futures = "0.3.30"
 
 # Dependencies for Linux builds only.
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/alumet/Cargo.toml
+++ b/alumet/Cargo.toml
@@ -11,19 +11,19 @@ default = ["dynamic"]
 dynamic = ["dep:libloading"]
 
 [dependencies]
-toml = { version = "0.8.8", features = ["preserve_order"] }
-libc = "0.2.152"
-log = "0.4.20"
-tokio = { version = "1.36.0", features = ["time", "rt", "rt-multi-thread", "macros", "signal"] }
-tokio-stream = "0.1.14"
-libloading = { version = "0.8.1", optional = true }
-anyhow = "1.0.79"
+toml = { version = "0.8.19", features = ["preserve_order"] }
+libc = "0.2.158"
+log = "0.4.22"
+tokio = { version = "1.40.0", features = ["time", "rt", "rt-multi-thread", "macros", "signal"] }
+tokio-stream = "0.1.16"
+libloading = { version = "0.8.5", optional = true }
+anyhow = "1.0.88"
 fxhash = "0.2.1"
-serde = "1.0.198"
+serde = "1.0.210"
 smallvec = { version = "1.13.2", features = ["union"] }
-tokio-util = "0.7.10"
+tokio-util = "0.7.12"
 indoc = "2.0.5"
-thiserror = "1.0.62"
+thiserror = "1.0.63"
 fancy-regex = "0.13.0"
 
 # Dependencies for Linux builds only.
@@ -33,7 +33,7 @@ tokio-timerfd = "0.2.0"
 # Dev dependencies for tests.
 [dev-dependencies]
 env_logger = "0.11.5"
-serde = { version = "1.0.198", features = ["derive"] }
+serde = { version = "1.0.210", features = ["derive"] }
 
 # Dependencies for the build script (build.rs).
 [build-dependencies]

--- a/alumet/src/ffi/metrics.rs
+++ b/alumet/src/ffi/metrics.rs
@@ -159,6 +159,7 @@ pub extern "C" fn mpoint_consumer_id(point: &MeasurementPoint) -> AString {
 }
 
 #[repr(C)]
+#[allow(unused)]
 pub enum FfiMeasurementValue {
     U64(u64),
     F64(f64),

--- a/alumet/src/ffi/plugin.rs
+++ b/alumet/src/ffi/plugin.rs
@@ -95,5 +95,5 @@ pub extern "C" fn alumet_add_output(
         write_fn: output_write_fn,
         drop_fn: output_drop_fn,
     });
-    alumet.add_output(output);
+    alumet.add_blocking_output(output);
 }

--- a/alumet/src/measurement.rs
+++ b/alumet/src/measurement.rs
@@ -376,6 +376,23 @@ impl<'a> IntoIterator for &'a MeasurementBuffer {
     }
 }
 
+impl IntoIterator for MeasurementBuffer {
+    type Item = MeasurementPoint;
+    type IntoIter = std::vec::IntoIter<MeasurementPoint>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.points.into_iter()
+    }
+}
+
+impl FromIterator<MeasurementPoint> for MeasurementBuffer {
+    fn from_iter<T: IntoIterator<Item = MeasurementPoint>>(iter: T) -> Self {
+        Self {
+            points: Vec::from_iter(iter),
+        }
+    }
+}
+
 impl std::fmt::Debug for MeasurementBuffer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MeasurementBuffer")

--- a/alumet/src/pipeline/elements/mod.rs
+++ b/alumet/src/pipeline/elements/mod.rs
@@ -1,4 +1,11 @@
 //! Implementation of the logic of pipeline elements.
+//!
+//! # Why are the builders traits?
+//! Builders are just closures, but they are quite long and used in various places of the `alumet` crate.
+//! To deduplicate the code and make it more readable, _trait aliases_ would have been idea.
+//!
+//! Unfortunately, _trait aliases_ are currently unstable.
+//! Therefore, I have defined subtraits with an automatic implementation for closures.
 pub mod error;
 pub mod output;
 pub mod source;

--- a/alumet/src/pipeline/elements/output.rs
+++ b/alumet/src/pipeline/elements/output.rs
@@ -1,30 +1,44 @@
 //! Implementation and control of output tasks.
 
+use std::future::Future;
 use std::ops::ControlFlow;
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::pin::Pin;
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 
 use anyhow::Context;
+use builder::{
+    AsyncOutputBuildContext, AsyncOutputBuilder, BlockingOutputBuildContext, BlockingOutputBuilder, OutputBuildContext,
+    OutputBuilder,
+};
+use control::SingleOutputController;
+use futures::Stream;
 use tokio::runtime;
-use tokio::sync::Notify;
 use tokio::task::{JoinError, JoinSet};
 
 use crate::measurement::MeasurementBuffer;
 use crate::metrics::MetricRegistry;
 use crate::pipeline::util::channel;
 use crate::pipeline::util::matching::OutputSelector;
-use crate::pipeline::util::naming::{NameGenerator, OutputName, ScopedNameGenerator};
-use crate::pipeline::{builder, PluginName};
+use crate::pipeline::util::naming::{NameGenerator, OutputName};
+use crate::pipeline::util::stream::{ControlledStream, SharedStreamState};
+use crate::pipeline::PluginName;
 
-use super::super::builder::elements::OutputBuilder;
 use super::super::registry;
 use super::error::WriteError;
 
-/// Exports measurements to an external entity, like a file or a database.
+/// A blocking output that exports measurements to an external entity, like a file or a database.
 pub trait Output: Send {
     /// Writes the measurements to the output.
     fn write(&mut self, measurements: &MeasurementBuffer, ctx: &OutputContext) -> Result<(), WriteError>;
 }
+
+/// An asynchronous stream of measurements, to be used by an asynchronous output.
+pub struct AsyncOutputStream(
+    pub Pin<Box<dyn Stream<Item = Result<MeasurementBuffer, channel::StreamRecvError>> + Send>>,
+); // TODO make opaque?
+
+pub type BoxedAsyncOutput = Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'static>>;
 
 /// Shared data that can be accessed by outputs.
 pub struct OutputContext<'a> {
@@ -40,7 +54,7 @@ pub(crate) struct OutputControl {
 
 struct TaskManager {
     spawned_tasks: JoinSet<anyhow::Result<()>>,
-    configs: Vec<(OutputName, Arc<SharedOutputConfig>)>,
+    controllers: Vec<(OutputName, control::SingleOutputController)>,
 
     rx_provider: channel::ReceiverProvider,
 
@@ -48,13 +62,6 @@ struct TaskManager {
     rt_normal: runtime::Handle,
 
     metrics: registry::MetricReader,
-}
-
-/// Context provided when building new outputs.
-struct BuildContext<'a> {
-    metrics: &'a MetricRegistry,
-    namegen: &'a mut ScopedNameGenerator,
-    runtime: runtime::Handle,
 }
 
 impl OutputControl {
@@ -66,7 +73,7 @@ impl OutputControl {
         Self {
             tasks: TaskManager {
                 spawned_tasks: JoinSet::new(),
-                configs: Vec::new(),
+                controllers: Vec::new(),
                 rx_provider,
                 rt_normal,
                 metrics: metrics.clone(),
@@ -76,13 +83,10 @@ impl OutputControl {
         }
     }
 
-    pub fn blocking_create_outputs(
-        &mut self,
-        outputs: Vec<(PluginName, Box<dyn OutputBuilder>)>,
-    ) -> anyhow::Result<()> {
+    pub fn blocking_create_outputs(&mut self, outputs: Vec<(PluginName, OutputBuilder)>) -> anyhow::Result<()> {
         let metrics = self.metrics.blocking_read();
         for (plugin, builder) in outputs {
-            let mut ctx = BuildContext {
+            let mut ctx = OutputBuildContext {
                 metrics: &metrics,
                 namegen: self.names.namegen_for_scope(&plugin),
                 runtime: self.tasks.rt_normal.clone(),
@@ -95,14 +99,14 @@ impl OutputControl {
     }
 
     #[allow(unused)]
-    pub async fn create_output(&mut self, plugin: PluginName, builder: Box<dyn OutputBuilder + Send>) {
+    pub async fn create_output(&mut self, plugin: PluginName, builder: builder::SendOutputBuilder) {
         let metrics = self.metrics.read().await;
-        let mut ctx = BuildContext {
+        let mut ctx = OutputBuildContext {
             metrics: &metrics,
             namegen: self.names.namegen_for_scope(&plugin),
             runtime: self.tasks.rt_normal.clone(),
         };
-        self.tasks.create_output(&mut ctx, builder);
+        self.tasks.create_output(&mut ctx, builder.into());
     }
 
     pub fn handle_message(&mut self, msg: ControlMessage) -> anyhow::Result<()> {
@@ -147,7 +151,24 @@ impl OutputControl {
 }
 
 impl TaskManager {
-    fn create_output(&mut self, ctx: &mut BuildContext, builder: Box<dyn OutputBuilder>) -> anyhow::Result<()> {
+    fn create_output<'a>(&mut self, ctx: &'a mut OutputBuildContext<'a>, builder: OutputBuilder) -> anyhow::Result<()> {
+        match builder {
+            OutputBuilder::Blocking(builder) => {
+                let mut ctx = BlockingOutputBuildContext(ctx);
+                self.create_blocking_output(&mut ctx, builder)
+            }
+            OutputBuilder::Async(builder) => {
+                let mut ctx = AsyncOutputBuildContext(ctx);
+                self.create_async_output(&mut ctx, builder)
+            }
+        }
+    }
+
+    fn create_blocking_output(
+        &mut self,
+        ctx: &mut BlockingOutputBuildContext,
+        builder: Box<dyn BlockingOutputBuilder>,
+    ) -> anyhow::Result<()> {
         // Build the output.
         let reg = builder(ctx).context("output creation failed")?;
 
@@ -155,9 +176,11 @@ impl TaskManager {
         let rx = self.rx_provider.get(); // to receive measurements
         let metrics = self.metrics.clone(); // to read metric definitions
 
-        // Create the task config.
-        let config = Arc::new(SharedOutputConfig::new());
-        self.configs.push((reg.name.clone(), config.clone()));
+        // Create and store the task controller.
+        let config = Arc::new(control::SharedOutputConfig::new());
+        let shared_config = config.clone();
+        let control = SingleOutputController::Blocking(config);
+        self.controllers.push((reg.name.clone(), control));
 
         // Put the output in a Mutex to overcome the lack of tokio::spawn_scoped.
         let guarded_output = Arc::new(Mutex::new(reg.output));
@@ -166,11 +189,11 @@ impl TaskManager {
         match rx {
             // Specialize on the kind of receiver at compile-time (for performance).
             channel::ReceiverEnum::Broadcast(rx) => {
-                let task = run_output(reg.name, guarded_output, rx, metrics, config);
+                let task = run_blocking_output(reg.name, guarded_output, rx, metrics, shared_config);
                 self.spawned_tasks.spawn_on(task, &self.rt_normal);
             }
             channel::ReceiverEnum::Single(rx) => {
-                let task = run_output(reg.name, guarded_output, rx, metrics, config);
+                let task = run_blocking_output(reg.name, guarded_output, rx, metrics, shared_config);
                 self.spawned_tasks.spawn_on(task, &self.rt_normal);
             }
         }
@@ -178,26 +201,49 @@ impl TaskManager {
         Ok(())
     }
 
+    fn create_async_output(
+        &mut self,
+        ctx: &mut AsyncOutputBuildContext,
+        builder: Box<dyn AsyncOutputBuilder>,
+    ) -> anyhow::Result<()> {
+        use channel::MeasurementReceiver;
+
+        fn box_controlled_stream<
+            S: Stream<Item = Result<MeasurementBuffer, channel::StreamRecvError>> + Send + 'static,
+        >(
+            stream: S,
+        ) -> (AsyncOutputStream, Arc<SharedStreamState>) {
+            let stream = Box::pin(ControlledStream::new(stream));
+            let state = stream.state();
+            (AsyncOutputStream(stream), state)
+        }
+
+        // For async outputs, we need to build the stream first
+        let rx = self.rx_provider.get();
+        let (stream, state) = match rx {
+            channel::ReceiverEnum::Broadcast(receiver) => box_controlled_stream(receiver.into_stream()),
+            channel::ReceiverEnum::Single(receiver) => box_controlled_stream(receiver.into_stream()),
+        };
+
+        // Create the output
+        let reg = builder(ctx, stream).context("output creation failed")?;
+
+        // Create and store the task controller
+        let control = SingleOutputController::Async(state);
+        self.controllers.push((reg.name.clone(), control));
+
+        // Spawn the output
+        let task = run_async_output(reg.name, reg.output);
+        self.spawned_tasks.spawn_on(task, &self.rt_normal);
+        Ok(())
+    }
+
     fn reconfigure(&mut self, msg: ControlMessage) {
-        for (name, output_config) in &mut self.configs {
+        for (name, output_config) in &mut self.controllers {
             if msg.selector.matches(name) {
                 output_config.set_state(msg.new_state);
             }
         }
-    }
-}
-
-impl builder::context::OutputBuildContext for BuildContext<'_> {
-    fn metric_by_name(&self, name: &str) -> Option<(crate::metrics::RawMetricId, &crate::metrics::Metric)> {
-        self.metrics.by_name(name)
-    }
-
-    fn output_name(&mut self, name: &str) -> OutputName {
-        self.namegen.output_name(name)
-    }
-
-    fn async_runtime(&self) -> &tokio::runtime::Handle {
-        &self.runtime
     }
 }
 
@@ -232,31 +278,12 @@ impl From<u8> for TaskState {
     }
 }
 
-pub struct SharedOutputConfig {
-    pub change_notifier: Notify,
-    pub atomic_state: AtomicU8,
-}
-
-impl SharedOutputConfig {
-    pub fn new() -> Self {
-        Self {
-            change_notifier: Notify::new(),
-            atomic_state: AtomicU8::new(TaskState::Run as u8),
-        }
-    }
-
-    pub fn set_state(&self, state: TaskState) {
-        self.atomic_state.store(state as u8, Ordering::Relaxed);
-        self.change_notifier.notify_one();
-    }
-}
-
-async fn run_output<Rx: channel::MeasurementReceiver>(
+async fn run_blocking_output<Rx: channel::MeasurementReceiver>(
     name: OutputName,
     guarded_output: Arc<Mutex<Box<dyn Output>>>,
     mut rx: Rx,
     metrics_reader: registry::MetricReader,
-    config: Arc<SharedOutputConfig>,
+    config: Arc<control::SharedOutputConfig>,
 ) -> anyhow::Result<()> {
     /// If `measurements` is an `Ok`, build an [`OutputContext`] and call `output.write(&measurements, &ctx)`.
     /// Otherwise, handle the error.
@@ -325,4 +352,166 @@ async fn run_output<Rx: channel::MeasurementReceiver>(
         }
     }
     Ok(())
+}
+
+async fn run_async_output(name: OutputName, output: BoxedAsyncOutput) -> anyhow::Result<()> {
+    output.await.with_context(|| format!("error in async output {}", name))
+}
+
+mod control {
+    use std::sync::{
+        atomic::{AtomicU8, Ordering},
+        Arc,
+    };
+    use tokio::sync::Notify;
+
+    use super::TaskState;
+    use crate::pipeline::util::stream::{SharedStreamState, StreamState};
+
+    pub enum SingleOutputController {
+        Blocking(Arc<SharedOutputConfig>),
+        Async(Arc<SharedStreamState>),
+    }
+
+    pub struct SharedOutputConfig {
+        pub change_notifier: Notify,
+        pub atomic_state: AtomicU8,
+    }
+
+    impl SharedOutputConfig {
+        pub fn new() -> Self {
+            Self {
+                change_notifier: Notify::new(),
+                atomic_state: AtomicU8::new(TaskState::Run as u8),
+            }
+        }
+
+        pub fn set_state(&self, state: TaskState) {
+            self.atomic_state.store(state as u8, Ordering::Relaxed);
+            self.change_notifier.notify_one();
+        }
+    }
+
+    impl SingleOutputController {
+        pub fn set_state(&mut self, state: TaskState) {
+            match self {
+                SingleOutputController::Blocking(shared) => shared.set_state(state),
+                SingleOutputController::Async(arc) => arc.set(StreamState::from(state as u8)),
+            }
+        }
+    }
+}
+
+pub mod builder {
+    use tokio::runtime;
+
+    use crate::{
+        metrics::MetricRegistry,
+        pipeline::util::naming::{OutputName, ScopedNameGenerator},
+    };
+
+    use super::AsyncOutputStream;
+
+    /// An output builder, for any type of output.
+    ///
+    /// Use this type in the pipeline builder.
+    pub enum OutputBuilder {
+        Blocking(Box<dyn BlockingOutputBuilder>),
+        Async(Box<dyn AsyncOutputBuilder>),
+    }
+
+    /// Like [`OutputBuilder`] but with a [`Send`] bound on the builder.
+    ///
+    /// Use this type in the pipeline control loop.
+    pub enum SendOutputBuilder {
+        Blocking(Box<dyn BlockingOutputBuilder + Send>),
+        Async(Box<dyn AsyncOutputBuilder + Send>),
+    }
+
+    impl From<SendOutputBuilder> for OutputBuilder {
+        fn from(value: SendOutputBuilder) -> Self {
+            match value {
+                SendOutputBuilder::Blocking(b) => OutputBuilder::Blocking(b),
+                SendOutputBuilder::Async(b) => OutputBuilder::Async(b),
+            }
+        }
+    }
+
+    pub struct BlockingOutputRegistration {
+        pub name: OutputName,
+        pub output: Box<dyn super::Output>,
+    }
+
+    pub struct AsyncOutputRegistration {
+        pub name: OutputName,
+        pub output: super::BoxedAsyncOutput,
+    }
+
+    /// Trait for builders of blocking outputs.
+    ///
+    ///  # Example
+    /// ```
+    /// use alumet::pipeline::builder::elements::{OutputBuilder, OutputRegistration};
+    /// use alumet::pipeline::builder::context::{OutputBuildContext};
+    /// use alumet::pipeline::{trigger, Output};
+    ///
+    /// fn build_my_output() -> anyhow::Result<Box<dyn Output>> {
+    ///     todo!("build a new output")
+    /// }
+    ///
+    /// let builder: &dyn OutputBuilder = &|ctx: &mut dyn OutputBuildContext| {
+    ///     let output = build_my_output()?;
+    ///     Ok(OutputRegistration {
+    ///         name: ctx.output_name("my-output"),
+    ///         output,
+    ///     })
+    /// };
+    /// ```
+    pub trait BlockingOutputBuilder:
+        FnOnce(&mut BlockingOutputBuildContext) -> anyhow::Result<BlockingOutputRegistration>
+    {
+    }
+    impl<F> BlockingOutputBuilder for F where
+        F: FnOnce(&mut BlockingOutputBuildContext) -> anyhow::Result<BlockingOutputRegistration>
+    {
+    }
+
+    pub trait AsyncOutputBuilder:
+        FnOnce(&mut AsyncOutputBuildContext, AsyncOutputStream) -> anyhow::Result<AsyncOutputRegistration>
+    {
+    }
+    impl<F> AsyncOutputBuilder for F where
+        F: FnOnce(&mut AsyncOutputBuildContext, AsyncOutputStream) -> anyhow::Result<AsyncOutputRegistration>
+    {
+    }
+
+    /// Context provided when building new outputs.
+    pub(super) struct OutputBuildContext<'a> {
+        pub(super) metrics: &'a MetricRegistry,
+        pub(super) namegen: &'a mut ScopedNameGenerator,
+        pub(super) runtime: runtime::Handle,
+    }
+
+    pub struct BlockingOutputBuildContext<'a>(pub(super) &'a mut OutputBuildContext<'a>);
+    pub struct AsyncOutputBuildContext<'a>(pub(super) &'a mut OutputBuildContext<'a>);
+
+    impl BlockingOutputBuildContext<'_> {
+        pub fn output_name(&mut self, name: &str) -> OutputName {
+            self.0.namegen.output_name(name)
+        }
+
+        pub fn metric_by_name(&self, name: &str) -> Option<(crate::metrics::RawMetricId, &crate::metrics::Metric)> {
+            self.0.metrics.by_name(name)
+        }
+    }
+
+    impl AsyncOutputBuildContext<'_> {
+        pub fn output_name(&mut self, name: &str) -> OutputName {
+            self.0.namegen.output_name(name)
+        }
+
+        pub fn async_runtime(&self) -> &tokio::runtime::Handle {
+            &self.0.runtime
+        }
+    }
 }

--- a/alumet/src/pipeline/registry.rs
+++ b/alumet/src/pipeline/registry.rs
@@ -2,6 +2,7 @@
 
 use std::{fmt::Debug, sync::Arc};
 
+use anyhow::Context;
 use tokio::{
     runtime,
     sync::{
@@ -93,7 +94,8 @@ impl MetricRegistryControl {
                 rt,
                 namegen: self.listener_names.namegen_for_scope(&plugin),
             };
-            let reg = builder(&mut ctx)?;
+            let reg = builder(&mut ctx)
+                .with_context(|| format!("error in listener creation requested by plugin {plugin}"))?;
             self.listeners.push(reg);
         }
         Ok(())

--- a/alumet/src/pipeline/util/mod.rs
+++ b/alumet/src/pipeline/util/mod.rs
@@ -2,6 +2,7 @@ pub mod channel;
 pub mod matching;
 pub mod naming;
 pub mod scope;
+pub mod stream;
 pub mod threading;
 
 /// Check (at compile-time) that `T` is [`Send`].

--- a/alumet/src/pipeline/util/naming.rs
+++ b/alumet/src/pipeline/util/naming.rs
@@ -119,6 +119,8 @@ pub struct ElementNameParts {
     pub(super) element: String,
 }
 
+// TODO for the name, I could use a &'static str (or a const perhaps?) for the type of the element.
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceName(pub(super) ElementNameParts);
 

--- a/alumet/src/pipeline/util/naming.rs
+++ b/alumet/src/pipeline/util/naming.rs
@@ -48,6 +48,7 @@ pub struct ScopedNameGenerator {
     source_dedup: NameDeduplicator,
     transform_dedup: NameDeduplicator,
     output_dedup: NameDeduplicator,
+    listener_dedup: NameDeduplicator,
     plugin: PluginName,
 }
 
@@ -57,6 +58,7 @@ impl ScopedNameGenerator {
             source_dedup: NameDeduplicator::new(),
             transform_dedup: NameDeduplicator::new(),
             output_dedup: NameDeduplicator::new(),
+            listener_dedup: NameDeduplicator::new(),
             plugin,
         }
     }
@@ -74,10 +76,18 @@ impl ScopedNameGenerator {
             element: self.transform_dedup.insert_deduplicate(name.to_owned(), false),
         })
     }
+
     pub fn output_name(&mut self, name: &str) -> OutputName {
         OutputName(ElementNameParts {
             plugin: self.plugin.0.clone(),
             element: self.output_dedup.insert_deduplicate(name.to_owned(), false),
+        })
+    }
+
+    pub fn listener_name(&mut self, name: &str) -> ListenerName {
+        ListenerName(ElementNameParts {
+            plugin: self.plugin.0.clone(),
+            element: self.listener_dedup.insert_deduplicate(name.to_owned(), false),
         })
     }
 }
@@ -111,10 +121,15 @@ pub struct ElementNameParts {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceName(pub(super) ElementNameParts);
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TransformName(pub(super) ElementNameParts);
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OutputName(pub(super) ElementNameParts);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ListenerName(pub(super) ElementNameParts);
 
 impl fmt::Display for PluginName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -137,6 +152,12 @@ impl fmt::Display for TransformName {
 impl fmt::Display for OutputName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}/output/{}", self.0.plugin, self.0.element)
+    }
+}
+
+impl fmt::Display for ListenerName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/listener/{}", self.0.plugin, self.0.element)
     }
 }
 

--- a/alumet/src/pipeline/util/stream.rs
+++ b/alumet/src/pipeline/util/stream.rs
@@ -1,0 +1,353 @@
+//! Stream-related utilities.
+
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use futures::task::AtomicWaker;
+use tokio_stream::Stream;
+
+/// A [`Stream`] wrapper that allows to pause and stop the stream.
+///
+/// Use [`state()`](Self::state) to obtain an `Arc` that points to the state of the stream,
+/// then [`SharedState::set`] to update it.
+pub struct ControlledStream<T, S: Stream<Item = T>> {
+    inner: S,
+    state: Arc<SharedStreamState>,
+}
+
+pub struct SharedStreamState {
+    waker: AtomicWaker,
+    state: AtomicU8,
+}
+
+/// State of a (managed) output task.
+#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[repr(u8)]
+pub enum StreamState {
+    Run,
+    Pause,
+    Stop,
+}
+
+impl SharedStreamState {
+    /// Updates the state of the stream.
+    pub fn set(&self, state: StreamState) {
+        self.state.store(state as u8, Ordering::Relaxed);
+        self.waker.wake();
+    }
+}
+
+impl<T, S: Stream<Item = T>> ControlledStream<T, S> {
+    /// Creates new controlled stream with the initial state [`StreamState::Run`].
+    pub fn new(inner: S) -> Self {
+        Self::with_initial_state(inner, StreamState::Run)
+    }
+
+    /// Wraps a stream in a new controlled stream with the given initial state.
+    pub fn with_initial_state(inner: S, state: StreamState) -> Self {
+        Self {
+            inner,
+            state: Arc::new(SharedStreamState {
+                waker: AtomicWaker::new(),
+                state: AtomicU8::new(state as u8),
+            }),
+        }
+    }
+
+    /// Returns a shared pointer to the shared stream state.
+    ///
+    /// Use this to update the state from any thread.
+    pub fn state(&self) -> Arc<SharedStreamState> {
+        self.state.clone()
+    }
+}
+
+impl<T, S: Stream<Item = T>> Stream for ControlledStream<T, S> {
+    type Item = T;
+
+    fn poll_next(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> std::task::Poll<Option<Self::Item>> {
+        // pin-project the fields
+        // SAFETY: we never use the fields directly after the unsafe block,
+        // and we never move the data out of self.get_unchecked_mut().
+        let (inner, state) = unsafe {
+            let this = self.get_unchecked_mut();
+            (Pin::new_unchecked(&mut this.inner), Pin::new_unchecked(&mut this.state))
+        };
+
+        let cur_state = state.state.load(Ordering::Relaxed).into();
+        match cur_state {
+            StreamState::Run => {
+                match Stream::poll_next(inner, cx) {
+                    Poll::Ready(item) => Poll::Ready(item),
+                    Poll::Pending => {
+                        // stream is not ready, register the waker for wakeup
+                        state.waker.register(cx.waker());
+                        Poll::Pending
+                    }
+                }
+            }
+            StreamState::Pause => {
+                // pause, wake up on config change
+                state.waker.register(cx.waker());
+                Poll::Pending
+            }
+            StreamState::Stop => {
+                // definitely stop
+                Poll::Ready(None)
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+impl From<u8> for StreamState {
+    fn from(value: u8) -> Self {
+        const RUN: u8 = StreamState::Run as u8;
+        const PAUSE: u8 = StreamState::Pause as u8;
+
+        match value {
+            RUN => StreamState::Run,
+            PAUSE => StreamState::Pause,
+            _ => StreamState::Stop,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        pin::pin,
+        sync::atomic::Ordering,
+        task::Poll,
+        time::{Duration, Instant},
+    };
+
+    use tokio_stream::StreamExt;
+
+    use crate::pipeline::util::stream::{ControlledStream, StreamState};
+
+    #[tokio::test]
+    async fn empty_controlled_stream() {
+        let values: Vec<&'static str> = vec![];
+        let stream = tokio_stream::iter(values.clone());
+        let mut stream = ControlledStream::new(stream);
+        assert_eq!(stream.next().await, None);
+    }
+
+    #[tokio::test]
+    async fn single_controlled_stream() {
+        let values: Vec<&'static str> = vec!["the one"];
+        let stream = tokio_stream::iter(values.clone());
+        let mut stream = ControlledStream::new(stream);
+        assert_eq!(stream.next().await, Some("the one"));
+        assert_eq!(stream.next().await, None);
+    }
+
+    #[tokio::test]
+    async fn multi_controlled_stream() {
+        let values: Vec<&'static str> = vec!["a", "b", "c"];
+        let stream = tokio_stream::iter(values.clone());
+        let mut stream = ControlledStream::new(stream);
+        assert_eq!(stream.next().await, Some("a"));
+        assert_eq!(stream.next().await, Some("b"));
+        assert_eq!(stream.next().await, Some("c"));
+        assert_eq!(stream.next().await, None);
+    }
+
+    #[tokio::test]
+    async fn collect_controlled_stream() {
+        {
+            let values = vec!["0", "1", "2", "3", "4", "5"];
+            let stream = tokio_stream::iter(values.clone());
+            let stream = ControlledStream::new(stream);
+            let collected: Vec<_> = stream.collect().await;
+            assert_eq!(collected, values);
+        }
+
+        {
+            let values = vec!["abc"];
+            let stream = tokio_stream::iter(values.clone());
+            let stream = ControlledStream::new(stream);
+            let collected: Vec<_> = stream.collect().await;
+            assert_eq!(collected, values);
+        }
+
+        {
+            let values: Vec<&'static str> = vec![];
+            let stream = tokio_stream::iter(values.clone());
+            let stream = ControlledStream::new(stream);
+            let collected: Vec<_> = stream.collect().await;
+            assert_eq!(collected, values);
+        }
+    }
+
+    #[tokio::test]
+    async fn pause_empty_controlled_stream() {
+        let mut stream = ControlledStream::new(tokio_stream::iter(Vec::<u8>::new()));
+        let stream_state = stream.state();
+        stream_state.set(StreamState::Pause);
+        let next = pin!(stream.next());
+        let polled = futures::poll!(next);
+        assert_eq!(Poll::Pending, polled);
+
+        stream_state.set(StreamState::Run);
+        let next = pin!(stream.next());
+        let polled = futures::poll!(next);
+        assert_eq!(Poll::Ready(None), polled);
+    }
+
+    #[tokio::test]
+    async fn pause_empty_controlled_stream_from_other_thread() {
+        let mut stream = ControlledStream::new(tokio_stream::iter(Vec::<u8>::new()));
+        let stream_state = stream.state();
+        stream_state.set(StreamState::Pause);
+        let next = pin!(stream.next());
+        let polled = futures::poll!(next);
+        assert_eq!(Poll::Pending, polled);
+
+        let sc = stream_state.clone();
+        let thread = std::thread::spawn(move || {
+            sc.set(StreamState::Run);
+        });
+        thread.join().unwrap();
+
+        let next = pin!(stream.next());
+        let polled = futures::poll!(next);
+        assert_eq!(Poll::Ready(None), polled);
+    }
+
+    #[tokio::test]
+    async fn pause_empty_controlled_stream_from_other_thread2() {
+        let mut stream = ControlledStream::new(tokio_stream::iter(Vec::<u8>::new()));
+        let stream_state = stream.state();
+        stream_state.set(StreamState::Pause);
+        let next = pin!(stream.next());
+        let polled = futures::poll!(next);
+        assert_eq!(Poll::Pending, polled);
+
+        let sc = stream_state.clone();
+        let thread = std::thread::spawn(move || {
+            sc.set(StreamState::Run);
+        });
+
+        let fut = stream.next();
+        let next = fut.await;
+        assert_eq!(None, next);
+
+        thread.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn pause_empty_controlled_stream_from_other_thread3() {
+        let mut stream = ControlledStream::with_initial_state(tokio_stream::iter(Vec::<u8>::new()), StreamState::Pause);
+        let stream_state = stream.state();
+        assert_eq!(stream_state.state.load(Ordering::Relaxed), StreamState::Pause as u8);
+
+        let next = pin!(stream.next());
+        let polled = futures::poll!(next);
+        assert_eq!(Poll::Pending, polled);
+
+        let sc = stream_state.clone();
+        let thread = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(100));
+            println!("&sc: {:p}", &sc);
+            println!("&sc.atomic_state: {:p}", &sc.state);
+            sc.set(StreamState::Run);
+        });
+
+        let fut = stream.next();
+        let next = fut.await;
+        assert_eq!(None, next);
+
+        thread.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn pause_nonempty_controlled_stream() {
+        let values = vec![1, 2, 3, 4, 5];
+        let mut stream = Box::pin(ControlledStream::with_initial_state(
+            tokio_stream::iter(values.clone()),
+            StreamState::Pause,
+        ));
+        let stream_state = stream.state();
+
+        println!("stream with state pause");
+        let polled = futures::poll!(pin!(stream.next()));
+        assert_eq!(Poll::Pending, polled);
+        println!("is pending");
+
+        let t0 = Instant::now();
+
+        let state_clone = stream_state.clone();
+        let thread = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(100));
+            println!("state.set(Run)");
+            state_clone.set(StreamState::Run);
+
+            std::thread::sleep(Duration::from_millis(100));
+            println!("state.set(Pause)");
+            state_clone.set(StreamState::Pause);
+
+            std::thread::sleep(Duration::from_millis(100));
+            println!("state.set(Run)");
+            state_clone.set(StreamState::Run);
+
+            std::thread::sleep(Duration::from_millis(100));
+            println!("state.set(Stop)");
+            state_clone.set(StreamState::Stop);
+        });
+
+        // paused, then run
+        println!("next().await...");
+        let value = stream.next().await;
+        let t1 = Instant::now();
+        println!("=> {value:?} after {:?}", t1.duration_since(t0));
+        assert!(t1.duration_since(t0) > Duration::from_millis(100));
+        assert_eq!(Some(1), value);
+
+        // run
+        println!("next().await...");
+        let t0 = Instant::now();
+        let value = stream.next().await;
+        let t1 = Instant::now();
+        println!("=> {value:?} after {:?}", t1.duration_since(t0));
+        assert!(t1.duration_since(t0) < Duration::from_millis(100));
+        assert_eq!(Some(2), value);
+
+        // run, then paused, then unpause
+        std::thread::sleep(Duration::from_millis(105));
+        println!("next().await...");
+        let t0 = Instant::now();
+        let last_value = stream.next().await;
+        let t1 = Instant::now();
+        println!("=> {last_value:?} after {:?}", t1.duration_since(t0));
+        assert!(t1.duration_since(t0) > Duration::from_millis(90));
+        assert_eq!(Some(3), last_value);
+
+        // run
+        println!("next().await...");
+        let t0 = Instant::now();
+        let value = stream.next().await;
+        let t1 = Instant::now();
+        println!("=> {value:?} after {:?}", t1.duration_since(t0));
+        assert!(t1.duration_since(t0) < Duration::from_millis(100));
+        assert_eq!(Some(4), value);
+
+        // stop
+        std::thread::sleep(Duration::from_millis(105));
+        println!("next().await...");
+        let t0 = Instant::now();
+        let last_value = stream.next().await;
+        let t1 = Instant::now();
+        println!("=> {last_value:?} after {:?}", t1.duration_since(t0));
+        assert!(t1.duration_since(t0) < Duration::from_millis(90));
+        assert_eq!(None, last_value);
+
+        thread.join().unwrap();
+    }
+}

--- a/alumet/src/pipeline/util/stream.rs
+++ b/alumet/src/pipeline/util/stream.rs
@@ -8,11 +8,11 @@ use std::task::{Context, Poll};
 use futures::task::AtomicWaker;
 use tokio_stream::Stream;
 
-/// A [`Stream`] wrapper that allows to pause and stop the stream.
+/// A [`Stream`] wrapper that allows to pause, unpause and stop the stream.
 ///
 /// Use [`state()`](Self::state) to obtain an `Arc` that points to the state of the stream,
 /// then [`SharedState::set`] to update it.
-pub struct ControlledStream<T, S: Stream<Item = T>> {
+pub struct ControlledStream<S: Stream> {
     inner: S,
     state: Arc<SharedStreamState>,
 }
@@ -39,7 +39,7 @@ impl SharedStreamState {
     }
 }
 
-impl<T, S: Stream<Item = T>> ControlledStream<T, S> {
+impl<S: Stream> ControlledStream<S> {
     /// Creates new controlled stream with the initial state [`StreamState::Run`].
     pub fn new(inner: S) -> Self {
         Self::with_initial_state(inner, StreamState::Run)
@@ -64,8 +64,8 @@ impl<T, S: Stream<Item = T>> ControlledStream<T, S> {
     }
 }
 
-impl<T, S: Stream<Item = T>> Stream for ControlledStream<T, S> {
-    type Item = T;
+impl<S: Stream> Stream for ControlledStream<S> {
+    type Item = S::Item;
 
     fn poll_next(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> std::task::Poll<Option<Self::Item>> {
         // pin-project the fields

--- a/alumet/tests/common/test_plugin.rs
+++ b/alumet/tests/common/test_plugin.rs
@@ -89,7 +89,7 @@ impl Plugin for TestPlugin {
         let trigger = trigger::builder::time_interval(Duration::from_secs(1)).build().unwrap();
         alumet.add_source(source, trigger);
         alumet.add_transform(Box::new(TestTransform));
-        alumet.add_output(Box::new(TestOutput));
+        alumet.add_blocking_output(Box::new(TestOutput));
 
         // Update state (for testing purposes)
         self.state.set(State::Started);

--- a/alumet/tests/errors/plugin.rs
+++ b/alumet/tests/errors/plugin.rs
@@ -2,8 +2,9 @@ use std::time::Duration;
 
 use super::points::{error_point, panic_point};
 use alumet::measurement::{MeasurementAccumulator, MeasurementBuffer, Timestamp};
-use alumet::pipeline::builder::elements::{ManagedSourceRegistration, OutputRegistration, TransformRegistration};
+use alumet::pipeline::builder::elements::{ManagedSourceRegistration, TransformRegistration};
 use alumet::pipeline::elements::error::{TransformError, WriteError};
+use alumet::pipeline::elements::output::builder::BlockingOutputRegistration;
 use alumet::pipeline::elements::output::OutputContext;
 use alumet::pipeline::elements::transform::TransformContext;
 use alumet::pipeline::{elements::error::PollError, trigger::TriggerSpec};
@@ -59,9 +60,9 @@ impl AlumetPlugin for BadPlugin {
                 transform: Box::new(BadTransform),
             })
         });
-        alumet.add_output_builder(|ctx| {
+        alumet.add_blocking_output_builder(|ctx| {
             error_point!(output_build);
-            Ok(OutputRegistration {
+            Ok(BlockingOutputRegistration {
                 name: ctx.output_name("output"),
                 output: Box::new(BadOutput),
             })

--- a/alumet/tests/errors/plugin.rs
+++ b/alumet/tests/errors/plugin.rs
@@ -2,12 +2,11 @@ use std::time::Duration;
 
 use super::points::{error_point, panic_point};
 use alumet::measurement::{MeasurementAccumulator, MeasurementBuffer, Timestamp};
-use alumet::pipeline::builder::elements::{ManagedSourceRegistration, TransformRegistration};
-use alumet::pipeline::elements::error::{TransformError, WriteError};
-use alumet::pipeline::elements::output::builder::BlockingOutputRegistration;
-use alumet::pipeline::elements::output::OutputContext;
-use alumet::pipeline::elements::transform::TransformContext;
-use alumet::pipeline::{elements::error::PollError, trigger::TriggerSpec};
+use alumet::pipeline::elements::error::{PollError, TransformError, WriteError};
+use alumet::pipeline::elements::output::{builder::BlockingOutputRegistration, OutputContext};
+use alumet::pipeline::elements::source::builder::ManagedSourceRegistration;
+use alumet::pipeline::elements::transform::{builder::TransformRegistration, TransformContext};
+use alumet::pipeline::trigger::TriggerSpec;
 use alumet::pipeline::{Output, Source, Transform};
 use alumet::plugin::{
     rust::{serialize_config, AlumetPlugin},

--- a/alumet/tests/errors/points.rs
+++ b/alumet/tests/errors/points.rs
@@ -64,6 +64,7 @@ pub struct ExpectedCatchPoints {
     pub agent_default_config: Expect,
     pub agent_config_from: Expect,
     pub agent_start: Expect,
+    #[allow(unused)]
     pub runtime: Expect,
     pub shutdown: Expect,
     pub wait_for_shutdown: Expect,
@@ -110,7 +111,7 @@ pub enum CatchResult<T> {
 
 pub enum PointCheckResult<T> {
     Ok(T),
-    ExpectedErrorOrPanic(anyhow::Error),
+    ExpectedErrorOrPanic(()),
     UnexpectedErrorOrPanic(anyhow::Error),
 }
 
@@ -188,13 +189,11 @@ pub fn process_catch_point<R>(name: &str, expected: &Expect, actual: CatchResult
         (Expect::Error, CatchResult::Panic(e)) => PointCheckResult::UnexpectedErrorOrPanic(anyhow!(
             "expected error at {name}, got panic (see backtrace below): {e:?}"
         )),
-        (Expect::Error, CatchResult::Err(e)) => PointCheckResult::ExpectedErrorOrPanic(e),
+        (Expect::Error, CatchResult::Err(_)) => PointCheckResult::ExpectedErrorOrPanic(()),
         (Expect::Panic, CatchResult::Ok(_)) => {
             PointCheckResult::UnexpectedErrorOrPanic(anyhow!("expected panic at {name}, got Ok(...)"))
         }
-        (Expect::Panic, CatchResult::Panic(_)) => {
-            PointCheckResult::ExpectedErrorOrPanic(anyhow!("{name} panicked as expected, all good"))
-        }
+        (Expect::Panic, CatchResult::Panic(_)) => PointCheckResult::ExpectedErrorOrPanic(()),
         (Expect::Panic, CatchResult::Err(e)) => {
             PointCheckResult::UnexpectedErrorOrPanic(anyhow!("expected panic at {name}, got error: {e}"))
         }

--- a/app-agent/.gitignore
+++ b/app-agent/.gitignore
@@ -1,1 +1,2 @@
 alumet-*.toml
+tmp/

--- a/app-agent/Cargo.toml
+++ b/app-agent/Cargo.toml
@@ -8,14 +8,14 @@ description = "Metric collector agent to install on each node."
 
 [dependencies]
 alumet = { path = "../alumet" }
-anyhow = "1.0.79"
-clap = { version = "4.5.4", features = ["derive"] }
-env_logger = "0.11.2"
+anyhow = "1.0.88"
+clap = { version = "4.5.17", features = ["derive"] }
+env_logger = "0.11.5"
 humantime-serde = "1.1.1"
-log = "0.4.20"
-serde = { version = "1.0.198", features = ["derive"] }
+log = "0.4.22"
+serde = { version = "1.0.210", features = ["derive"] }
 tokio = { version = "1.40.0", features = ["rt"] }
-toml = "0.8.12"
+toml = "0.8.19"
 
 # plugins
 plugin-csv = { path = "../plugin-csv", optional = true }

--- a/app-agent/src/lib.rs
+++ b/app-agent/src/lib.rs
@@ -11,6 +11,18 @@ pub fn resolve_application_path() -> std::io::Result<PathBuf> {
     std::env::current_exe()?.canonicalize()
 }
 
+pub fn relative_app_path_string() -> PathBuf {
+    resolve_application_path()
+        .map(|exe| {
+            std::env::current_dir()
+                .ok()
+                .and_then(|wdir| exe.strip_prefix(wdir).ok())
+                .map(|p| p.to_path_buf())
+                .unwrap_or(exe)
+        })
+        .unwrap_or_else(|_| "path/to/alumet-agent".into())
+}
+
 /// Initializes the global logger.
 ///
 /// Call this first!

--- a/plugin-cgroupv2/Cargo.toml
+++ b/plugin-cgroupv2/Cargo.toml
@@ -7,12 +7,12 @@ edition = "2021"
 
 [dependencies]
 alumet = { path = "../alumet" }
-anyhow = "1.0.79"
+anyhow = "1.0.88"
 gethostname = "0.5.0"
-log = "0.4.20"
-reqwest = { version = "0.12", features = ["json"] }
-tokio = "1.37.0"
-serde = { version = "1.0.198", features = ["derive"] }
+log = "0.4.22"
+reqwest = { version = "0.12.7", features = ["json"] }
+tokio = "1.40.0"
+serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0"
 humantime-serde = "1.1.1"
 notify = "6.1.1"

--- a/plugin-csv/Cargo.toml
+++ b/plugin-csv/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 
 [dependencies]
 alumet = { path = "../alumet" }
-anyhow = "1.0.82"
-log = "0.4.21"
-serde = { version = "1.0.201", features = ["derive"] }
+anyhow = "1.0.88"
+log = "0.4.22"
+serde = { version = "1.0.210", features = ["derive"] }
 time = { version = "0.3.36", features = ["formatting"] }
 
 [dev-dependencies]

--- a/plugin-csv/src/lib.rs
+++ b/plugin-csv/src/lib.rs
@@ -42,7 +42,7 @@ impl AlumetPlugin for CsvPlugin {
             self.config.csv_delimiter,
             self.config.csv_escaped_quote.take().unwrap_or(String::from("\"\"")),
         )?);
-        alumet.add_output(output);
+        alumet.add_blocking_output(output);
         Ok(())
     }
 

--- a/plugin-influxdb/Cargo.toml
+++ b/plugin-influxdb/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2021"
 
 [dependencies]
 alumet = { path = "../alumet" }
-anyhow = "1.0.82"
-log = "0.4.21"
+anyhow = "1.0.88"
+log = "0.4.22"
 
 # We disable HTTP2 because it's not supported by InfluxDB.
-reqwest = { version = "0.12.4", default-features = false, features = ["default-tls"] }
-serde = { version = "1.0.200", features = ["derive"] }
-tokio = { version = "1.37.0", features = ["rt"] }
+reqwest = { version = "0.12.7", default-features = false, features = ["default-tls"] }
+serde = { version = "1.0.210", features = ["derive"] }
+tokio = { version = "1.40.0", features = ["rt"] }
 
 [lints]
 workspace = true

--- a/plugin-influxdb/src/influxdb2.rs
+++ b/plugin-influxdb/src/influxdb2.rs
@@ -72,6 +72,7 @@ pub struct LineProtocolBuilder {
     after_first_field: bool,
 }
 
+#[allow(unused)]
 impl LineProtocolBuilder {
     pub fn new() -> Self {
         Self {

--- a/plugin-influxdb/src/lib.rs
+++ b/plugin-influxdb/src/lib.rs
@@ -54,7 +54,7 @@ impl AlumetPlugin for InfluxDbPlugin {
         log::info!("Test successfull.");
 
         // Create the output.
-        alumet.add_output(Box::new(InfluxDbOutput {
+        alumet.add_blocking_output(Box::new(InfluxDbOutput {
             client: influx_client,
             org: config.org,
             bucket: config.bucket,

--- a/plugin-nvidia/Cargo.toml
+++ b/plugin-nvidia/Cargo.toml
@@ -11,13 +11,13 @@ jetson = ["dep:regex"]
 
 [dependencies]
 alumet = { path = "../alumet" }
-anyhow = "1.0.79"
+anyhow = "1.0.88"
 humantime-serde = "1.1.1"
-log = "0.4.20"
+log = "0.4.22"
 nvml-wrapper = { version = "0.10.0", features = ["legacy-functions"], optional = true}
 nvml-wrapper-sys = { version = "0.8.0", optional = true }
-regex = { version = "1.10.4", optional = true }
-serde = { version = "1.0.201", features = ["derive"] }
+regex = { version = "1.10.6", optional = true }
+serde = { version = "1.0.210", features = ["derive"] }
 
 [lints]
 workspace = true

--- a/plugin-nvidia/src/nvml.rs
+++ b/plugin-nvidia/src/nvml.rs
@@ -9,7 +9,7 @@ use alumet::{
     measurement::{MeasurementAccumulator, MeasurementPoint},
     metrics::TypedMetricId,
     pipeline::elements::error::PollError,
-    plugin::util::{CounterDiff, CounterDiffUpdate},
+    plugin::util::CounterDiff,
     plugin::AlumetPluginStart,
     resources::Resource,
     units::Unit,

--- a/plugin-oar2/Cargo.toml
+++ b/plugin-oar2/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 
 [dependencies]
 alumet = { path = "../alumet" }
-anyhow = "1.0.86"
+anyhow = "1.0.88"
 notify = { version = "6.1.1", default-features = false, features = ["macos_fsevent"] }
-serde = { version = "1.0.202", features = ["derive"] }
+serde = { version = "1.0.210", features = ["derive"] }
 humantime-serde = "1.1"
 serde_derive = "1.0"
-log = "0.4.21"
+log = "0.4.22"
 
 [lints]
 workspace = true

--- a/plugin-perf/Cargo.toml
+++ b/plugin-perf/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2021"
 
 [dependencies]
 alumet = { path = "../alumet" }
-anyhow = "1.0.82"
-itertools = "0.12.1"
-log = "0.4.21"
-perf-event2 = "0.7.2"
-serde = { version = "1.0.199", features = ["derive"] }
+anyhow = "1.0.88"
+itertools = "0.13.0"
+log = "0.4.22"
+perf-event2 = "0.7.4"
+serde = { version = "1.0.210", features = ["derive"] }
 
 [lints]
 workspace = true

--- a/plugin-perf/Cargo.toml
+++ b/plugin-perf/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 alumet = { path = "../alumet" }
 anyhow = "1.0.88"
+humantime-serde = "1.1.1"
 itertools = "0.13.0"
 log = "0.4.22"
 perf-event2 = "0.7.4"

--- a/plugin-procfs/Cargo.toml
+++ b/plugin-procfs/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 
 [dependencies]
 alumet = { path = "../alumet" }
-anyhow = "1.0.82"
+anyhow = "1.0.88"
 humantime-serde = "1.1.1"
 log = "0.4.22"
 procfs = "0.16.0"
 regex = "1.10.6"
-serde = { version = "1.0.201", features = ["derive"] }
+serde = { version = "1.0.210", features = ["derive"] }
 
 [lints]
 workspace = true

--- a/plugin-procfs/src/serde_regex.rs
+++ b/plugin-procfs/src/serde_regex.rs
@@ -49,8 +49,8 @@ pub mod option {
 
 #[cfg(test)]
 mod tests {
-    use pretty_assertions::{assert_eq, assert_ne};
-    use regex::{Regex, RegexBuilder};
+    use pretty_assertions::assert_eq;
+    use regex::Regex;
     use serde::{Deserialize, Serialize};
     use toml;
 

--- a/plugin-rapl/Cargo.toml
+++ b/plugin-rapl/Cargo.toml
@@ -10,13 +10,13 @@ edition = "2021"
 
 [dependencies]
 alumet = { path = "../alumet" }
-anyhow = "1.0.79"
+anyhow = "1.0.88"
 humantime-serde = "1.1.1"
 indoc = "2.0.5"
-log = "0.4.20"
+log = "0.4.22"
 perf-event-open-sys = "4.0.0"
-regex = "1.10.3"
-serde = { version = "1.0.198", features = ["derive"] }
+regex = "1.10.6"
+serde = { version = "1.0.210", features = ["derive"] }
 
 [lints]
 workspace = true

--- a/plugin-relay/Cargo.toml
+++ b/plugin-relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plugin-relay"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 [features]
@@ -17,6 +17,9 @@ serde = { version = "1.0.210", features = ["derive"] }
 tokio = { version = "1.40.0", features = ["rt"] }
 tonic = "0.12.2"
 prost = "0.13" # required because we include generated code that depends on prost in lib.rs
+tokio-stream = "0.1.16"
+futures = "0.3.30"
+humantime-serde = "1.1.1"
 
 [build-dependencies]
 tonic-build = "0.12.2"

--- a/plugin-relay/Cargo.toml
+++ b/plugin-relay/Cargo.toml
@@ -1,25 +1,25 @@
 [package]
 name = "plugin-relay"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [features]
-# default = ["client", "server"]
+default = ["client", "server"]
 client = []
 server = []
 
 [dependencies]
 alumet = { path = "../alumet" }
-anyhow = "1.0.82"
+anyhow = "1.0.88"
 hostname = "0.4.0"
-log = "0.4.21"
-prost = "0.12.4"
-serde = { version = "1.0.198", features = ["derive"] }
+log = "0.4.22"
+serde = { version = "1.0.210", features = ["derive"] }
 tokio = { version = "1.37.0", features = ["rt"] }
-tonic = "0.11.0"
+tonic = "0.12.2"
+prost = "0.13" # required because we include generated code that depends on prost in lib.rs
 
 [build-dependencies]
-tonic-build = "0.11.0"
+tonic-build = "0.12.2"
 
 [lints]
 workspace = true

--- a/plugin-relay/Cargo.toml
+++ b/plugin-relay/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0.88"
 hostname = "0.4.0"
 log = "0.4.22"
 serde = { version = "1.0.210", features = ["derive"] }
-tokio = { version = "1.37.0", features = ["rt"] }
+tokio = { version = "1.40.0", features = ["rt"] }
 tonic = "0.12.2"
 prost = "0.13" # required because we include generated code that depends on prost in lib.rs
 

--- a/plugin-relay/proto/alumet-relay.proto
+++ b/plugin-relay/proto/alumet-relay.proto
@@ -3,7 +3,7 @@ package alumet_relay;
 
 service MetricCollector {
     // Ingest new measurements, returns nothing.
-    rpc IngestMeasurements (MeasurementBuffer) returns (Empty);
+    rpc IngestMeasurements (stream MeasurementBuffer) returns (Empty);
 
     // Registers new metrics, returns their id.
     rpc RegisterMetrics (MetricDefinitions) returns (RegisterReply);

--- a/plugin-relay/src/client/mod.rs
+++ b/plugin-relay/src/client/mod.rs
@@ -1,0 +1,38 @@
+use std::{fmt::Display, str::FromStr};
+
+use tonic::metadata::{errors::InvalidMetadataValue, AsciiMetadataValue};
+
+mod grpc;
+mod plugin;
+
+pub use plugin::RelayClientPlugin;
+
+#[derive(Debug, Clone)]
+pub struct AsciiString {
+    metadata_value: AsciiMetadataValue,
+    string: String,
+}
+
+impl FromStr for AsciiString {
+    type Err = InvalidMetadataValue;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mv = AsciiMetadataValue::from_str(s)?;
+        Ok(AsciiString {
+            metadata_value: mv,
+            string: s.to_owned(),
+        })
+    }
+}
+
+impl Display for AsciiString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.string)
+    }
+}
+
+impl AsciiString {
+    pub fn as_str(&self) -> &str {
+        &self.string
+    }
+}

--- a/plugin-relay/src/client/plugin.rs
+++ b/plugin-relay/src/client/plugin.rs
@@ -2,9 +2,8 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use alumet::pipeline::{
-    builder::elements::MetricListenerRegistration,
     elements::output::{builder::AsyncOutputRegistration, BoxedAsyncOutput},
-    registry::MetricListener,
+    registry::listener::{MetricListener, MetricListenerRegistration},
 };
 use alumet::plugin::{
     rust::{deserialize_config, serialize_config, AlumetPlugin},
@@ -49,7 +48,7 @@ mod config {
                 client_name: default_client_name(),
                 collector_uri: default_collector_uri(),
                 buffer_size: 4096,
-                buffer_timeout: Duration::from_secs(60),
+                buffer_timeout: Duration::from_secs(30),
             }
         }
     }

--- a/plugin-relay/src/client/plugin.rs
+++ b/plugin-relay/src/client/plugin.rs
@@ -1,0 +1,208 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use alumet::pipeline::{
+    builder::elements::MetricListenerRegistration,
+    elements::output::{builder::AsyncOutputRegistration, BoxedAsyncOutput},
+    registry::MetricListener,
+};
+use alumet::plugin::{
+    rust::{deserialize_config, serialize_config, AlumetPlugin},
+    AlumetPluginStart, AlumetPreStart, ConfigTable,
+};
+use anyhow::Context;
+
+pub struct RelayClientPlugin {
+    config: config::Config,
+    metric_ids: Arc<Mutex<HashMap<u64, u64>>>,
+}
+
+mod config {
+    use std::{str::FromStr, time::Duration};
+
+    use serde::{de, Deserialize, Serialize};
+
+    use crate::client::AsciiString;
+
+    #[derive(Serialize, Deserialize)]
+    pub struct Config {
+        /// The name that this client will use to identify itself to the collector server.
+        /// Defaults to the hostname.
+        #[serde(default = "default_client_name")]
+        pub client_name: AsciiString,
+
+        /// The URI of the collector, for instance `http://127.0.0.1:50051`.
+        #[serde(default = "default_collector_uri")]
+        pub collector_uri: String,
+
+        /// Maximum number of elements to keep in the output buffer before sending it.
+        pub buffer_size: usize,
+
+        /// Maximum amount of time to wait before sending the measurements to the server.
+        #[serde(with = "humantime_serde")]
+        pub buffer_timeout: Duration,
+    }
+
+    impl Default for Config {
+        fn default() -> Self {
+            Self {
+                client_name: default_client_name(),
+                collector_uri: default_collector_uri(),
+                buffer_size: 4096,
+                buffer_timeout: Duration::from_secs(60),
+            }
+        }
+    }
+
+    fn default_client_name() -> AsciiString {
+        let binding = hostname::get()
+            .expect("No client_name specified in the config, and unable to retrieve the hostname of the current node.");
+        let hostname = binding.to_string_lossy();
+        AsciiString::from_str(&hostname).unwrap_or_else(|_| {
+            log::error!(
+                "I tried to use '{hostname}' as a default client name, but this is not a valid ASCII hostname."
+            );
+            panic!("hostname {hostname} cannot be used as a client name")
+        })
+    }
+
+    fn default_collector_uri() -> String {
+        String::from("http://[::1]:50051")
+    }
+
+    impl<'de> Deserialize<'de> for AsciiString {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            struct V;
+            impl<'d> de::Visitor<'d> for V {
+                type Value = AsciiString;
+
+                fn expecting(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+                    fmt.write_str("a string containing only visible ASCII characters")
+                }
+
+                fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                where
+                    E: de::Error,
+                {
+                    AsciiString::from_str(v).map_err(|_| E::invalid_value(de::Unexpected::Str(v), &self))
+                }
+            }
+            deserializer.deserialize_str(V)
+        }
+    }
+
+    impl Serialize for AsciiString {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            self.as_str().serialize(serializer)
+        }
+    }
+}
+
+impl AlumetPlugin for RelayClientPlugin {
+    fn name() -> &'static str {
+        "relay-client"
+    }
+
+    fn version() -> &'static str {
+        env!("CARGO_PKG_VERSION")
+    }
+
+    fn default_config() -> anyhow::Result<Option<ConfigTable>> {
+        Ok(Some(serialize_config(config::Config::default())?))
+    }
+
+    fn init(config: ConfigTable) -> anyhow::Result<Box<Self>> {
+        // Read the configuration.
+        let config = deserialize_config::<config::Config>(config)?;
+
+        // Initialize a thread-safe HashMap to store the mapping 'local metric id' -> 'collector metric id'
+        let metric_ids = Arc::new(Mutex::new(HashMap::new()));
+
+        // Return initialized plugin.
+        Ok(Box::new(Self { config, metric_ids }))
+    }
+
+    fn start(&mut self, alumet: &mut AlumetPluginStart) -> anyhow::Result<()> {
+        let collector_uri = self.config.collector_uri.clone();
+        let client_name = self.config.client_name.clone();
+        let metric_ids = self.metric_ids.clone();
+
+        let buffer_size = self.config.buffer_size;
+        let buffer_timeout = self.config.buffer_timeout;
+
+        // The output is async :)
+        alumet.add_async_output_builder(move |ctx, stream| {
+            log::info!("Connecting to gRPC server {collector_uri}...");
+            // Connect to gRPC server, using the tokio runtime in which Alumet will trigger the output.
+            // Note that a Tonic gRPC client can only be used from the runtime it has been initialized with.
+            let rt = ctx.async_runtime();
+            let client_name_str = client_name.to_string();
+            let client = rt
+                .block_on(super::grpc::RelayClient::new(collector_uri, client_name, metric_ids))
+                .context("gRPC connection error")?;
+            log::info!("Successfully connected with client name {client_name_str}.");
+
+            let output = client.process_measurement_stream(stream, buffer_size, buffer_timeout);
+            let output: BoxedAsyncOutput = Box::into_pin(Box::new(output));
+            Ok(AsyncOutputRegistration {
+                name: ctx.output_name("grpc-measurements"),
+                output,
+            })
+        });
+        Ok(())
+    }
+
+    fn pre_pipeline_start(&mut self, alumet: &mut AlumetPreStart) -> anyhow::Result<()> {
+        let collector_uri = self.config.collector_uri.clone();
+        let client_name = self.config.client_name.clone();
+        let metric_ids = self.metric_ids.clone();
+
+        // Clone the existing metrics (which have been registered by the `start` methods of all the plugins).
+        let existing_metrics = alumet
+            .metrics()
+            .iter()
+            .map(|(id, def)| (id.clone(), def.clone()))
+            .collect();
+
+        // Get notified of late metric registration. (TODO: is this the best way? Would it be faster to inspect the points in the output instead?)
+        // Also register the existing metrics on the async pipeline.
+        alumet.add_metric_listener_builder(move |ctx| {
+            let rt = ctx.async_runtime();
+
+            let mut client = rt.block_on(async move {
+                // We need to create another client, the one created in `start` has been moved to the output.
+                let mut client = super::grpc::RelayClient::new(collector_uri, client_name, metric_ids).await?;
+
+                // Register the existing metrics.
+                client.register_metrics(existing_metrics).await?;
+
+                // Pass the client, for use in the listener.
+                anyhow::Ok(client)
+            })?;
+
+            // Build a listener that uses the client.
+            let listener: Box<dyn MetricListener> = Box::new(move |new_metrics| {
+                // register the metrics, wait for the message to be sent
+                let rt = tokio::runtime::Handle::current();
+                rt.block_on(client.register_metrics(new_metrics))?;
+                Ok(())
+            });
+
+            Ok(MetricListenerRegistration {
+                name: ctx.listener_name("grpc-registration"),
+                listener,
+            })
+        });
+        Ok(())
+    }
+
+    fn stop(&mut self) -> anyhow::Result<()> {
+        Ok(())
+    }
+}

--- a/plugin-relay/src/lib.rs
+++ b/plugin-relay/src/lib.rs
@@ -10,7 +10,7 @@ pub mod client;
 #[cfg(feature = "server")]
 pub mod server;
 
-pub mod protocol {
+pub(crate) mod protocol {
     tonic::include_proto!("alumet_relay");
 }
 

--- a/plugin-relay/src/lib.rs
+++ b/plugin-relay/src/lib.rs
@@ -14,6 +14,8 @@ pub mod protocol {
     tonic::include_proto!("alumet_relay");
 }
 
+pub const CLIENT_NAME_HEADER: &str = "x-alumet-client";
+
 /// Parses and resolves a socket address, made of an `address` and a `port`.
 ///
 /// # Result

--- a/plugin-relay/src/lib.rs
+++ b/plugin-relay/src/lib.rs
@@ -1,3 +1,10 @@
+use std::{
+    collections::HashSet,
+    net::{SocketAddr, ToSocketAddrs},
+};
+
+use anyhow::{anyhow, Context};
+
 #[cfg(feature = "client")]
 pub mod client;
 #[cfg(feature = "server")]
@@ -5,4 +12,62 @@ pub mod server;
 
 pub mod protocol {
     tonic::include_proto!("alumet_relay");
+}
+
+/// Parses and resolves a socket address, made of an `address` and a `port`.
+///
+/// # Result
+/// Returns a **non-empty** vector of socket addresses, or an error.
+pub fn resolve_socket_address(
+    address: String,
+    port: u16,
+    ipv6_scope_id: Option<u32>,
+) -> anyhow::Result<Vec<SocketAddr>> {
+    // Resolve the address and port. This may return multiple results.
+    let socket_addrs: Vec<SocketAddr> = (address.clone(), port)
+        .to_socket_addrs()
+        .with_context(|| format!("invalid address: {address}"))?
+        .collect();
+
+    fn has_correct_scope(addr: &SocketAddr, ipv6_scope_id: Option<u32>) -> bool {
+        match (addr, ipv6_scope_id) {
+            (SocketAddr::V6(addr), Some(scope_id)) => addr.scope_id() == scope_id,
+            (SocketAddr::V4(_), Some(_scope_id)) => false,
+            _ => true,
+        }
+    }
+
+    match socket_addrs[..] {
+        [] => Err(anyhow!("no address found when resolving ({address}, {port})")),
+        [single] => {
+            // Set the IPv6 scope id if applicable.
+            match single {
+                SocketAddr::V4(addr4) => Ok(vec![std::net::SocketAddr::V4(addr4)]),
+                SocketAddr::V6(mut addr6) => {
+                    if let Some(scope_id) = ipv6_scope_id {
+                        addr6.set_scope_id(scope_id);
+                    }
+                    Ok(vec![std::net::SocketAddr::V6(addr6)])
+                }
+            }
+        }
+        _ => {
+            // filter
+            let mut addresses: Vec<_> = socket_addrs
+                .into_iter()
+                .filter(|addr| has_correct_scope(addr, ipv6_scope_id))
+                .collect();
+            // deduplicate but preserve order (the addresses should be tried in the order returned by the system, see man getaddrinfo)
+            let mut seen: HashSet<SocketAddr> = HashSet::with_capacity(addresses.len());
+            addresses.retain(|addr| seen.insert(addr.clone()));
+            if addresses.is_empty() {
+                Err(anyhow!(
+                    "no address matches ({address}, {port}) and ipv6 scope id {}",
+                    ipv6_scope_id.unwrap()
+                ))
+            } else {
+                Ok(addresses)
+            }
+        }
+    }
 }

--- a/plugin-relay/src/server/mod.rs
+++ b/plugin-relay/src/server/mod.rs
@@ -1,0 +1,4 @@
+mod grpc;
+mod plugin;
+
+pub use plugin::RelayServerPlugin;

--- a/plugin-relay/src/server/plugin.rs
+++ b/plugin-relay/src/server/plugin.rs
@@ -1,7 +1,7 @@
 use std::net::SocketAddr;
 
 use alumet::{
-    pipeline::builder::elements::AutonomousSourceRegistration,
+    pipeline::elements::source::builder::AutonomousSourceRegistration,
     plugin::{
         rust::{deserialize_config, serialize_config, AlumetPlugin},
         AlumetPluginStart, ConfigTable,

--- a/plugin-relay/src/server/plugin.rs
+++ b/plugin-relay/src/server/plugin.rs
@@ -1,0 +1,94 @@
+use std::net::SocketAddr;
+
+use alumet::{
+    pipeline::builder::elements::AutonomousSourceRegistration,
+    plugin::{
+        rust::{deserialize_config, serialize_config, AlumetPlugin},
+        AlumetPluginStart, ConfigTable,
+    },
+};
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+use tonic::transport::Server;
+
+use crate::{resolve_socket_address, server::grpc};
+
+pub struct RelayServerPlugin {
+    config: Config,
+}
+
+#[derive(Deserialize, Serialize)]
+struct Config {
+    /// Address to listen on.
+    /// The default value is ip6-localhost = `::1`.
+    ///
+    /// To listen all your network interfaces please use `0.0.0.0` or `::`.
+    address: String,
+
+    /// Port on which to serve.
+    port: u16,
+
+    /// IPv6 scope id, for link-local addressing.
+    ipv6_scope_id: Option<u32>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            address: String::from("::1"), // "any" on ipv6
+            port: 50051,
+            ipv6_scope_id: None,
+        }
+    }
+}
+
+impl AlumetPlugin for RelayServerPlugin {
+    fn name() -> &'static str {
+        "relay-server"
+    }
+
+    fn version() -> &'static str {
+        env!("CARGO_PKG_VERSION")
+    }
+
+    fn default_config() -> anyhow::Result<Option<ConfigTable>> {
+        let config = serialize_config(Config::default())?;
+        Ok(Some(config))
+    }
+
+    fn init(config: ConfigTable) -> anyhow::Result<Box<Self>> {
+        let config: Config = deserialize_config(config)?;
+
+        Ok(Box::new(RelayServerPlugin { config }))
+    }
+
+    fn start(&mut self, alumet: &mut AlumetPluginStart) -> anyhow::Result<()> {
+        // Resolve the address from the config.
+        let config_address = std::mem::take(&mut self.config.address);
+        let addr: SocketAddr = resolve_socket_address(config_address, self.config.port, self.config.ipv6_scope_id)?[0];
+
+        log::info!("Starting gRPC server with on socket {addr}");
+        alumet.add_autonomous_source_builder(move |ctx, cancel_token, out_tx| {
+            let metrics_tx = ctx.metrics_sender();
+            let collector = grpc::MetricCollectorImpl::new(out_tx, metrics_tx);
+            let source = Box::pin(async move {
+                Server::builder()
+                    .add_service(collector.into_service())
+                    .serve_with_shutdown(addr, cancel_token.cancelled_owned())
+                    .await
+                    .context("gRPC server error")?;
+                Ok(())
+            });
+            Ok(AutonomousSourceRegistration {
+                name: ctx.source_name("grpc-server"),
+                source,
+            })
+        });
+        Ok(())
+    }
+
+    fn stop(&mut self) -> anyhow::Result<()> {
+        // The autonomous source has already been stopped at this point.
+        Ok(())
+    }
+}

--- a/plugin-socket-control/Cargo.toml
+++ b/plugin-socket-control/Cargo.toml
@@ -7,12 +7,12 @@ edition = "2021"
 
 [dependencies]
 alumet = { path = "../alumet" }
-anyhow = "1.0.82"
+anyhow = "1.0.88"
 humantime = "2.1.0"
-log = "0.4.21"
-tokio = { version = "1.37.0", features = ["net", "io-util"] }
-tokio-util = "0.7.10"
-serde = { version = "1.0.198", features = ["derive"] }
+log = "0.4.22"
+tokio = { version = "1.40.0", features = ["net", "io-util"] }
+tokio-util = "0.7.12"
+serde = { version = "1.0.210", features = ["derive"] }
 
 [lints]
 workspace = true

--- a/plugin-socket-control/src/command.rs
+++ b/plugin-socket-control/src/command.rs
@@ -148,10 +148,9 @@ pub fn parse(command: &str) -> anyhow::Result<Command> {
 
 #[cfg(test)]
 mod tests {
-    use std::{any::Any, time::Duration};
+    use std::time::Duration;
 
     use alumet::pipeline::{
-        builder::elements::SendSourceBuilder,
         control::ControlMessage,
         elements::{output, source, transform},
         matching::{NamePattern, NamePatterns, OutputSelector, SourceSelector, TransformSelector},
@@ -257,6 +256,9 @@ mod tests {
     }
 
     fn control_message_eq(a: &ControlMessage, b: &ControlMessage) -> bool {
+        use source::builder::SendSourceBuilder;
+        use std::any::Any;
+
         fn source_builder_eq(a: &SendSourceBuilder, b: &SendSourceBuilder) -> bool {
             match (a, b) {
                 (SendSourceBuilder::Managed(b1), SendSourceBuilder::Managed(b2)) => b1.type_id() == b2.type_id(),

--- a/test-dynamic-plugins/Cargo.toml
+++ b/test-dynamic-plugins/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 
 [dependencies]
 alumet = { path = "../alumet", features = ["dynamic"] }
-env_logger = "0.11.3"
+env_logger = "0.11.5"
 log = "0.4.22"
 pretty_assertions = "1.4.0"
-regex = "1.10.3"
-toml = "0.8.11"
+regex = "1.10.6"
+toml = "0.8.19"


### PR DESCRIPTION
~~This PR is based on PR #38~~ rebased on main

Remaining things to do:
- [x] better config
- [x] allow stream-based async outputs
  - [x] implement a "controlled" async stream 
- [x] handle more errors with anyhow instead of panicking
- [x] use gRPC streaming mode for measurements
- [x] add a buffer on the client side
- [x] tidy up Alumet
- [x] ensure that the client name is always added as a header (Actually, this doesn't allow the server to get this information during streaming because of how streaming work)