### PR TITLE
Feature/plugin_cgroupv2_k8s_memory

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -12,7 +12,9 @@
         "*.proto",
         "*.h",
         ".git/*",
-        ".gitignore"
+        ".gitignore",
+        ".github/",
+        ".circleci/"
     ],
     "import": [
         "@cspell/dict-rust/cspell-ext.json"
@@ -32,7 +34,8 @@
                 "\\/[\\w.\\-_]+",
                 "[\\w.\\-_]+\\/",
                 "pod[a-zA-Z0-9]+",
-                "\", .*\""
+                "\", .*\"",
+                "JWT"
             ]
         },
         {
@@ -81,6 +84,10 @@
         {
             "name": "string",
             "pattern": "\".*\""
+        },
+        {
+            "name": "JWT",
+            "pattern": "/([A-Za-z0-9+\/]+={0,2}\\.[A-Za-z0-9+\/]+={0,2}\\.[A-Za-z0-9+\/]+={0,2})/g"
         }
     ]
 }

--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -24,6 +24,7 @@ miri
 monitorable
 mpoint
 NVML
+pagetables
 PERFMON
 POWERCAP
 psys

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ app-*/perf.data.old
 app-*/*output.csv
 .DS_Store
 .vscode
-tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ app-*/perf.data
 app-*/perf.data.old
 app-*/*output.csv
 .DS_Store
+.vscode
+tmp/

--- a/plugin-cgroupv2/Cargo.toml
+++ b/plugin-cgroupv2/Cargo.toml
@@ -20,3 +20,7 @@ base64 = "0.22.1"
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+tempfile = "3.5"
+mockito = "0.31"

--- a/plugin-cgroupv2/src/cgroupv2.rs
+++ b/plugin-cgroupv2/src/cgroupv2.rs
@@ -1,51 +1,72 @@
-use std::str::FromStr;
-
 use alumet::{
     metrics::{MetricCreationError, TypedMetricId},
     plugin::AlumetPluginStart,
     units::{PrefixedUnit, Unit},
 };
+use anyhow::{Context, Result};
+use std::str::FromStr;
 
 pub(crate) const CGROUP_MAX_TIME_COUNTER: u64 = u64::MAX;
 
 #[derive(Debug, PartialEq, Clone)]
-pub struct CgroupV2Metric {
-    pub name: String,
-    pub uid: String,
+pub struct CgroupMeasurements {
+    /// Name of a Kubernetes pod.
+    pub pod_name: String,
+    /// Unique identification of a Kubernetes pod.
+    pub pod_uid: String,
+    /// Resources isolation of a Kubernetes pod.
     pub namespace: String,
+    /// Kubernetes pod node.
     pub node: String,
-    pub time_used_tot: u64,
-    pub time_used_user_mode: u64,
-    pub time_used_system_mode: u64,
+    /// Total CPU usage time by the cgroup.
+    pub cpu_time_total: u64,
+    /// CPU in user mode usage time by the cgroup.
+    pub cpu_time_user_mode: u64,
+    /// CPU in system mode usage time by the cgroup.
+    pub cpu_time_system_mode: u64,
+    /// Anonymous used memory, corresponding to running process and various allocated memory.
+    pub memory_anonymous: u64,
+    // Files memory, corresponding to open files and descriptors.
+    pub memory_file: u64,
+    // Memory reserved for kernel operations.
+    pub memory_kernel: u64,
+    /// Memory used to manage correspondence between virtual and physical addresses.
+    pub memory_pagetables: u64,
 }
 
-impl FromStr for CgroupV2Metric {
+impl FromStr for CgroupMeasurements {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut cgroup_struc_to_ret = CgroupV2Metric {
-            name: "".to_owned(),
-            uid: "".to_owned(),
+        let mut cgroup_struc_to_ret = CgroupMeasurements {
+            pod_name: "".to_owned(),
+            pod_uid: "".to_owned(),
             namespace: "".to_owned(),
             node: "".to_owned(),
-            time_used_tot: 0,
-            time_used_user_mode: 0,
-            time_used_system_mode: 0,
+            cpu_time_total: 0,
+            cpu_time_user_mode: 0,
+            cpu_time_system_mode: 0,
+            memory_anonymous: 0,
+            memory_file: 0,
+            memory_kernel: 0,
+            memory_pagetables: 0,
         };
+
         for line in s.lines() {
             let parts: Vec<&str> = line.split_ascii_whitespace().collect();
             if parts.len() >= 2 {
+                let value = parts[1]
+                    .parse::<u64>()
+                    .with_context(|| format!("Parsing of value : {}", parts[1]))?;
                 match parts[0] {
-                    "usage_usec" => {
-                        cgroup_struc_to_ret.time_used_tot = parts[1].parse::<u64>()?;
-                    }
-                    "user_usec" => {
-                        cgroup_struc_to_ret.time_used_user_mode = parts[1].parse::<u64>()?;
-                    }
-                    "system_usec" => {
-                        cgroup_struc_to_ret.time_used_system_mode = parts[1].parse::<u64>()?;
-                    }
-                    &_ => continue,
+                    "usage_usec" => cgroup_struc_to_ret.cpu_time_total = value,
+                    "user_usec" => cgroup_struc_to_ret.cpu_time_user_mode = value,
+                    "system_usec" => cgroup_struc_to_ret.cpu_time_system_mode = value,
+                    "anon" => cgroup_struc_to_ret.memory_anonymous = value,
+                    "file" => cgroup_struc_to_ret.memory_file = value,
+                    "kernel_stack" => cgroup_struc_to_ret.memory_kernel = value,
+                    "pagetables" => cgroup_struc_to_ret.memory_pagetables = value,
+                    _ => continue,
                 }
             }
         }
@@ -53,31 +74,83 @@ impl FromStr for CgroupV2Metric {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct Metrics {
-    pub time_used_tot: TypedMetricId<u64>,
-    pub time_used_user_mode: TypedMetricId<u64>,
-    pub time_used_system_mode: TypedMetricId<u64>,
+    /// Total CPU usage time by the cgroup.
+    pub cpu_time_total: TypedMetricId<u64>,
+    /// CPU in user mode usage time by the cgroup.
+    pub cpu_time_user_mode: TypedMetricId<u64>,
+    /// CPU in system mode usage time by the cgroup.
+    pub cpu_time_system_mode: TypedMetricId<u64>,
+    /// Anonymous used memory, corresponding to running process and various allocated memory.
+    pub memory_anonymous: TypedMetricId<u64>,
+    /// Files memory, corresponding to open files and descriptors.
+    pub memory_file: TypedMetricId<u64>,
+    /// Memory reserved for kernel operations.
+    pub memory_kernel: TypedMetricId<u64>,
+    /// Memory used to manage correspondence between virtual and physical addresses.
+    pub memory_pagetables: TypedMetricId<u64>,
+    /// Total memory used by cgroup.
+    pub memory_total: TypedMetricId<u64>,
 }
 
 impl Metrics {
+    /// Provides a information base to create metric before sending CPU and memory data,
+    /// with `name`, `unit` and `description` parameters.
+    ///
+    /// # Arguments
+    ///
+    /// * `alumet` - A AlumetPluginStart structure passed to plugins for the start-up phase.
+    ///
+    /// # Error
+    ///
+    ///  Return `MetricCreationError` when an error occur during creation a new metric.
     pub fn new(alumet: &mut AlumetPluginStart) -> Result<Self, MetricCreationError> {
-        let usec: PrefixedUnit = PrefixedUnit::micro(Unit::Second);
+        let usec = PrefixedUnit::micro(Unit::Second);
+
         Ok(Self {
-            time_used_tot: alumet.create_metric::<u64>(
+            // CPU cgroup data
+            cpu_time_total: alumet.create_metric::<u64>(
                 "cgroup_cpu_usage_total",
                 usec.clone(),
                 "Total CPU usage time by the cgroup",
             )?,
-            time_used_user_mode: alumet.create_metric::<u64>(
+            cpu_time_user_mode: alumet.create_metric::<u64>(
                 "cgroup_cpu_usage_user",
                 usec.clone(),
                 "CPU in user mode usage time by the cgroup",
             )?,
-            time_used_system_mode: alumet.create_metric::<u64>(
+            cpu_time_system_mode: alumet.create_metric::<u64>(
                 "cgroup_cpu_usage_system",
                 usec.clone(),
                 "CPU in system mode usage time by the cgroup",
+            )?,
+
+            // Memory cgroup data
+            memory_anonymous: alumet.create_metric::<u64>(
+                "cgroup_memory_anonymous",
+                Unit::Byte.clone(),
+                "Anonymous used memory, corresponding to running process and various allocated memory",
+            )?,
+            memory_file: alumet.create_metric::<u64>(
+                "cgroup_memory_file",
+                Unit::Byte.clone(),
+                "Files memory, corresponding to open files and descriptors",
+            )?,
+            memory_kernel: alumet.create_metric::<u64>(
+                "cgroup_memory_kernel_stack",
+                Unit::Byte.clone(),
+                "Memory reserved for kernel operations",
+            )?,
+            memory_pagetables: alumet.create_metric::<u64>(
+                "cgroup_memory_pagetables",
+                Unit::Byte.clone(),
+                "Memory used to manage correspondence between virtual and physical addresses",
+            )?,
+            memory_total: alumet.create_metric::<u64>(
+                "cgroup_memory_total",
+                Unit::Byte.clone(),
+                "Total memory used by cgroup",
             )?,
         })
     }
@@ -87,71 +160,119 @@ impl Metrics {
 mod tests {
     use super::*;
 
+    // Test `from_str` function with in extracted result,
+    // a negative value to test representation
     #[test]
-    fn test_parser() {
-        let str1 = format!(
-            "usage_usec 1111\n
-        user_usec 222222222222222222\n
-        system_usec 33\n
-        nr_periods 0\n
-        nr_throttled 0\n
-        throttled_usec 0"
-        );
-        let result: CgroupV2Metric = CgroupV2Metric::from_str(&str1).unwrap();
-        assert_eq!(result.name, "");
-        assert_eq!(result.time_used_tot, 1111 as u64);
-        assert_eq!(result.time_used_user_mode, 222222222222222222 as u64);
-        assert_eq!(result.time_used_system_mode, 33 as u64);
+    fn test_signed_values() {
+        let str_cpu = "
+            usage_usec -10000
+            user_usec -20000
+            system_usec -30000";
 
-        let str2 = format!(
-            "nr_throttled 0\n
-        usage_usec 1111\n
-        system_usec 33"
-        );
-        let result: CgroupV2Metric = CgroupV2Metric::from_str(&str2).unwrap();
-        assert_eq!(result.name, "");
-        assert_eq!(result.time_used_tot, 1111 as u64);
-        assert_eq!(result.time_used_user_mode, 0 as u64);
-        assert_eq!(result.time_used_system_mode, 33 as u64);
+        let str_memory = "
+            anon -10000
+            file -20000
+            kernel_stack -30000
+            pagetables -40000
+            percpu 890784
+            sock 16384
+            shmem 2453504
+            file_mapped -50000
+            ....";
 
-        let str3 = format!(
-            "
-        system_usec 33"
-        );
-        let result: CgroupV2Metric = CgroupV2Metric::from_str(&str3).unwrap();
-        assert_eq!(result.name, "");
-        assert_eq!(result.time_used_tot, 0 as u64);
-        assert_eq!(result.time_used_user_mode, 0 as u64);
-        assert_eq!(result.time_used_system_mode, 33 as u64);
+        CgroupMeasurements::from_str(str_cpu).expect_err("ERROR : Signed value");
+        CgroupMeasurements::from_str(str_memory).expect_err("ERROR : Signed value");
+    }
 
-        let str4 = format!(
-            "usage_usec 1111\n
-        system_usec 33\n
-        user_usec 222222222222222222\n
-        throttled_usec 0"
-        );
-        let result: CgroupV2Metric = CgroupV2Metric::from_str(&str4).unwrap();
-        assert_eq!(result.name, "");
-        assert_eq!(result.time_used_tot, 1111 as u64);
-        assert_eq!(result.time_used_user_mode, 222222222222222222 as u64);
-        assert_eq!(result.time_used_system_mode, 33 as u64);
+    // Test `from_str` function with in extracted result,
+    // a float or decimal value
+    #[test]
+    fn test_double_values() {
+        let str_cpu = "
+            usage_usec 10000.05
+            user_usec 20000.25
+            system_usec 30000.33";
 
-        let str5 = format!("");
-        let result: CgroupV2Metric = CgroupV2Metric::from_str(&str5).unwrap();
-        assert_eq!(result.name, "");
-        assert_eq!(result.time_used_tot, 0 as u64);
-        assert_eq!(result.time_used_user_mode, 0 as u64);
-        assert_eq!(result.time_used_system_mode, 0 as u64);
+        let str_memory = "
+            anon 10000.05
+            file 20000.25
+            kernel_stack 30000.33
+            pagetables 124325768932.56";
 
-        let str6 = format!(
-            "nr_periods 0\n
-        nr_throttled 0\n
-        throttled_usec 0"
-        );
-        let result: CgroupV2Metric = CgroupV2Metric::from_str(&str6).unwrap();
-        assert_eq!(result.name, "");
-        assert_eq!(result.time_used_tot, 0 as u64);
-        assert_eq!(result.time_used_user_mode, 0 as u64);
-        assert_eq!(result.time_used_system_mode, 0 as u64);
+        CgroupMeasurements::from_str(str_cpu).expect_err("ERROR : Decimal value");
+        CgroupMeasurements::from_str(str_memory).expect_err("ERROR : Decimal value");
+    }
+
+    // Test `from_str` function with in extracted result,
+    // a null, empty or incompatible string
+    #[test]
+    fn test_invalid_values() {
+        let str_cpu = "
+            usage_usec !#⚠
+            user_usec
+            system_usec -123abc";
+
+        let str_memory = "
+            anon !#⚠
+            file
+            pagetables -123abc
+            ...";
+
+        CgroupMeasurements::from_str(str_cpu).expect_err("ERROR : Incompatible value");
+        CgroupMeasurements::from_str(str_memory).expect_err("ERROR : Incompatible value");
+    }
+
+    // Test `from_str` function with in extracted result,
+    // an empty string
+    #[test]
+    fn test_empty_values() {
+        let str: &str = "";
+        let result = CgroupMeasurements::from_str(str).unwrap();
+        // Memory file str
+        assert_eq!(result.memory_anonymous, 0);
+        assert_eq!(result.memory_file, 0);
+        assert_eq!(result.memory_kernel, 0);
+        assert_eq!(result.memory_pagetables, 0);
+        // CPU file str
+        assert_eq!(result.cpu_time_total, 0);
+        assert_eq!(result.cpu_time_user_mode, 0);
+        assert_eq!(result.cpu_time_system_mode, 0);
+    }
+
+    // Test for calculating `mem_total` with structure parameters
+    #[test]
+    fn test_calc_mem() {
+        let result = CgroupMeasurements {
+            pod_name: "".to_owned(),
+            pod_uid: "test_pod_uid".to_owned(),
+            namespace: "test_pod_namespace".to_owned(),
+            node: "test_pod_node".to_owned(),
+            cpu_time_total: 64,
+            cpu_time_user_mode: 16,
+            cpu_time_system_mode: 32,
+            memory_anonymous: 1024,
+            memory_file: 256,
+            memory_kernel: 4096,
+            memory_pagetables: 512,
+        };
+
+        let expected = CgroupMeasurements {
+            pod_name: "".to_owned(),
+            pod_uid: "test_pod_uid".to_owned(),
+            namespace: "test_pod_namespace".to_owned(),
+            node: "test_pod_node".to_owned(),
+            cpu_time_total: 64,
+            cpu_time_user_mode: 16,
+            cpu_time_system_mode: 32,
+            memory_anonymous: 1024,
+            memory_file: 256,
+            memory_kernel: 4096,
+            memory_pagetables: 512,
+        };
+
+        assert_eq!(result, expected);
+
+        let mem_total = result.memory_anonymous + result.memory_file + result.memory_kernel + result.memory_pagetables;
+        assert_eq!(mem_total, 5888);
     }
 }

--- a/plugin-cgroupv2/src/k8s/plugin.rs
+++ b/plugin-cgroupv2/src/k8s/plugin.rs
@@ -208,7 +208,7 @@ impl AlumetPlugin for K8sPlugin {
                                 let file_memory = File::open(&path_memory)
                                     .with_context(|| format!("failed to open file {}", path_memory.display()))?;
 
-                                // CPU ressource consumer for cpu.stat file in cgroup
+                                // CPU resource consumer for cpu.stat file in cgroup
                                 let consumer_cpu = ResourceConsumer::ControlGroup {
                                     path: path_cpu
                                         .to_str()
@@ -216,7 +216,7 @@ impl AlumetPlugin for K8sPlugin {
                                         .to_string()
                                         .into(),
                                 };
-                                // Memory ressource consumer for memory.stat file in cgroup
+                                // Memory resource consumer for memory.stat file in cgroup
                                 let consumer_memory = ResourceConsumer::ControlGroup {
                                     path: path_memory
                                         .to_str()

--- a/plugin-cgroupv2/src/k8s/plugin.rs
+++ b/plugin-cgroupv2/src/k8s/plugin.rs
@@ -5,8 +5,9 @@ use alumet::{
         util::CounterDiff,
         AlumetPluginStart, AlumetPostStart, ConfigTable,
     },
+    resources::ResourceConsumer,
 };
-use anyhow::Context;
+use anyhow::{anyhow, Context};
 use gethostname::gethostname;
 use notify::{Event, EventHandler, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use serde::{Deserialize, Serialize};
@@ -14,6 +15,7 @@ use std::{fs::File, path::PathBuf, time::Duration};
 
 use crate::{
     cgroupv2::{Metrics, CGROUP_MAX_TIME_COUNTER},
+    is_accessible_dir,
     k8s::utils::get_pod_name,
 };
 
@@ -38,12 +40,11 @@ struct K8sConfig {
     poll_interval: Duration,
     kubernetes_api_url: String,
     hostname: String,
-
     /// Way to retrieve the k8s API token.
     token_retrieval: TokenRetrieval,
 }
 
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize, PartialEq, Debug)]
 #[serde(rename_all = "lowercase")]
 pub enum TokenRetrieval {
     Kubectl,
@@ -73,10 +74,14 @@ impl AlumetPlugin for K8sPlugin {
         }))
     }
 
+    fn stop(&mut self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     fn start(&mut self, alumet: &mut AlumetPluginStart) -> anyhow::Result<()> {
-        let v2_used: bool = super::utils::is_accessible_dir(&PathBuf::from("/sys/fs/cgroup/"));
+        let v2_used = is_accessible_dir(&PathBuf::from("/sys/fs/cgroup/"))?;
         if !v2_used {
-            anyhow::bail!("Cgroups v2 are not being used!");
+            return Err(anyhow!("Cgroups v2 are not being used!"));
         }
         self.metrics = Some(Metrics::new(alumet)?);
 
@@ -95,11 +100,13 @@ impl AlumetPlugin for K8sPlugin {
             self.config.kubernetes_api_url.clone(),
             &Token::new(self.config.token_retrieval.clone()),
         )?;
-        //Add as a source each pod already present
+
+        // Add as a source each pod already present
         for metric_file in final_list_metric_file {
-            let counter_tmp_tot: CounterDiff = CounterDiff::with_max_value(crate::cgroupv2::CGROUP_MAX_TIME_COUNTER);
-            let counter_tmp_usr: CounterDiff = CounterDiff::with_max_value(crate::cgroupv2::CGROUP_MAX_TIME_COUNTER);
-            let counter_tmp_sys: CounterDiff = CounterDiff::with_max_value(crate::cgroupv2::CGROUP_MAX_TIME_COUNTER);
+            let counter_tmp_tot = CounterDiff::with_max_value(crate::cgroupv2::CGROUP_MAX_TIME_COUNTER);
+            let counter_tmp_usr = CounterDiff::with_max_value(crate::cgroupv2::CGROUP_MAX_TIME_COUNTER);
+            let counter_tmp_sys = CounterDiff::with_max_value(crate::cgroupv2::CGROUP_MAX_TIME_COUNTER);
+
             let probe = K8SProbe::new(
                 self.metrics.as_ref().expect("Metrics is not available").clone(),
                 metric_file,
@@ -113,14 +120,10 @@ impl AlumetPlugin for K8sPlugin {
         Ok(())
     }
 
-    fn stop(&mut self) -> anyhow::Result<()> {
-        Ok(())
-    }
-
     fn post_pipeline_start(&mut self, alumet: &mut AlumetPostStart) -> anyhow::Result<()> {
         let control_handle = alumet.pipeline_control();
 
-        let metrics: Metrics = self.metrics.clone().expect("Metrics is not available");
+        let metrics = self.metrics.clone().expect("Metrics is not available");
         let poll_interval = self.config.poll_interval;
         let kubernetes_api_url = self.config.kubernetes_api_url.clone();
         let hostname = self.config.hostname.to_owned();
@@ -153,24 +156,27 @@ impl AlumetPlugin for K8sPlugin {
                         for path in paths {
                             match path.extension() {
                                 None => {
-                                    // Case of no extension found --> I will not find cpu.stat file
+                                    // Case of no extension found --> I will not find cpu.stat or memory.stat file
                                     return Ok(());
                                 }
                                 Some(os_str) => match os_str.to_str() {
                                     Some("slice") => {
-                                        // Case of .slice found --> I will find cpu.stat file
+                                        // Case of .slice found --> I will find cpu.stat or memory.stat file
                                         log::debug!(".slice extension found, will continue");
                                     }
                                     _ => {
-                                        // Case of an other extension than .slice is found --> I will not find cpu.stat file
+                                        // Case of an other extension than .slice is found --> I will not find cpu.stat or memory.stat file
                                         return Ok(());
                                     }
                                 },
                             };
+
                             if let Some(pod_uid) = path.file_name() {
                                 let pod_uid = pod_uid.to_str().expect("Can't retrieve the pod uid value");
+
                                 // We open a File Descriptor to the newly created file
                                 let mut path_cpu = path.clone();
+                                let mut path_memory = path.clone();
                                 let full_name_to_seek = pod_uid.strip_suffix(".slice").unwrap_or(pod_uid);
                                 let parts: Vec<&str> = full_name_to_seek.split("pod").collect();
                                 let name_to_seek_raw = *(parts.last().unwrap_or(&full_name_to_seek));
@@ -195,22 +201,46 @@ impl AlumetPlugin for K8sPlugin {
                                     .with_context(|| "Block on failed returned an error")?;
 
                                 path_cpu.push("cpu.stat");
-                                let file = File::open(&path_cpu)
+                                let file_cpu = File::open(&path_cpu)
                                     .with_context(|| format!("failed to open file {}", path_cpu.display()))?;
+
+                                path_memory.push("memory.stat");
+                                let file_memory = File::open(&path_memory)
+                                    .with_context(|| format!("failed to open file {}", path_memory.display()))?;
+
+                                // CPU ressource consumer for cpu.stat file in cgroup
+                                let consumer_cpu = ResourceConsumer::ControlGroup {
+                                    path: path_cpu
+                                        .to_str()
+                                        .expect("Path to 'cpu.stat' must be valid UTF8")
+                                        .to_string()
+                                        .into(),
+                                };
+                                // Memory ressource consumer for memory.stat file in cgroup
+                                let consumer_memory = ResourceConsumer::ControlGroup {
+                                    path: path_memory
+                                        .to_str()
+                                        .expect("Path to 'memory.stat' must to be valid UTF8")
+                                        .to_string()
+                                        .into(),
+                                };
 
                                 let metric_file = CgroupV2MetricFile {
                                     name: name.to_owned(),
-                                    path: path_cpu,
-                                    file,
+                                    consumer_cpu,
+                                    file_cpu,
+                                    consumer_memory,
+                                    file_memory,
                                     uid: uid.to_owned(),
                                     namespace: namespace.to_owned(),
                                     node: node.to_owned(),
                                 };
 
-                                let counter_tmp_tot: CounterDiff = CounterDiff::with_max_value(CGROUP_MAX_TIME_COUNTER);
-                                let counter_tmp_usr: CounterDiff = CounterDiff::with_max_value(CGROUP_MAX_TIME_COUNTER);
-                                let counter_tmp_sys: CounterDiff = CounterDiff::with_max_value(CGROUP_MAX_TIME_COUNTER);
-                                let probe: K8SProbe = K8SProbe::new(
+                                let counter_tmp_tot = CounterDiff::with_max_value(CGROUP_MAX_TIME_COUNTER);
+                                let counter_tmp_usr = CounterDiff::with_max_value(CGROUP_MAX_TIME_COUNTER);
+                                let counter_tmp_sys = CounterDiff::with_max_value(CGROUP_MAX_TIME_COUNTER);
+
+                                let probe = K8SProbe::new(
                                     detector.metrics.clone(),
                                     metric_file,
                                     counter_tmp_tot,
@@ -261,6 +291,9 @@ impl AlumetPlugin for K8sPlugin {
 impl Default for K8sConfig {
     fn default() -> Self {
         let root_path = PathBuf::from("/sys/fs/cgroup/kubepods.slice/");
+        if !root_path.exists() {
+            log::warn!("Error : Path '{}' not exist.", root_path.display());
+        }
         Self {
             path: root_path,
             poll_interval: Duration::from_secs(1), // 1Hz
@@ -268,5 +301,62 @@ impl Default for K8sConfig {
             hostname: String::from(""),
             token_retrieval: TokenRetrieval::Kubectl,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+    use std::path::PathBuf;
+
+    // Create a fake plugin structure for k8s plugin
+    fn fake_k8s() -> K8sPlugin {
+        K8sPlugin {
+            config: K8sConfig {
+                path: PathBuf::from("/sys/fs/cgroup/kubepods.slice/"),
+                poll_interval: Duration::from_secs(1),
+                kubernetes_api_url: String::from("https://127.0.0.1:8080"),
+                hostname: String::from("test-hostname"),
+                token_retrieval: TokenRetrieval::Kubectl,
+            },
+            watcher: None,
+            metrics: None,
+        }
+    }
+
+    // Test `default_config` function of k8s plugin
+    #[test]
+    fn test_default_config() {
+        let result = K8sPlugin::default_config().unwrap();
+        assert!(result.is_some(), "result = None");
+
+        let config_table = result.unwrap();
+        let config: K8sConfig = deserialize_config(config_table).expect("Failed to deserialize config");
+
+        assert_eq!(config.path, PathBuf::from("/sys/fs/cgroup/kubepods.slice/"));
+        assert_eq!(config.poll_interval, Duration::from_secs(1));
+        assert_eq!(config.kubernetes_api_url, "https://127.0.0.1:8080");
+        assert_eq!(config.hostname, "");
+        assert_eq!(config.token_retrieval, TokenRetrieval::Kubectl);
+    }
+
+    // Test `init` function to initialize k8s plugin configuration
+    #[test]
+    fn test_init() -> Result<()> {
+        let config_table = serialize_config(K8sConfig::default())?;
+        let plugin = K8sPlugin::init(config_table)?;
+        assert_eq!(plugin.config.kubernetes_api_url, "https://127.0.0.1:8080");
+        assert!(plugin.metrics.is_none());
+        assert!(plugin.watcher.is_none());
+        Ok(())
+    }
+
+    // Test `stop` function to stop k8s plugin
+    #[test]
+    fn test_stop() {
+        let mut plugin = fake_k8s();
+        let result = plugin.stop();
+        assert!(result.is_ok(), "Stop should complete without errors.");
     }
 }

--- a/plugin-cgroupv2/src/k8s/probe.rs
+++ b/plugin-cgroupv2/src/k8s/probe.rs
@@ -1,24 +1,28 @@
 use alumet::{
     measurement::{AttributeValue, MeasurementAccumulator, MeasurementPoint, Timestamp},
     metrics::TypedMetricId,
-    pipeline::elements::error::PollError,
+    pipeline::elements::error::{PollError, PollRetry},
     plugin::util::CounterDiff,
     resources::{Resource, ResourceConsumer},
 };
-use anyhow::Result;
-
-use crate::cgroupv2::{CgroupV2Metric, Metrics};
+use anyhow::{Context, Result};
 
 use super::utils::{gather_value, CgroupV2MetricFile};
+use crate::cgroupv2::{CgroupMeasurements, Metrics};
 
 pub struct K8SProbe {
     pub cgroup_v2_metric_file: CgroupV2MetricFile,
     pub time_tot: CounterDiff,
     pub time_usr: CounterDiff,
     pub time_sys: CounterDiff,
-    pub time_used_tot: TypedMetricId<u64>,
-    pub time_used_user_mode: TypedMetricId<u64>,
-    pub time_used_system_mode: TypedMetricId<u64>,
+    pub cpu_time_tot: TypedMetricId<u64>,
+    pub cpu_time_user_mode: TypedMetricId<u64>,
+    pub cpu_time_system_mode: TypedMetricId<u64>,
+    pub memory_anon: TypedMetricId<u64>,
+    pub memory_file: TypedMetricId<u64>,
+    pub memory_kernel: TypedMetricId<u64>,
+    pub memory_pagetables: TypedMetricId<u64>,
+    pub memory_total: TypedMetricId<u64>,
 }
 
 impl K8SProbe {
@@ -34,66 +38,142 @@ impl K8SProbe {
             time_tot: counter_tot,
             time_usr: counter_usr,
             time_sys: counter_sys,
-            time_used_tot: metric.time_used_tot,
-            time_used_system_mode: metric.time_used_system_mode,
-            time_used_user_mode: metric.time_used_user_mode,
+            cpu_time_tot: metric.cpu_time_total,
+            cpu_time_user_mode: metric.cpu_time_user_mode,
+            cpu_time_system_mode: metric.cpu_time_system_mode,
+            memory_anon: metric.memory_anonymous,
+            memory_file: metric.memory_file,
+            memory_kernel: metric.memory_kernel,
+            memory_pagetables: metric.memory_pagetables,
+            memory_total: metric.memory_total,
         })
     }
 }
 
 impl alumet::pipeline::Source for K8SProbe {
     fn poll(&mut self, measurements: &mut MeasurementAccumulator, timestamp: Timestamp) -> Result<(), PollError> {
-        let mut file_buffer = String::new();
-        let metrics: CgroupV2Metric = gather_value(&mut self.cgroup_v2_metric_file, &mut file_buffer)?;
-        let diff_tot = self.time_tot.update(metrics.time_used_tot).difference();
-        let diff_usr = self.time_usr.update(metrics.time_used_user_mode).difference();
-        let diff_sys = self.time_sys.update(metrics.time_used_system_mode).difference();
-        let consumer = ResourceConsumer::ControlGroup {
-            path: (self.cgroup_v2_metric_file.path.to_string_lossy().to_string().into()),
-        };
-        if let Some(value_tot) = diff_tot {
-            let p_tot: MeasurementPoint = MeasurementPoint::new(
+        /// Create a measurement point with given value,
+        /// the `LocalMachine` resource and some attributes related to the pod.
+        fn create_measurement_point(
+            timestamp: Timestamp,
+            metric_id: TypedMetricId<u64>,
+            resource_consumer: ResourceConsumer,
+            value_measured: u64,
+            metrics_param: &CgroupMeasurements,
+        ) -> MeasurementPoint {
+            MeasurementPoint::new(
                 timestamp,
-                self.time_used_tot,
+                metric_id,
                 Resource::LocalMachine,
-                consumer.clone(),
-                value_tot,
+                resource_consumer,
+                value_measured,
             )
-            .with_attr("uid", AttributeValue::String(metrics.uid.clone()))
-            .with_attr("name", AttributeValue::String(metrics.name.clone()))
-            .with_attr("namespace", AttributeValue::String(metrics.namespace.clone()))
-            .with_attr("node", AttributeValue::String(metrics.node.clone()));
+            .with_attr("uid", AttributeValue::String(metrics_param.pod_uid.clone()))
+            .with_attr("name", AttributeValue::String(metrics_param.pod_name.clone()))
+            .with_attr("namespace", AttributeValue::String(metrics_param.namespace.clone()))
+            .with_attr("node", AttributeValue::String(metrics_param.node.clone()))
+        }
+
+        let mut buffer = String::new();
+        let metrics = gather_value(&mut self.cgroup_v2_metric_file, &mut buffer)
+            .context("Error get value")
+            .retry_poll()?;
+
+        let diff_tot = self.time_tot.update(metrics.cpu_time_total).difference();
+        let diff_usr = self.time_usr.update(metrics.cpu_time_user_mode).difference();
+        let diff_sys = self.time_sys.update(metrics.cpu_time_system_mode).difference();
+
+        // Push cpu total usage measure for user and system
+        if let Some(value_tot) = diff_tot {
+            let p_tot = create_measurement_point(
+                timestamp,
+                self.cpu_time_tot,
+                self.cgroup_v2_metric_file.consumer_cpu.clone(),
+                value_tot,
+                &metrics,
+            );
             measurements.push(p_tot);
         }
+
+        // Push cpu usage measure for user
         if let Some(value_usr) = diff_usr {
-            let p_usr: MeasurementPoint = MeasurementPoint::new(
+            let p_usr = create_measurement_point(
                 timestamp,
-                self.time_used_user_mode,
-                Resource::LocalMachine,
-                consumer.clone(),
+                self.cpu_time_user_mode,
+                self.cgroup_v2_metric_file.consumer_cpu.clone(),
                 value_usr,
-            )
-            .with_attr("uid", AttributeValue::String(metrics.uid.clone()))
-            .with_attr("name", AttributeValue::String(metrics.name.clone()))
-            .with_attr("namespace", AttributeValue::String(metrics.namespace.clone()))
-            .with_attr("node", AttributeValue::String(metrics.node.clone()));
+                &metrics,
+            );
             measurements.push(p_usr);
         }
-        if let Some(value_sys) = diff_sys {
-            let p_sys: MeasurementPoint = MeasurementPoint::new(
-                timestamp,
-                self.time_used_system_mode,
-                Resource::LocalMachine,
-                consumer.clone(),
-                value_sys,
-            )
-            .with_attr("uid", AttributeValue::String(metrics.uid.clone()))
-            .with_attr("name", AttributeValue::String(metrics.name.clone()))
-            .with_attr("namespace", AttributeValue::String(metrics.namespace.clone()))
-            .with_attr("node", AttributeValue::String(metrics.node.clone()));
 
+        // Push cpu usage measure for system
+        if let Some(value_sys) = diff_sys {
+            let p_sys = create_measurement_point(
+                timestamp,
+                self.cpu_time_system_mode,
+                self.cgroup_v2_metric_file.consumer_cpu.clone(),
+                value_sys,
+                &metrics,
+            );
             measurements.push(p_sys);
         }
+
+        // Push anonymous used memory measure corresponding to running process and various allocated memory
+        let mem_anon_value = metrics.memory_anonymous;
+        let m_anon = create_measurement_point(
+            timestamp,
+            self.memory_anon,
+            self.cgroup_v2_metric_file.consumer_memory.clone(),
+            mem_anon_value,
+            &metrics,
+        );
+        measurements.push(m_anon);
+
+        // Push files memory measure, corresponding to open files and descriptors
+        let mem_file_value = metrics.memory_file;
+        let m_file = create_measurement_point(
+            timestamp,
+            self.memory_file,
+            self.cgroup_v2_metric_file.consumer_memory.clone(),
+            mem_file_value,
+            &metrics,
+        );
+        measurements.push(m_file);
+
+        // Push kernel memory measure
+        let mem_kernel_value = metrics.memory_kernel;
+        let m_ker = create_measurement_point(
+            timestamp,
+            self.memory_kernel,
+            self.cgroup_v2_metric_file.consumer_memory.clone(),
+            mem_kernel_value,
+            &metrics,
+        );
+        measurements.push(m_ker);
+
+        // Push pagetables memory measure
+        let mem_pagetables_value = metrics.memory_pagetables;
+        let m_pgt = create_measurement_point(
+            timestamp,
+            self.memory_pagetables,
+            self.cgroup_v2_metric_file.consumer_memory.clone(),
+            mem_pagetables_value,
+            &metrics,
+        );
+        measurements.push(m_pgt);
+
+        // Push total memory used by cgroup measure
+        let mem_total_value = mem_anon_value + mem_file_value + mem_kernel_value + mem_pagetables_value;
+        let m_tot = create_measurement_point(
+            timestamp,
+            self.memory_total,
+            self.cgroup_v2_metric_file.consumer_memory.clone(),
+            mem_total_value,
+            &metrics,
+        );
+        measurements.push(m_tot);
+
         Ok(())
     }
 }

--- a/plugin-cgroupv2/src/k8s/token.rs
+++ b/plugin-cgroupv2/src/k8s/token.rs
@@ -241,12 +241,10 @@ mod tests {
         let dir = root.join("run/secrets/kubernetes.io/serviceaccount/");
         std::fs::create_dir_all(&dir).unwrap();
 
-        // spell-checker: disable
         // HEADER = { "alg": "HS256", "typ": "JWT" }
         // PAYLOAD = { "sub": "1234567890", "exp": 4102444800, "name": "T3st1ng T0k3n" }
         // SIGNATURE = { HMACSHA256(base64UrlEncode(header) + "." +  base64UrlEncode(payload), signature) }
         let content = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiZXhwIjo0MTAyNDQ0ODAwLCJuYW1lIjoiVDNzdDFuZyBUMGszbiJ9.3vho4u0hx9QobMNbpDPvorWhTHsK9nSg2pZAGKxeVxA";
-        // spell-checker: enable
         let path = dir.join("token_1");
 
         std::fs::write(&path, content).unwrap();
@@ -276,13 +274,11 @@ mod tests {
         let dir = root.join("run/secrets/kubernetes.io/serviceaccount/");
         std::fs::create_dir_all(&dir).unwrap();
 
-        // spell-checker: disable
         // HEADER = { "alg": "HS256", "typ": "JWT" }
         // PAYLOAD = { "sub": "1234567890", "name": "T3st1ng T0k3n", "iat": 1516239022 }
         // SIGNATURE = { HMACSHA256(base64UrlEncode(header) + "." +  base64UrlEncode(payload), signature) }
         let content =
             "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IlQzc3QxbmcgVDBrM24iLCJpYXQiOjE1MTYyMzkwMjJ9.3vho4u0hx9QobMNbpDPvorWhTHsK9nSg2pZAGKxeVxA";
-        // spell-checker: enable
         let path = dir.join("token_2");
 
         std::fs::write(&path, content).unwrap();

--- a/plugin-cgroupv2/src/k8s/token.rs
+++ b/plugin-cgroupv2/src/k8s/token.rs
@@ -6,18 +6,25 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use base64::{prelude::BASE64_STANDARD_NO_PAD, Engine};
 use tokio::sync::RwLock;
 
 use super::plugin::TokenRetrieval;
 
+/// Kubernetes token and way to retrieve it.
+#[derive(Debug)]
 pub struct Token {
+    /// Way to obtain a token, in file or with Kubectl command.
     retrieval: TokenRetrieval,
+    /// Thread safe token data.
     data: Arc<RwLock<TokenData>>,
+    /// Public path for a token if we store it in a file.
+    pub path: Option<String>,
 }
 
 /// Private structure that holds the JWT token data.
+#[derive(Debug)]
 struct TokenData {
     /// Optional expiration time, in POSIX seconds.
     expiration_time: Option<u64>,
@@ -33,6 +40,7 @@ impl Token {
                 expiration_time: None,
                 value: None,
             })),
+            path: None,
         }
     }
 
@@ -72,7 +80,8 @@ impl Token {
             TokenRetrieval::Kubectl => {
                 let output = Command::new("kubectl")
                     .args(["create", "token", "alumet-reader", "-n", "alumet"])
-                    .output()?;
+                    .output()
+                    .context("Kubectl command execution")?;
 
                 if !output.status.success() {
                     return Err(anyhow!(
@@ -84,8 +93,14 @@ impl Token {
                 let token = String::from_utf8_lossy(&output.stdout);
                 token.trim().to_string()
             }
+
             TokenRetrieval::File => {
-                let mut file = File::open("/var/run/secrets/kubernetes.io/serviceaccount/token")?;
+                let token_path = match &self.path {
+                    Some(path_value) => path_value.clone(),
+                    None => "/var/run/secrets/kubernetes.io/serviceaccount/token".to_string(),
+                };
+
+                let mut file = File::open(token_path).context("Could not retrieve the file")?;
                 let mut token = String::new();
                 file.read_to_string(&mut token)?;
                 token
@@ -104,6 +119,7 @@ impl Token {
                     .trim(),
             )?,
         )?;
+
         let _ = components
             .next()
             .ok_or(anyhow!("Could not parse the token, the signature is missing"))?;
@@ -137,18 +153,53 @@ impl Token {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use tempfile::tempdir;
     use time::Duration;
     use tokio::time;
 
-    use super::*;
+    // Test `get_value` function to get token with valid value
+    #[tokio::test]
+    async fn test_get_value_with_valid_value() {
+        let retrieval = TokenRetrieval::File;
+        let token = Token::new(retrieval);
 
+        {
+            // Expand the expiration of the token to make it still valid.
+            let mut data = token.data.write().await;
+            data.value = Some("valid_token".to_string());
+            data.expiration_time = Some(SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() + 3600);
+        }
+
+        let result = token.get_value().await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "valid_token");
+    }
+
+    // Test `get_value` function to returns error when value is none
+    #[tokio::test]
+    async fn test_get_value_with_invalid_value() {
+        let retrieval = TokenRetrieval::File;
+        let token = Token::new(retrieval);
+
+        {
+            // Expand the expiration of the token to make it still valid.
+            let mut data = token.data.write().await;
+            data.value = None;
+            data.expiration_time = Some(SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() + 3600);
+        }
+
+        let result = token.get_value().await;
+        assert!(result.is_err());
+    }
+
+    // Test `is_valid` function
     #[tokio::test]
     async fn test_is_valid() {
         let token: Token = Token::new(TokenRetrieval::File);
         assert!(!token.is_valid().await);
-
         {
-            // Expand the expiration of the token to make it still valid.
             let mut new_data = token.data.write().await;
             (*new_data).expiration_time = Some(
                 SystemTime::now()
@@ -162,9 +213,7 @@ mod tests {
         }
 
         assert!(token.is_valid().await);
-
         {
-            // Decrease the expiration of the token to make it invalid.
             let mut new_data = token.data.write().await;
             (*new_data).expiration_time = Some(
                 SystemTime::now()
@@ -177,5 +226,79 @@ mod tests {
         }
 
         assert!(!token.is_valid().await);
+    }
+
+    // Test `refresh` function with valid file and token
+    #[tokio::test]
+    async fn test_refresh_with_valid_token() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join("test-alumet-plugin-k8s/var_1/");
+
+        if root.exists() {
+            std::fs::remove_dir_all(&root).unwrap();
+        }
+
+        let dir = root.join("run/secrets/kubernetes.io/serviceaccount/");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // spell-checker: disable
+        // HEADER = { "alg": "HS256", "typ": "JWT" }
+        // PAYLOAD = { "sub": "1234567890", "exp": 4102444800, "name": "T3st1ng T0k3n" }
+        // SIGNATURE = { HMACSHA256(base64UrlEncode(header) + "." +  base64UrlEncode(payload), signature) }
+        let content = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiZXhwIjo0MTAyNDQ0ODAwLCJuYW1lIjoiVDNzdDFuZyBUMGszbiJ9.3vho4u0hx9QobMNbpDPvorWhTHsK9nSg2pZAGKxeVxA";
+        // spell-checker: enable
+        let path = dir.join("token_1");
+
+        std::fs::write(&path, content).unwrap();
+
+        let mut token = Token::new(TokenRetrieval::File);
+        token.path = Some(path.to_str().unwrap().to_owned());
+        let result = token.refresh().await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), content);
+
+        let data = token.data.read().await;
+        assert_eq!(data.value, Some(content.to_string()));
+        assert_eq!(data.expiration_time, Some(4102444800));
+    }
+
+    // Test `refresh` function with missing exp field token
+    #[tokio::test]
+    async fn test_refresh_with_missing_exp() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join("test-alumet-plugin-k8s/var_2/");
+
+        if root.exists() {
+            std::fs::remove_dir_all(&root).unwrap();
+        }
+
+        let dir = root.join("run/secrets/kubernetes.io/serviceaccount/");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // spell-checker: disable
+        // HEADER = { "alg": "HS256", "typ": "JWT" }
+        // PAYLOAD = { "sub": "1234567890", "name": "T3st1ng T0k3n", "iat": 1516239022 }
+        // SIGNATURE = { HMACSHA256(base64UrlEncode(header) + "." +  base64UrlEncode(payload), signature) }
+        let content =
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IlQzc3QxbmcgVDBrM24iLCJpYXQiOjE1MTYyMzkwMjJ9.3vho4u0hx9QobMNbpDPvorWhTHsK9nSg2pZAGKxeVxA";
+        // spell-checker: enable
+        let path = dir.join("token_2");
+
+        std::fs::write(&path, content).unwrap();
+
+        let mut token = Token::new(TokenRetrieval::File);
+        token.path = Some(path.to_str().unwrap().to_owned());
+        let result = token.refresh().await;
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Could not extract the 'exp' field from the token"),);
+
+        let data = token.data.read().await;
+        assert_eq!(data.expiration_time, None);
+        assert_eq!(data.value, None);
     }
 }

--- a/plugin-cgroupv2/src/k8s/utils.rs
+++ b/plugin-cgroupv2/src/k8s/utils.rs
@@ -1,4 +1,6 @@
-use anyhow::*;
+use super::token::Token;
+use alumet::resources::ResourceConsumer;
+use anyhow::{Context, Result};
 use reqwest::{self, header};
 use serde_json::Value;
 use std::{
@@ -11,32 +13,26 @@ use std::{
     vec,
 };
 
-use crate::cgroupv2::CgroupV2Metric;
+use crate::cgroupv2::CgroupMeasurements;
 
-use super::token::Token;
-
-/// CgroupV2MetricFile represents a file containing cgroup v2 data about cpu usage.
-///
-/// Note that the file contains multiple metrics.
 #[derive(Debug)]
 pub struct CgroupV2MetricFile {
     /// Name of the pod.
     pub name: String,
-    /// Path to the file.
-    pub path: PathBuf,
-    /// Opened file descriptor.
-    pub file: File,
+    /// Path to the cgroup cpu stat file.
+    pub consumer_cpu: ResourceConsumer,
+    /// Path to the cgroup memory stat file.
+    pub consumer_memory: ResourceConsumer,
+    /// Opened file descriptor for cgroup cpu stat.
+    pub file_cpu: File,
+    /// Opened file descriptor for cgroup memory stat.
+    pub file_memory: File,
     /// UID of the pod.
     pub uid: String,
     /// Namespace of the pod.
     pub namespace: String,
     /// Node of the pod.
     pub node: String,
-}
-
-/// Check if a specific file is a dir. Used to know if cgroup v2 are used
-pub fn is_accessible_dir(path: &Path) -> bool {
-    path.is_dir()
 }
 
 /// Returns a Vector of CgroupV2MetricFile associated to pods available under a given directory.
@@ -50,24 +46,19 @@ fn list_metric_file_in_dir(
     let entries = fs::read_dir(root_directory_path)?;
     // Let's create a runtime to await async function and fill hashmap
     let rt = tokio::runtime::Builder::new_current_thread().enable_all().build()?;
-    let main_hash_map: HashMap<String, (String, String, String)> =
-        rt.block_on(async { get_existing_pods(hostname, kubernetes_api_url, token).await })?;
+    let main_hash_map = rt.block_on(async { get_existing_pods(hostname, kubernetes_api_url, token).await })?;
 
     // For each File in the root path
     for entry in entries {
         let path = entry?.path();
-        let mut path_cloned = path.clone();
+        let mut path_cloned_cpu = path.clone();
+        let mut path_cloned_memory = path.clone();
 
         if path.is_dir() {
-            let path_mf = path_cloned.clone();
-
             let file_name = path.file_name().ok_or_else(|| anyhow::anyhow!("No file name found"))?;
-            let dir_uid = file_name
-                .to_str()
-                .with_context(|| format!("Filename is not valid UTF-8: {:?}", path))?;
+            let dir_uid = file_name.to_str().context("Filename is not valid UTF-8")?;
 
-            // If the dir_uid doesn't end with .slice, we will not find the right files
-            if !dir_uid.ends_with(".slice") {
+            if !(dir_uid.ends_with(".slice")) {
                 continue;
             }
 
@@ -76,9 +67,7 @@ fn list_metric_file_in_dir(
             let root_file_name = root_directory_path
                 .file_name()
                 .ok_or_else(|| anyhow::anyhow!("No file name found"))?;
-            let truncated_prefix = root_file_name
-                .to_str()
-                .with_context(|| format!("filename is not valid UTF-8: {path:?}"))?;
+            let truncated_prefix = root_file_name.to_str().context("Filename is not valid UTF-8")?;
 
             let mut new_prefix = truncated_prefix
                 .strip_suffix(".slice")
@@ -87,23 +76,48 @@ fn list_metric_file_in_dir(
 
             new_prefix.push('-');
             let uid = dir_uid_mod.strip_prefix(&new_prefix).unwrap_or(dir_uid_mod);
-            path_cloned.push("cpu.stat");
+
+            path_cloned_cpu.push("cpu.stat");
+            path_cloned_memory.push("memory.stat");
+
             let name_to_seek_raw = uid.strip_prefix("pod").unwrap_or(uid);
             let name_to_seek = name_to_seek_raw.replace('_', "-"); // Replace _ with - to match with hashmap
 
             // Look in the hashmap if there is a tuple (name, namespace, node) associated to the uid of the cgroup
-            let (name, namespace, node): (String, String, String) = match main_hash_map.get(&name_to_seek.to_owned()) {
+            let (name, namespace, node) = match main_hash_map.get(&name_to_seek.to_owned()) {
                 Some((name, namespace, node)) => (name.to_owned(), namespace.to_owned(), node.to_owned()),
                 None => ("".to_owned(), "".to_owned(), "".to_owned()),
             };
 
-            let file: File =
-                File::open(&path_cloned).with_context(|| format!("failed to open file {}", path_cloned.display()))?;
+            let file_cpu = File::open(&path_cloned_cpu)
+                .with_context(|| format!("failed to open file {}", path_cloned_cpu.display()))?;
+            let file_memory = File::open(&path_cloned_memory)
+                .with_context(|| format!("failed to open file {}", path_cloned_memory.display()))?;
+
+            // CPU ressource consumer for cpu.stat file in cgroup
+            let consumer_cpu = ResourceConsumer::ControlGroup {
+                path: path_cloned_cpu
+                    .to_str()
+                    .expect("Path to 'cpu.stat' must be valid UTF8")
+                    .to_string()
+                    .into(),
+            };
+            // Memory ressource consumer for memory.stat file in cgroup
+            let consumer_memory = ResourceConsumer::ControlGroup {
+                path: path_cloned_memory
+                    .to_str()
+                    .expect("Path to 'memory.stat' must to be valid UTF8")
+                    .to_string()
+                    .into(),
+            };
+
             // Let's create the new metric and push it to the vector of metrics
             vec_file_metric.push(CgroupV2MetricFile {
                 name: name.clone(),
-                path: path_mf,
-                file,
+                consumer_cpu,
+                file_cpu,
+                consumer_memory,
+                file_memory,
                 uid: uid.to_owned(),
                 namespace: namespace.clone(),
                 node: node.clone(),
@@ -125,8 +139,10 @@ pub fn list_all_k8s_pods_file(
     if !root_directory_path.exists() {
         return Ok(final_list_metric_file);
     }
+
     // Add the root for all subdirectory:
     let mut all_sub_dir: Vec<PathBuf> = vec![root_directory_path.to_owned()];
+
     // Iterate in the root directory and add to the vec all folder ending with "".slice"
     // On unix, folders are files, files are files and peripherals are also files
     for file in fs::read_dir(root_directory_path)? {
@@ -153,23 +169,52 @@ pub fn list_all_k8s_pods_file(
     Ok(final_list_metric_file)
 }
 
-/// Extracts the metrics from the file.
-pub fn gather_value(file: &mut CgroupV2MetricFile, content_buffer: &mut String) -> anyhow::Result<CgroupV2Metric> {
-    content_buffer.clear(); //Clear before use
-    file.file
+/// Extracts the metrics from data files of cgroup.
+///
+/// # Arguments
+///
+/// - Get `CgroupV2MetricFile` structure parameters to use cgroup data.
+/// - `content_buffer` : Buffer where we store content of cgroup data file.
+///
+/// # Return
+///
+/// - Error if CPU or memory data file are not found.
+pub fn gather_value(file: &mut CgroupV2MetricFile, content_buffer: &mut String) -> anyhow::Result<CgroupMeasurements> {
+    content_buffer.clear();
+
+    // CPU cgroup data
+    file.file_cpu
         .read_to_string(content_buffer)
-        .with_context(|| format!("Unable to gather cgroup v2 metrics by reading file {}", file.name))?;
-    file.file.rewind()?;
+        .context("Unable to gather cgroup v2 CPU metrics by reading file")?;
+    if content_buffer.is_empty() {
+        return Err(anyhow::anyhow!("CPU stat file is empty for {}", file.name));
+    }
+    file.file_cpu.rewind()?;
+
+    // Memory cgroup data
+    file.file_memory
+        .read_to_string(content_buffer)
+        .context("Unable to gather cgroup v2 memory metrics by reading file")?;
+    if content_buffer.is_empty() {
+        return Err(anyhow::anyhow!("Memory stat file is empty for {}", file.name));
+    }
+    file.file_memory.rewind()?;
+
     let mut new_metric =
-        CgroupV2Metric::from_str(content_buffer).with_context(|| format!("failed to parse {}", file.name))?;
-    new_metric.name = file.name.clone();
+        CgroupMeasurements::from_str(content_buffer).with_context(|| format!("failed to parse {}", file.name))?;
+
+    new_metric.pod_name = file.name.clone();
     new_metric.namespace = file.namespace.clone();
-    new_metric.uid = file.uid.clone();
+    new_metric.pod_uid = file.uid.clone();
     new_metric.node = file.node.clone();
+
     Ok(new_metric)
 }
 
-/// Returns a HashMap where the key is the uid used and the value is a tuple containing it's name, namespace and node
+/// # Returns
+///
+/// `HashMap` where the key is the uid used,
+/// and the value is a tuple containing it's name, namespace and node
 pub async fn get_existing_pods(
     node: &str,
     kubernetes_api_url: &str,
@@ -186,9 +231,11 @@ pub async fn get_existing_pods(
     if kubernetes_api_url.is_empty() {
         return Ok(HashMap::new());
     }
+
     let mut api_url_root = kubernetes_api_url.to_string();
     api_url_root.push_str("/api/v1/pods/");
     let mut selector = false;
+
     let api_url = if node.is_empty() {
         api_url_root.to_owned()
     } else {
@@ -196,12 +243,15 @@ pub async fn get_existing_pods(
         selector = true;
         tmp
     };
+
     let mut headers = header::HeaderMap::new();
     headers.insert(header::AUTHORIZATION, format!("Bearer {}", token).parse()?);
+
     let client = reqwest::Client::builder()
         .danger_accept_invalid_certs(true)
         .default_headers(headers)
         .build()?;
+
     let Ok(response) = client.get(api_url).send().await else {
         return Ok(HashMap::new());
     };
@@ -213,16 +263,19 @@ pub async fn get_existing_pods(
             Value::Null
         }
     };
+
     let mut hash_map_to_ret = HashMap::new();
 
     // let's check if the items' part contain pods to look at
     if let Some(items) = data.get("items") {
-        let size = items.as_array().unwrap_or(&vec![]).len(); // If the node was not found i.e. no item in the response, we call the API again with all nodes
+        // If the node was not found i.e. no item in the response, we call the API again with all nodes
+        let size = items.as_array().map(|a| a.len()).unwrap_or(0);
         if size == 0 && selector {
             // Ask again the api, with all nodes
             let Ok(response) = client.get(api_url_root).send().await else {
                 return Ok(HashMap::new());
             };
+
             data = match response.json().await {
                 Ok(value) => value,
                 Err(err) => {
@@ -244,6 +297,7 @@ pub async fn get_existing_pods(
                 .get("kubernetes.io/config.hash")
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
+
             if config_hash.is_empty() {
                 match metadata {
                     Value::Null => {
@@ -258,7 +312,7 @@ pub async fn get_existing_pods(
             let pod_name = metadata.get("name").and_then(|v| v.as_str()).unwrap_or("");
             let pod_namespace = metadata.get("namespace").and_then(|v| v.as_str()).unwrap_or("");
             let pod_node = spec.get("nodeName").and_then(|v| v.as_str()).unwrap_or("");
-            log::debug!("Found matching pod: {} in namespace {}", pod_name, pod_namespace);
+
             hash_map_to_ret.entry(String::from(config_hash)).or_insert((
                 pod_name.to_owned(),
                 pod_namespace.to_owned(),
@@ -291,9 +345,11 @@ pub async fn get_pod_name(
     if kubernetes_api_url.is_empty() {
         return Ok(("".to_string(), "".to_string(), "".to_string()));
     }
+
     let mut api_url_root = kubernetes_api_url.to_string();
     api_url_root.push_str("/api/v1/pods/");
     let mut selector = false;
+
     let api_url = if node.is_empty() {
         api_url_root.to_owned()
     } else {
@@ -301,6 +357,7 @@ pub async fn get_pod_name(
         selector = true;
         tmp
     };
+
     let mut headers = header::HeaderMap::new();
     headers.insert(header::AUTHORIZATION, format!("Bearer {}", token).parse()?);
     let client = reqwest::Client::builder()
@@ -322,7 +379,8 @@ pub async fn get_pod_name(
 
     // let's check if the items' part contain pods to look at
     if let Some(items) = data.get("items") {
-        let size = items.as_array().unwrap_or(&vec![]).len(); // If the node was not found i.e. no item in the response, we call the API again with all nodes
+        // If the node was not found i.e. no item in the response, we call the API again with all nodes
+        let size = items.as_array().map(|a| a.len()).unwrap_or(0);
         if size == 0 && selector {
             // Ask again the api, with all nodes
             let Ok(response) = client.get(api_url_root).send().await else {
@@ -350,6 +408,7 @@ pub async fn get_pod_name(
                 .get("kubernetes.io/config.hash")
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
+
             if config_hash.is_empty() {
                 match metadata {
                     Value::Null => {
@@ -360,6 +419,7 @@ pub async fn get_pod_name(
                     }
                 }
             }
+
             if config_hash == new_uid {
                 let pod_name = metadata.get("name").and_then(|v| v.as_str()).unwrap_or("");
                 let pod_namespace = metadata.get("namespace").and_then(|v| v.as_str()).unwrap_or("");
@@ -377,46 +437,56 @@ pub async fn get_pod_name(
 #[cfg(test)]
 mod tests {
     use super::{super::plugin::TokenRetrieval, *};
+    use mockito::mock;
+    use serde_json::json;
+    use std::{fs::File, path::PathBuf};
+    use tempfile::tempdir;
 
-    #[test]
-    fn test_is_cgroups_v2() {
-        let tmp = std::env::temp_dir();
-        let root: std::path::PathBuf = tmp.join("test-alumet-plugin-k8s/is_cgroupv2");
-        if root.exists() {
-            std::fs::remove_dir_all(&root).unwrap();
-        }
-        let cgroupv2_dir = root.join("myDirCgroup");
-        std::fs::create_dir_all(&cgroupv2_dir).unwrap();
-        assert!(is_accessible_dir(Path::new(&cgroupv2_dir)));
-        assert!(!is_accessible_dir(std::path::Path::new(
-            "test-alumet-plugin-k8s/is_cgroupv2/myDirCgroup_bad"
-        )));
-    }
+    // spell-checker: disable
+    // HEADER = { "alg": "HS256", "typ": "JWT" }
+    // PAYLOAD = { "sub": "1234567890", "exp": 4102444800, "name": "T3st1ng T0k3n" }
+    // SIGNATURE = { HMACSHA256(base64UrlEncode(header) + "." +  base64UrlEncode(payload), signature) }
+    const TOKEN_CONTENT: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiZXhwIjo0MTAyNDQ0ODAwLCJuYW1lIjoiVDNzdDFuZyBUMGszbiJ9.3vho4u0hx9QobMNbpDPvorWhTHsK9nSg2pZAGKxeVxA";
+    // spell-checker: enable
 
+    // Test `list_metric_file_in_dir` function to simulate arborescence of kubernetes pods
+    // and missing files in Kubernetes directory
     #[test]
     fn test_list_metric_file_in_dir() {
-        let tmp = std::env::temp_dir();
-        let root: std::path::PathBuf = tmp.join("test-alumet-plugin-k8s/kubepods-folder.slice/");
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join("test-alumet-plugin-k8s/kubepods-folder.slice/");
+
         if root.exists() {
             std::fs::remove_dir_all(&root).unwrap();
         }
-        let burstable_dir = root.join("kubepods-burstable.slice/");
-        std::fs::create_dir_all(&burstable_dir).unwrap();
 
-        let a = burstable_dir.join("kubepods-burstable-pod32a1942cb9a81912549c152a49b5f9b1.slice/");
-        let b = burstable_dir.join("kubepods-burstable-podd9209de2b4b526361248c9dcf3e702c0.slice/");
-        let c = burstable_dir.join("kubepods-burstable-podccq5da1942a81912549c152a49b5f9b1.slice/");
-        let d = burstable_dir.join("kubepods-burstable-podd87dz3z8z09de2b4b526361248c902c0.slice/");
-        std::fs::create_dir_all(&a).unwrap();
-        std::fs::create_dir_all(&b).unwrap();
-        std::fs::create_dir_all(&c).unwrap();
-        std::fs::create_dir_all(&d).unwrap();
-        std::fs::write(a.join("cpu.stat"), "en").unwrap();
-        std::fs::write(b.join("cpu.stat"), "fr").unwrap();
-        std::fs::write(c.join("cpu.stat"), "sv").unwrap();
-        std::fs::write(d.join("cpu.stat"), "ne").unwrap();
-        let list_met_file: anyhow::Result<Vec<CgroupV2MetricFile>> =
-            list_metric_file_in_dir(&burstable_dir, "", "", &Token::new(TokenRetrieval::Kubectl));
+        let dir = root.join("kubepods-burstable.slice/");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let sub_dir = dir.join("kubepods-burstable-pod32a1942cb9a81912549c152a49b5f9b1.slice/");
+        std::fs::create_dir_all(&sub_dir).unwrap();
+        std::fs::write(sub_dir.join("cpu.stat"), "test_cpu").unwrap();
+
+        let result = list_metric_file_in_dir(&dir, "", "", &Token::new(TokenRetrieval::Kubectl));
+        assert!(result.is_err());
+
+        let sub_dir = [
+            dir.join("kubepods-burstable-pod32a1942cb9a81912549c152a49b5f9b1.slice/"),
+            dir.join("kubepods-burstable-podd9209de2b4b526361248c9dcf3e702c0.slice/"),
+            dir.join("kubepods-burstable-podccq5da1942a81912549c152a49b5f9b1.slice/"),
+            dir.join("kubepods-burstable-podd87dz3z8z09de2b4b526361248c902c0.slice/"),
+        ];
+
+        for i in 0..4 {
+            std::fs::create_dir_all(&sub_dir[i]).unwrap();
+        }
+
+        for i in 0..4 {
+            std::fs::write(sub_dir[i].join("cpu.stat"), "test_cpu").unwrap();
+            std::fs::write(sub_dir[i].join("memory.stat"), "test_memory").unwrap();
+        }
+
+        let list_met_file = list_metric_file_in_dir(&dir, "", "", &Token::new(TokenRetrieval::Kubectl));
         let list_pod_name = [
             "pod32a1942cb9a81912549c152a49b5f9b1",
             "podd9209de2b4b526361248c9dcf3e702c0",
@@ -435,30 +505,97 @@ mod tests {
                 }
             }
             Err(err) => {
-                log::error!("Error reading list_met_file: {:?}", err);
+                log::error!("Reading list_met_file: {:?}", err);
                 assert!(false);
             }
         }
+
         assert!(true);
     }
+
+    // Test `gather_value` function with invalid data
     #[test]
-    fn test_gather_value() {
-        let tmp = std::env::temp_dir();
-        let root: std::path::PathBuf = tmp.join("test-alumet-plugin-k8s/kubepods-gather.slice/");
+    fn test_gather_value_with_invalid_data() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join("test-alumet-plugin-k8s/kubepods-invalid-gather.slice/");
+
         if root.exists() {
             std::fs::remove_dir_all(&root).unwrap();
         }
-        let burstable_dir = root.join("kubepods-burstable.slice/");
-        std::fs::create_dir_all(&burstable_dir).unwrap();
 
-        let a = burstable_dir.join("kubepods-burstable-pod32a1942cb9a81912549c152a49b5f9b1.slice/");
+        let dir = root.join("kubepods-burstable.slice/");
+        std::fs::create_dir_all(&dir).unwrap();
 
-        std::fs::create_dir_all(&a).unwrap();
-        let path_file = a.join("cpu.stat");
+        let sub_dir = dir.join("kubepods-burstable-pod32a1942cb9a81912549c152a49b5f9b1.slice/");
+        std::fs::create_dir_all(&sub_dir).unwrap();
+
+        let path_cpu = sub_dir.join("cpu.stat");
+        let path_memory = sub_dir.join("memory.stat");
+
+        std::fs::write(&path_cpu, "invalid_cpu_data").unwrap();
+        std::fs::write(&path_memory, "invalid_memory_data").unwrap();
+
+        let file_cpu = File::open(&path_cpu).unwrap();
+        let file_memory = File::open(&path_memory).unwrap();
+
+        // CPU ressource consumer for cpu.stat file in cgroup
+        let consumer_cpu = ResourceConsumer::ControlGroup {
+            path: path_cpu
+                .to_str()
+                .expect("Path to 'cpu.stat' must be valid UTF8")
+                .to_string()
+                .into(),
+        };
+        // Memory ressource consumer for memory.stat file in cgroup
+        let consumer_memory = ResourceConsumer::ControlGroup {
+            path: path_memory
+                .to_str()
+                .expect("Path to 'memory.stat' must to be valid UTF8")
+                .to_string()
+                .into(),
+        };
+
+        let mut metric_file = CgroupV2MetricFile {
+            name: "test-pod".to_string(),
+            consumer_cpu,
+            consumer_memory,
+            file_cpu,
+            file_memory,
+            uid: "test-uid".to_string(),
+            namespace: "default".to_string(),
+            node: "test-node".to_string(),
+        };
+
+        let mut content_buffer = String::new();
+        let result = gather_value(&mut metric_file, &mut content_buffer);
+
+        result.expect("gather_value get invalid data");
+    }
+
+    // Test `gather_value` function with valid values
+    #[test]
+    fn test_gather_value_with_valid_values() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join("test-alumet-plugin-k8s/kubepods-gather.slice/");
+
+        if root.exists() {
+            std::fs::remove_dir_all(&root).unwrap();
+        }
+
+        let dir = root.join("kubepods-burstable.slice/");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let sub_dir = dir.join("kubepods-burstable-pod32a1942cb9a81912549c152a49b5f9b1.slice/");
+        std::fs::create_dir_all(&sub_dir).unwrap();
+
+        let path_cpu = sub_dir.join("cpu.stat");
+        let path_memory = sub_dir.join("memory.stat");
+
         std::fs::write(
-            path_file.clone(),
+            path_cpu.clone(),
             format!(
-                "usage_usec 8335557927\n
+                "
+                usage_usec 8335557927\n
                 user_usec 4728882396\n
                 system_usec 3606675531\n
                 nr_periods 0\n
@@ -468,37 +605,703 @@ mod tests {
         )
         .unwrap();
 
-        let file = match File::open(&path_file) {
-            Err(why) => panic!("couldn't open {}: {}", path_file.display(), why),
-            Ok(file) => file,
+        std::fs::write(
+            path_memory.clone(),
+            format!(
+                "
+                anon 8335557927
+                file 4728882396
+                kernel_stack 3686400
+                pagetables 0
+                percpu 16317568
+                sock 12288
+                shmem 233824256
+                file_mapped 0
+                file_dirty 20480,
+                ...."
+            ),
+        )
+        .unwrap();
+
+        let file_cpu = match File::open(&path_cpu) {
+            Err(why) => panic!("ERROR : Couldn't open {}: {}", path_cpu.display(), why),
+            Ok(file_cpu) => file_cpu,
         };
 
-        let mut my_cgroup_test_file: CgroupV2MetricFile = CgroupV2MetricFile {
+        let file_memory = match File::open(&path_memory) {
+            Err(why) => panic!("ERROR : Couldn't open {}: {}", path_memory.display(), why),
+            Ok(file_memory) => file_memory,
+        };
+
+        // CPU ressource consumer for cpu.stat file in cgroup
+        let consumer_cpu = ResourceConsumer::ControlGroup {
+            path: path_cpu
+                .to_str()
+                .expect("Path to 'cpu.stat' must be valid UTF8")
+                .to_string()
+                .into(),
+        };
+        // Memory ressource consumer for memory.stat file in cgroup
+        let consumer_memory = ResourceConsumer::ControlGroup {
+            path: path_memory
+                .to_str()
+                .expect("Path to 'memory.stat' must to be valid UTF8")
+                .to_string()
+                .into(),
+        };
+
+        let metric_file = CgroupV2MetricFile {
             name: "testing_pod".to_string(),
-            path: path_file,
-            file,
+            consumer_cpu,
+            file_cpu,
+            consumer_memory,
+            file_memory,
             uid: "uid_test".to_string(),
             namespace: "namespace_test".to_string(),
             node: "node_test".to_owned(),
         };
-        let mut content_file = String::new();
-        let res_metric = gather_value(&mut my_cgroup_test_file, &mut content_file);
-        if let Ok(CgroupV2Metric {
-            name,
-            time_used_tot,
-            time_used_user_mode,
-            time_used_system_mode,
-            uid: _uid,
-            namespace: _ns,
-            node: _nd,
-        }) = res_metric
+
+        let mut cgroup = metric_file;
+        let mut content = String::new();
+        let result = gather_value(&mut cgroup, &mut content);
+
+        if let Ok(CgroupMeasurements {
+            pod_name,
+            pod_uid,
+            namespace,
+            node,
+            cpu_time_total,
+            cpu_time_user_mode,
+            cpu_time_system_mode,
+            memory_anonymous,
+            memory_file,
+            memory_kernel,
+            memory_pagetables,
+        }) = result
         {
-            assert_eq!(name, "testing_pod".to_owned());
-            assert_eq!(time_used_tot, 8335557927);
-            assert_eq!(time_used_user_mode, 4728882396);
-            assert_eq!(time_used_system_mode, 3606675531);
-        } else {
-            assert!(false);
+            assert_eq!(pod_name, "testing_pod".to_owned());
+            assert_eq!(pod_uid, "uid_test".to_owned());
+            assert_eq!(namespace, "namespace_test".to_owned());
+            assert_eq!(node, "node_test".to_owned());
+            assert_eq!(cpu_time_total, 8335557927);
+            assert_eq!(cpu_time_user_mode, 4728882396);
+            assert_eq!(cpu_time_system_mode, 3606675531);
+            assert_eq!(memory_anonymous, 8335557927);
+            assert_eq!(memory_file, 4728882396);
+            assert_eq!(memory_kernel, 3686400);
+            assert_eq!(memory_pagetables, 0);
         }
+    }
+
+    // Test `list_all_k8s_pods` function with a not existing file root directory
+    #[tokio::test]
+    async fn test_list_all_k8s_pods_file_with_no_root_directory() {
+        let root = PathBuf::from("invalid");
+        let hostname = "test-host".to_string();
+        let kubernetes_api_url = "https://127.0.0.1:8080".to_string();
+        let token = Token::new(TokenRetrieval::Kubectl);
+
+        let result = list_all_k8s_pods_file(&root, hostname, kubernetes_api_url, &token);
+        assert!(result.unwrap().is_empty());
+    }
+
+    // Test `list_all_k8s_pods` function with a no slice folders file
+    #[test]
+    fn test_list_all_k8s_pods_file_with_no_slice_folder() -> Result<()> {
+        let temp = tempdir()?;
+        let hostname = "test-host".to_string();
+        let kubernetes_api_url = "https://127.0.0.1:8080".to_string();
+        let token = Token::new(TokenRetrieval::Kubectl);
+
+        fs::create_dir(temp.path().join("folder1"))?;
+        fs::create_dir(temp.path().join("folder2"))?;
+
+        let result = list_all_k8s_pods_file(temp.path(), hostname, kubernetes_api_url, &token)?;
+        assert!(result.is_empty());
+        Ok(())
+    }
+
+    // Test `list_all_k8s_pods` function with a file with invalid subfolder
+    #[test]
+    fn test_list_all_k8s_pods_file_with_invalid_subfolder() -> Result<()> {
+        let temp_dir = tempdir()?;
+        let hostname = "test-host".to_string();
+        let kubernetes_api_url = "https://127.0.0.1:8080".to_string();
+        let token = Token::new(TokenRetrieval::Kubectl);
+
+        let slice_dir = temp_dir.path().join("folder1.slice");
+        fs::create_dir(&slice_dir)?;
+
+        File::create(slice_dir.join("invalid_file"))?;
+        let result = list_all_k8s_pods_file(temp_dir.path(), hostname, kubernetes_api_url, &token);
+
+        assert!(result.is_err());
+        Ok(())
+    }
+
+    // Test `get_existing_pods` with an empty kubernetes api url
+    #[tokio::test]
+    async fn test_get_existing_pods_with_empty_url() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join("test-alumet-plugin-k8s/var_3/");
+
+        if root.exists() {
+            std::fs::remove_dir_all(&root).unwrap();
+        }
+
+        let dir = root.join("run/secrets/kubernetes.io/serviceaccount/");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let path = dir.join("token_3");
+        std::fs::write(&path, TOKEN_CONTENT).unwrap();
+
+        let node = "test_node";
+        let mut token = Token::new(TokenRetrieval::File);
+
+        token.path = Some(path.to_str().unwrap().to_owned());
+
+        let result = get_existing_pods(node, "", &token).await;
+        assert!(result.is_ok());
+
+        let map = result.unwrap();
+        assert!(map.is_empty());
+
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    // Test `get_existing_pods` with JSON send in fake server to a specific token
+    #[tokio::test]
+    async fn test_get_existing_pods_with_valid_data() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join("test-alumet-plugin-k8s/var_4/");
+
+        if root.exists() {
+            std::fs::remove_dir_all(&root).unwrap();
+        }
+
+        let dir = root.join("run/secrets/kubernetes.io/serviceaccount/");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let path = dir.join("token_4");
+        std::fs::write(&path, TOKEN_CONTENT).unwrap();
+
+        let node = "pod1";
+        let url = format!("/api/v1/pods/?fieldSelector=spec.nodeName={}", node);
+        let _mock = mock("GET", url.as_str())
+            .with_status(200)
+            .with_header("Content-Type", "application/json")
+            .with_body(
+                json!({
+                    "items": [
+                        {
+                            "metadata": {
+                                "name": "pod1",
+                                "namespace": "default",
+                                "uid": "01234",
+                                "annotations": {
+                                    "kubernetes.io/config.hash": "hash1"
+                                }
+                            },
+                            "spec": {
+                                "nodeName": "node1"
+                            }
+                        },
+                        {
+                            "metadata": {
+                                "name": "pod2",
+                                "namespace": "default",
+                                "uid": "56789"
+                            },
+                            "spec": {
+                                "nodeName": "node2"
+                            }
+                        }
+                    ]
+                })
+                .to_string(),
+            )
+            .create();
+
+        let kubernetes_api_url = &mockito::server_url();
+        let mut token = Token::new(TokenRetrieval::File);
+
+        token.path = Some(path.to_str().unwrap().to_owned());
+
+        let result = get_existing_pods(node, kubernetes_api_url, &token).await.unwrap();
+
+        assert_eq!(
+            result.get("hash1").unwrap(),
+            &("pod1".to_string(), "default".to_string(), "node1".to_string())
+        );
+        assert_eq!(
+            result.get("56789").unwrap(),
+            &("pod2".to_string(), "default".to_string(), "node2".to_string())
+        );
+    }
+
+    // Test `get_existing_pods` with JSON send in fake server to a specific token,
+    // with some of them missing in the JSON
+    #[tokio::test]
+    async fn test_get_existing_pods_with_half_valid_data() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join("test-alumet-plugin-k8s/var_5/");
+
+        if root.exists() {
+            std::fs::remove_dir_all(&root).unwrap();
+        }
+
+        let dir = root.join("run/secrets/kubernetes.io/serviceaccount/");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let path = dir.join("token_5");
+        std::fs::write(&path, TOKEN_CONTENT).unwrap();
+
+        let node = "pod1";
+        let url = format!("/api/v1/pods/?fieldSelector=spec.nodeName={}", node);
+        let _mock = mock("GET", url.as_str())
+            .with_status(200)
+            .with_header("Content-Type", "application/json")
+            .with_body(
+                json!({
+                    "items": [
+                        {
+                            "metadata": {
+                                "namespace": "default",
+                                "annotations": {
+                                    "kubernetes.io/config.hash": "hash1"
+                                }
+                            },
+                            "nodeName": "node1",
+                        },
+                    ]
+                })
+                .to_string(),
+            )
+            .create();
+
+        let kubernetes_api_url = &mockito::server_url();
+        let mut token = Token::new(TokenRetrieval::File);
+
+        token.path = Some(path.to_str().unwrap().to_owned());
+
+        let result = get_existing_pods(node, kubernetes_api_url, &token).await.unwrap();
+
+        assert_eq!(
+            result.get("hash1").unwrap(),
+            &("".to_string(), "default".to_string(), "".to_string())
+        );
+    }
+
+    // Test `get_existing_pods` with JSON parsing and URL error
+    #[tokio::test]
+    async fn test_get_existing_pods_with_url_and_json_error() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join("test-alumet-plugin-k8s/var_6/");
+
+        if root.exists() {
+            std::fs::remove_dir_all(&root).unwrap();
+        }
+
+        let dir = root.join("run/secrets/kubernetes.io/serviceaccount/");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let path = dir.join("token_6");
+        std::fs::write(&path, TOKEN_CONTENT).unwrap();
+
+        let node = "pod1";
+        let _mock = mock("GET", "invalid")
+            .with_status(200)
+            .with_header("Content-Type", "application/json")
+            .with_body(
+                json!({
+                    "items": [
+                        {
+                            "invalid": {
+                                "invalid": "invalid"
+                            },
+                        },
+                    ]
+                })
+                .to_string(),
+            )
+            .create();
+
+        let kubernetes_api_url = &mockito::server_url();
+        let mut token = Token::new(TokenRetrieval::File);
+
+        token.path = Some(path.to_str().unwrap().to_owned());
+
+        let result = get_existing_pods(node, kubernetes_api_url, &token).await;
+        assert!(result.is_ok());
+
+        let map = result.unwrap();
+        assert!(map.is_empty());
+    }
+
+    // Test `get_existing_pods` with JSON reading cursor error
+    #[tokio::test]
+    async fn test_get_existing_pods_with_cursor_error() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join("test-alumet-plugin-k8s/var_7/");
+
+        if root.exists() {
+            std::fs::remove_dir_all(&root).unwrap();
+        }
+
+        let dir = root.join("run/secrets/kubernetes.io/serviceaccount/");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let path = dir.join("token_7");
+        std::fs::write(&path, TOKEN_CONTENT).unwrap();
+
+        let node = "pod1";
+        let url = format!("/api/v1/pods/?fieldSelector=spec.nodeName={}", node);
+        let _mock = mock("GET", url.as_str())
+            .with_status(200)
+            .with_header("Content-Type", "application/json")
+            .with_body(
+                json!({
+                    "items": []
+                })
+                .to_string(),
+            )
+            .create();
+
+        let kubernetes_api_url = &mockito::server_url();
+        let mut token = Token::new(TokenRetrieval::File);
+
+        token.path = Some(path.to_str().unwrap().to_owned());
+
+        let result = get_existing_pods(node, kubernetes_api_url, &token).await;
+        assert!(result.is_ok());
+
+        let map = result.unwrap();
+        assert!(map.is_empty());
+    }
+
+    // Test `get_pod_name` with not existing token file and empty kubernetes api url
+    #[tokio::test]
+    async fn test_get_pod_name_with_empty_url() {
+        let uid = "test_uid";
+        let node = "test_node";
+        let token = Token::new(TokenRetrieval::File);
+
+        let result = get_pod_name(uid, node, "", &token).await;
+        assert!(result.is_ok());
+
+        let (name, namespace, node) = result.unwrap();
+        assert!(name.is_empty());
+        assert!(namespace.is_empty());
+        assert!(node.is_empty());
+    }
+
+    // Test `get_pod_name` with valid existing token file and empty kubernetes api url
+    #[tokio::test]
+    async fn test_get_pod_name_with_valid_token_and_empty_url() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join("test-alumet-plugin-k8s/var_8/");
+
+        if root.exists() {
+            std::fs::remove_dir_all(&root).unwrap();
+        }
+
+        let dir = root.join("run/secrets/kubernetes.io/serviceaccount/");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let path = dir.join("token_8");
+        std::fs::write(&path, TOKEN_CONTENT).unwrap();
+
+        let uid = "test_uid";
+        let node = "test_node";
+        let mut token = Token::new(TokenRetrieval::File);
+
+        token.path = Some(path.to_str().unwrap().to_owned());
+
+        let result = get_pod_name(uid, node, "", &token).await;
+        assert!(result.is_ok());
+
+        let (name, namespace, node) = result.unwrap();
+        assert!(name.is_empty());
+        assert!(namespace.is_empty());
+        assert!(node.is_empty());
+    }
+
+    // Test `get_pod_name` with JSON send in fake server to a specific token and get valid data
+    #[tokio::test]
+    async fn test_get_pod_name_with_valid_data() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join("test-alumet-plugin-k8s/var_9/");
+
+        if root.exists() {
+            std::fs::remove_dir_all(&root).unwrap();
+        }
+
+        let dir = root.join("run/secrets/kubernetes.io/serviceaccount/");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let path = dir.join("token_9");
+        std::fs::write(&path, TOKEN_CONTENT).unwrap();
+
+        let node = "pod1";
+        let url = format!("/api/v1/pods/?fieldSelector=spec.nodeName={}", node);
+        let _mock = mock("GET", url.as_str())
+            .with_status(200)
+            .with_header("Content-Type", "application/json")
+            .with_body(
+                json!({
+                    "items": [
+                        {
+                            "metadata": {
+                                "name": "pod1",
+                                "namespace": "default",
+                                "uid": "01234",
+                                "annotations": {
+                                    "kubernetes.io/config.hash": "hash1"
+                                }
+                            },
+                            "spec": {
+                                "nodeName": "node1"
+                            }
+                        },
+                        {
+                            "metadata": {
+                                "name": "pod2",
+                                "namespace": "default",
+                                "uid": "56789"
+                            },
+                            "spec": {
+                                "nodeName": "node2"
+                            }
+                        }
+                    ]
+                })
+                .to_string(),
+            )
+            .create();
+
+        let uid = "hash1";
+        let kubernetes_api_url = &mockito::server_url();
+        let mut token = Token::new(TokenRetrieval::File);
+
+        token.path = Some(path.to_str().unwrap().to_owned());
+
+        let result = get_pod_name(uid, node, kubernetes_api_url, &token).await.unwrap();
+        assert_eq!(result.0, "pod1");
+        assert_eq!(result.1, "default");
+        assert_eq!(result.2, "node1");
+    }
+
+    // Test `get_pod_name` with JSON send in fake server to a specific token and get data,
+    // with some of them missing in the JSON
+    #[tokio::test]
+    async fn test_get_pod_name_with_half_valid_data() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join("test-alumet-plugin-k8s/var_10/");
+
+        if root.exists() {
+            std::fs::remove_dir_all(&root).unwrap();
+        }
+
+        let dir = root.join("run/secrets/kubernetes.io/serviceaccount/");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let path = dir.join("token_10");
+        std::fs::write(&path, TOKEN_CONTENT).unwrap();
+
+        let node = "pod1";
+        let url = format!("/api/v1/pods/?fieldSelector=spec.nodeName={}", node);
+        let _mock = mock("GET", url.as_str())
+            .with_status(200)
+            .with_header("Content-Type", "application/json")
+            .with_body(
+                json!({
+                    "items": [
+                        {
+                            "metadata": {
+                                "namespace": "default",
+                                "uid": "01234",
+                                "annotations": {
+                                    "kubernetes.io/config.hash": "hash1"
+                                }
+                            },
+                            "nodeName": "node1",
+                        },
+                    ]
+                })
+                .to_string(),
+            )
+            .create();
+
+        let uid = "hash1";
+        let kubernetes_api_url = &mockito::server_url();
+        let mut token = Token::new(TokenRetrieval::File);
+
+        token.path = Some(path.to_str().unwrap().to_owned());
+
+        let result = get_pod_name(uid, node, kubernetes_api_url, &token).await.unwrap();
+        assert_eq!(result.0, "");
+        assert_eq!(result.1, "default");
+        assert_eq!(result.2, "");
+    }
+
+    // Test `get_pod_name` with JSON parsing and URL error
+    #[tokio::test]
+    async fn test_get_pod_name_with_url_and_json_error() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join("test-alumet-plugin-k8s/var_11/");
+
+        if root.exists() {
+            std::fs::remove_dir_all(&root).unwrap();
+        }
+
+        let dir = root.join("run/secrets/kubernetes.io/serviceaccount/");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let path = dir.join("token_11");
+        std::fs::write(&path, TOKEN_CONTENT).unwrap();
+
+        let node = "pod1";
+        let _mock = mock("GET", "invalid")
+            .with_status(200)
+            .with_header("Content-Type", "application/json")
+            .with_body(
+                json!({
+                    "items": [
+                        {
+                            "invalid": {
+                                "invalid": "invalid"
+                            },
+                        },
+                    ]
+                })
+                .to_string(),
+            )
+            .create();
+
+        let uid = "hash1";
+        let kubernetes_api_url = &mockito::server_url();
+        let mut token = Token::new(TokenRetrieval::File);
+
+        token.path = Some(path.to_str().unwrap().to_owned());
+
+        let result = get_pod_name(uid, node, kubernetes_api_url, &token).await;
+        assert!(result.is_ok());
+
+        let (name, namespace, node) = result.unwrap();
+        assert!(name.is_empty());
+        assert!(namespace.is_empty());
+        assert!(node.is_empty());
+    }
+
+    // Test `get_pod_name` with uid error
+    #[tokio::test]
+    async fn test_get_pod_name_with_uid_error() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join("test-alumet-plugin-k8s/var_12/");
+
+        if root.exists() {
+            std::fs::remove_dir_all(&root).unwrap();
+        }
+
+        let dir = root.join("run/secrets/kubernetes.io/serviceaccount/");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let path = dir.join("token_12");
+        std::fs::write(&path, TOKEN_CONTENT).unwrap();
+
+        let node = "pod1";
+        let url = format!("/api/v1/pods/?fieldSelector=spec.nodeName={}", node);
+        let _mock = mock("GET", url.as_str())
+            .with_status(200)
+            .with_header("Content-Type", "application/json")
+            .with_body(
+                json!({
+                    "items": [
+                        {
+                            "metadata": {
+                                "name": "pod1",
+                                "namespace": "default",
+                                "uid": "01234",
+                                "annotations": {
+                                    "kubernetes.io/config.hash": "hash1"
+                                }
+                            },
+                            "spec": {
+                                "nodeName": "node1"
+                            }
+                        },
+                        {
+                            "metadata": {
+                                "name": "pod2",
+                                "namespace": "default",
+                                "uid": "56789"
+                            },
+                            "spec": {
+                                "nodeName": "node2"
+                            }
+                        }
+                    ]
+                })
+                .to_string(),
+            )
+            .create();
+
+        let uid = "invalid";
+        let kubernetes_api_url = &mockito::server_url();
+        let mut token = Token::new(TokenRetrieval::File);
+
+        token.path = Some(path.to_str().unwrap().to_owned());
+
+        let result = get_pod_name(uid, node, kubernetes_api_url, &token).await;
+        assert!(result.is_ok());
+
+        let (name, namespace, node) = result.unwrap();
+        assert!(name.is_empty());
+        assert!(namespace.is_empty());
+        assert!(node.is_empty());
+    }
+
+    // Test `get_pod_name` with JSON reading cursor error
+    #[tokio::test]
+    async fn test_get_pod_name_with_cursor_error() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join("test-alumet-plugin-k8s/var_13/");
+
+        if root.exists() {
+            std::fs::remove_dir_all(&root).unwrap();
+        }
+
+        let dir = root.join("run/secrets/kubernetes.io/serviceaccount/");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let path = dir.join("token_13");
+        std::fs::write(&path, TOKEN_CONTENT).unwrap();
+
+        let node = "pod1";
+        let url = format!("/api/v1/pods/?fieldSelector=spec.nodeName={}", node);
+        let _mock = mock("GET", url.as_str())
+            .with_status(200)
+            .with_header("Content-Type", "application/json")
+            .with_body(
+                json!({
+                    "items": []
+                })
+                .to_string(),
+            )
+            .create();
+
+        let uid = "invalid";
+        let kubernetes_api_url = &mockito::server_url();
+        let mut token = Token::new(TokenRetrieval::File);
+
+        token.path = Some(path.to_str().unwrap().to_owned());
+
+        let result = get_pod_name(uid, node, kubernetes_api_url, &token).await;
+        assert!(result.is_ok());
+
+        let (name, namespace, node) = result.unwrap();
+        assert!(name.is_empty());
+        assert!(namespace.is_empty());
+        assert!(node.is_empty());
     }
 }

--- a/plugin-cgroupv2/src/k8s/utils.rs
+++ b/plugin-cgroupv2/src/k8s/utils.rs
@@ -94,7 +94,7 @@ fn list_metric_file_in_dir(
             let file_memory = File::open(&path_cloned_memory)
                 .with_context(|| format!("failed to open file {}", path_cloned_memory.display()))?;
 
-            // CPU ressource consumer for cpu.stat file in cgroup
+            // CPU resource consumer for cpu.stat file in cgroup
             let consumer_cpu = ResourceConsumer::ControlGroup {
                 path: path_cloned_cpu
                     .to_str()
@@ -102,7 +102,7 @@ fn list_metric_file_in_dir(
                     .to_string()
                     .into(),
             };
-            // Memory ressource consumer for memory.stat file in cgroup
+            // Memory resource consumer for memory.stat file in cgroup
             let consumer_memory = ResourceConsumer::ControlGroup {
                 path: path_cloned_memory
                     .to_str()
@@ -442,12 +442,10 @@ mod tests {
     use std::{fs::File, path::PathBuf};
     use tempfile::tempdir;
 
-    // spell-checker: disable
     // HEADER = { "alg": "HS256", "typ": "JWT" }
     // PAYLOAD = { "sub": "1234567890", "exp": 4102444800, "name": "T3st1ng T0k3n" }
     // SIGNATURE = { HMACSHA256(base64UrlEncode(header) + "." +  base64UrlEncode(payload), signature) }
     const TOKEN_CONTENT: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiZXhwIjo0MTAyNDQ0ODAwLCJuYW1lIjoiVDNzdDFuZyBUMGszbiJ9.3vho4u0hx9QobMNbpDPvorWhTHsK9nSg2pZAGKxeVxA";
-    // spell-checker: enable
 
     // Test `list_metric_file_in_dir` function to simulate arborescence of kubernetes pods
     // and missing files in Kubernetes directory
@@ -538,7 +536,7 @@ mod tests {
         let file_cpu = File::open(&path_cpu).unwrap();
         let file_memory = File::open(&path_memory).unwrap();
 
-        // CPU ressource consumer for cpu.stat file in cgroup
+        // CPU resource consumer for cpu.stat file in cgroup
         let consumer_cpu = ResourceConsumer::ControlGroup {
             path: path_cpu
                 .to_str()
@@ -546,7 +544,7 @@ mod tests {
                 .to_string()
                 .into(),
         };
-        // Memory ressource consumer for memory.stat file in cgroup
+        // Memory resource consumer for memory.stat file in cgroup
         let consumer_memory = ResourceConsumer::ControlGroup {
             path: path_memory
                 .to_str()
@@ -633,7 +631,7 @@ mod tests {
             Ok(file_memory) => file_memory,
         };
 
-        // CPU ressource consumer for cpu.stat file in cgroup
+        // CPU resource consumer for cpu.stat file in cgroup
         let consumer_cpu = ResourceConsumer::ControlGroup {
             path: path_cpu
                 .to_str()
@@ -641,7 +639,7 @@ mod tests {
                 .to_string()
                 .into(),
         };
-        // Memory ressource consumer for memory.stat file in cgroup
+        // Memory resource consumer for memory.stat file in cgroup
         let consumer_memory = ResourceConsumer::ControlGroup {
             path: path_memory
                 .to_str()

--- a/plugin-cgroupv2/src/lib.rs
+++ b/plugin-cgroupv2/src/lib.rs
@@ -2,5 +2,63 @@ mod cgroupv2;
 mod k8s;
 mod oar3;
 
+use std::path::Path;
+
 pub use k8s::plugin::K8sPlugin;
 pub use oar3::plugin::OARPlugin;
+
+/// Check if a specific file is a dir. Used to know if cgroup v2 are used.
+///
+/// # Return value
+///
+/// Returns `Ok(true)` if it can be verified that `path` is a directory, and `Ok(false)` if it can be verified that it is not a directory.
+/// Returns an error if the path metadata cannot be obtained.
+pub fn is_accessible_dir(path: &Path) -> Result<bool, std::io::Error> {
+    match std::fs::metadata(path) {
+        Ok(metadata) => Ok(metadata.is_dir()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::is_accessible_dir;
+    use std::path::{Path, PathBuf};
+
+    // Tests `is_accessible_dir` function to check the existence of cgroupv2 file system
+    #[test]
+    fn test_is_accessible_dir() {
+        let tmp = std::env::temp_dir();
+        let root = tmp.join("test-alumet-plugin-k8s/kubepods-list-metrics");
+
+        if root.exists() {
+            std::fs::remove_dir_all(&root).unwrap();
+        }
+
+        let dir = root.join("dir_cgroup");
+        std::fs::create_dir_all(&dir).unwrap();
+        assert!(is_accessible_dir(&dir).unwrap());
+
+        let non_existent_path = root.join("non_existent_dir");
+        assert!(!is_accessible_dir(&non_existent_path).unwrap());
+
+        let file_path = root.join("data.stat");
+        std::fs::write(&file_path, "test file").unwrap();
+        assert!(!is_accessible_dir(&file_path).unwrap());
+
+        assert!(!is_accessible_dir(&PathBuf::new()).unwrap());
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    // Tests `is_accessible_dir` function with permission error
+    #[test]
+    fn test_is_accessible_dir_permission_error() {
+        let root = Path::new("/root/protected");
+        let result = is_accessible_dir(&root);
+        assert!(result.is_err());
+        if let Err(e) = result {
+            assert_eq!(e.kind(), std::io::ErrorKind::PermissionDenied);
+        }
+    }
+}

--- a/plugin-cgroupv2/src/lib.rs
+++ b/plugin-cgroupv2/src/lib.rs
@@ -25,12 +25,13 @@ pub fn is_accessible_dir(path: &Path) -> Result<bool, std::io::Error> {
 mod tests {
     use crate::is_accessible_dir;
     use std::path::{Path, PathBuf};
+    use tempfile::tempdir;
 
     // Tests `is_accessible_dir` function to check the existence of cgroupv2 file system
     #[test]
     fn test_is_accessible_dir() {
-        let tmp = std::env::temp_dir();
-        let root = tmp.join("test-alumet-plugin-k8s/kubepods-list-metrics");
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join("test-alumet-plugin-k8s/kubepods-list-metrics");
 
         if root.exists() {
             std::fs::remove_dir_all(&root).unwrap();
@@ -46,9 +47,7 @@ mod tests {
         let file_path = root.join("data.stat");
         std::fs::write(&file_path, "test file").unwrap();
         assert!(!is_accessible_dir(&file_path).unwrap());
-
         assert!(!is_accessible_dir(&PathBuf::new()).unwrap());
-        std::fs::remove_dir_all(&root).unwrap();
     }
 
     // Tests `is_accessible_dir` function with permission error

--- a/plugin-cgroupv2/src/oar3/plugin.rs
+++ b/plugin-cgroupv2/src/oar3/plugin.rs
@@ -124,7 +124,7 @@ impl AlumetPlugin for OARPlugin {
                                     let mut path_cpu = path.clone();
                                     let mut path_memory = path.clone();
 
-                                    // CPU ressource consumer for cpu.stat file in cgroup
+                                    // CPU resource consumer for cpu.stat file in cgroup
                                     let consumer_cpu = ResourceConsumer::ControlGroup {
                                         path: path_cpu
                                             .to_str()
@@ -132,7 +132,7 @@ impl AlumetPlugin for OARPlugin {
                                             .to_string()
                                             .into(),
                                     };
-                                    // Memory ressource consumer for memory.stat file in cgroup
+                                    // Memory resource consumer for memory.stat file in cgroup
                                     let consumer_memory = ResourceConsumer::ControlGroup {
                                         path: path_memory
                                             .to_str()

--- a/plugin-cgroupv2/src/oar3/plugin.rs
+++ b/plugin-cgroupv2/src/oar3/plugin.rs
@@ -5,13 +5,17 @@ use alumet::{
         util::CounterDiff,
         AlumetPluginStart, AlumetPostStart, ConfigTable,
     },
+    resources::ResourceConsumer,
 };
-use anyhow::Context;
+use anyhow::{anyhow, Context};
 use notify::{Event, EventHandler, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use serde::{Deserialize, Serialize};
 use std::{fs::File, path::PathBuf, time::Duration};
 
-use crate::cgroupv2::{Metrics, CGROUP_MAX_TIME_COUNTER};
+use crate::{
+    cgroupv2::{Metrics, CGROUP_MAX_TIME_COUNTER},
+    is_accessible_dir,
+};
 
 use super::{probe::CgroupV2prob, utils::CgroupV2MetricFile};
 
@@ -53,22 +57,27 @@ impl AlumetPlugin for OARPlugin {
         }))
     }
 
+    fn stop(&mut self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     fn start(&mut self, alumet: &mut AlumetPluginStart) -> anyhow::Result<()> {
-        let v2_used: bool = super::utils::is_accessible_dir(&PathBuf::from("/sys/fs/cgroup/"));
+        let v2_used = is_accessible_dir(&PathBuf::from("/sys/fs/cgroup/"))?;
         if !v2_used {
-            anyhow::bail!("Cgroups v2 are not being used!");
+            return Err(anyhow!("Cgroups v2 are not being used!"));
         }
         let metrics_result = Metrics::new(alumet);
         let metrics = metrics_result?;
         self.metrics = Some(metrics.clone());
 
-        let final_list_metric_file: Vec<CgroupV2MetricFile> = super::utils::list_all_file(&self.config.path)?;
+        let final_list_metric_file = super::utils::list_all_file(&self.config.path)?;
 
-        //Add as a source each pod already present
+        // Add as a source each pod already present
         for metric_file in final_list_metric_file {
             let counter_tmp_tot: CounterDiff = CounterDiff::with_max_value(CGROUP_MAX_TIME_COUNTER);
             let counter_tmp_usr: CounterDiff = CounterDiff::with_max_value(CGROUP_MAX_TIME_COUNTER);
             let counter_tmp_sys: CounterDiff = CounterDiff::with_max_value(CGROUP_MAX_TIME_COUNTER);
+
             let probe = CgroupV2prob::new(
                 metrics.clone(),
                 metric_file,
@@ -79,10 +88,6 @@ impl AlumetPlugin for OARPlugin {
             alumet.add_source(Box::new(probe), TriggerSpec::at_interval(self.config.poll_interval));
         }
 
-        Ok(())
-    }
-
-    fn stop(&mut self) -> anyhow::Result<()> {
         Ok(())
     }
 
@@ -116,10 +121,33 @@ impl AlumetPlugin for OARPlugin {
                         for path in paths {
                             if path.is_dir() {
                                 if let Some(pod_uid) = path.file_name() {
-                                    let mut cpu_path = path.clone();
-                                    cpu_path.push("cpu.stat");
-                                    let file = File::open(&cpu_path)
-                                        .with_context(|| format!("failed to open file {}", cpu_path.display()))?;
+                                    let mut path_cpu = path.clone();
+                                    let mut path_memory = path.clone();
+
+                                    // CPU ressource consumer for cpu.stat file in cgroup
+                                    let consumer_cpu = ResourceConsumer::ControlGroup {
+                                        path: path_cpu
+                                            .to_str()
+                                            .expect("Path to 'cpu.stat' must be valid UTF8")
+                                            .to_string()
+                                            .into(),
+                                    };
+                                    // Memory ressource consumer for memory.stat file in cgroup
+                                    let consumer_memory = ResourceConsumer::ControlGroup {
+                                        path: path_memory
+                                            .to_str()
+                                            .expect("Path to 'memory.stat' must to be valid UTF8")
+                                            .to_string()
+                                            .into(),
+                                    };
+
+                                    path_cpu.push("cpu.stat");
+                                    let file_cpu = File::open(&path_cpu)
+                                        .with_context(|| format!("failed to open file {}", path_cpu.display()))?;
+
+                                    path_memory.push("memory.stat");
+                                    let file_memory = File::open(&path_memory)
+                                        .with_context(|| format!("failed to open file {}", path_memory.display()))?;
 
                                     let metric_file = CgroupV2MetricFile {
                                         name: pod_uid
@@ -127,16 +155,16 @@ impl AlumetPlugin for OARPlugin {
                                             .with_context(|| format!("Filename is not valid UTF-8: {:?}", path))
                                             .unwrap_or("ERROR")
                                             .to_string(),
-                                        path: cpu_path,
-                                        file,
+                                        consumer_cpu,
+                                        file_cpu,
+                                        consumer_memory,
+                                        file_memory,
                                     };
 
-                                    let counter_tmp_tot: CounterDiff =
-                                        CounterDiff::with_max_value(CGROUP_MAX_TIME_COUNTER);
-                                    let counter_tmp_usr: CounterDiff =
-                                        CounterDiff::with_max_value(CGROUP_MAX_TIME_COUNTER);
-                                    let counter_tmp_sys: CounterDiff =
-                                        CounterDiff::with_max_value(CGROUP_MAX_TIME_COUNTER);
+                                    let counter_tmp_tot = CounterDiff::with_max_value(CGROUP_MAX_TIME_COUNTER);
+                                    let counter_tmp_usr = CounterDiff::with_max_value(CGROUP_MAX_TIME_COUNTER);
+                                    let counter_tmp_sys = CounterDiff::with_max_value(CGROUP_MAX_TIME_COUNTER);
+
                                     let probe: CgroupV2prob = CgroupV2prob::new(
                                         detector.metrics.clone(),
                                         metric_file,
@@ -188,9 +216,62 @@ impl AlumetPlugin for OARPlugin {
 impl Default for OAR3Config {
     fn default() -> Self {
         let root_path = PathBuf::from("/sys/fs/cgroup/");
+        if !root_path.exists() {
+            log::warn!("Error : Path '{}' not exist.", root_path.display());
+        }
         Self {
             path: root_path,
             poll_interval: Duration::from_secs(1), // 1Hz
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+    use std::path::PathBuf;
+
+    // Create a fake plugin structure for oar3 plugin
+    fn create_mock_plugin() -> OARPlugin {
+        OARPlugin {
+            config: OAR3Config {
+                path: PathBuf::from("/sys/fs/cgroup/kubepods.slice/"),
+                poll_interval: Duration::from_secs(1),
+            },
+            watcher: None,
+            metrics: None,
+        }
+    }
+
+    // Test `default_config` function of oar3 plugin
+    #[test]
+    fn test_default_config() {
+        let result = OARPlugin::default_config().unwrap();
+        assert!(result.is_some(), "result : None");
+
+        let config_table = result.unwrap();
+        let config: OAR3Config = deserialize_config(config_table).expect("ERROR : Failed to deserialize config");
+
+        assert_eq!(config.path, PathBuf::from("/sys/fs/cgroup/"));
+        assert_eq!(config.poll_interval, Duration::from_secs(1));
+    }
+
+    // Test `init` function to initialize oar3 plugin configuration
+    #[test]
+    fn test_init() -> Result<()> {
+        let config_table = serialize_config(OAR3Config::default())?;
+        let plugin = OARPlugin::init(config_table)?;
+        assert!(plugin.metrics.is_none());
+        assert!(plugin.watcher.is_none());
+        Ok(())
+    }
+
+    // Test `stop` function to stop oar3 plugin
+    #[test]
+    fn test_stop() {
+        let mut plugin = create_mock_plugin();
+        let result = plugin.stop();
+        assert!(result.is_ok(), "Stop should complete without errors.");
     }
 }

--- a/plugin-cgroupv2/src/oar3/probe.rs
+++ b/plugin-cgroupv2/src/oar3/probe.rs
@@ -7,18 +7,22 @@ use alumet::{
 };
 use anyhow::Result;
 
-use crate::cgroupv2::{CgroupV2Metric, Metrics};
-
 use super::utils::{gather_value, CgroupV2MetricFile};
+use crate::cgroupv2::{CgroupMeasurements, Metrics};
 
 pub struct CgroupV2prob {
     pub cgroup_v2_metric_file: CgroupV2MetricFile,
     pub time_tot: CounterDiff,
     pub time_usr: CounterDiff,
     pub time_sys: CounterDiff,
-    pub time_used_tot: TypedMetricId<u64>,
-    pub time_used_user_mode: TypedMetricId<u64>,
-    pub time_used_system_mode: TypedMetricId<u64>,
+    pub cpu_time_tot: TypedMetricId<u64>,
+    pub cpu_time_user_mode: TypedMetricId<u64>,
+    pub cpu_time_system_mode: TypedMetricId<u64>,
+    pub memory_anon: TypedMetricId<u64>,
+    pub memory_file: TypedMetricId<u64>,
+    pub memory_kernel: TypedMetricId<u64>,
+    pub memory_pagetables: TypedMetricId<u64>,
+    pub memory_total: TypedMetricId<u64>,
 }
 
 impl CgroupV2prob {
@@ -34,67 +38,148 @@ impl CgroupV2prob {
             time_tot: counter_tot,
             time_usr: counter_usr,
             time_sys: counter_sys,
-            time_used_tot: metric.time_used_tot,
-            time_used_system_mode: metric.time_used_system_mode,
-            time_used_user_mode: metric.time_used_user_mode,
+            cpu_time_tot: metric.cpu_time_total,
+            cpu_time_system_mode: metric.cpu_time_user_mode,
+            cpu_time_user_mode: metric.cpu_time_system_mode,
+            memory_anon: metric.memory_anonymous,
+            memory_file: metric.memory_file,
+            memory_kernel: metric.memory_kernel,
+            memory_pagetables: metric.memory_pagetables,
+            memory_total: metric.memory_total,
         })
     }
 }
 
 impl alumet::pipeline::Source for CgroupV2prob {
     fn poll(&mut self, measurements: &mut MeasurementAccumulator, timestamp: Timestamp) -> Result<(), PollError> {
-        let mut file_buffer = String::new();
-        let metrics: CgroupV2Metric = gather_value(&mut self.cgroup_v2_metric_file, &mut file_buffer)?;
-        let diff_tot = match self.time_tot.update(metrics.time_used_tot) {
+        /// Create a measurement point with given value,
+        /// the `LocalMachine` resource and some attributes related to the pod.
+        fn create_measurement_point(
+            timestamp: Timestamp,
+            metric_id: TypedMetricId<u64>,
+            resource_consumer: ResourceConsumer,
+            value_measured: u64,
+            metrics_param: &CgroupMeasurements,
+        ) -> MeasurementPoint {
+            MeasurementPoint::new(
+                timestamp,
+                metric_id,
+                Resource::LocalMachine,
+                resource_consumer,
+                value_measured,
+            )
+            .with_attr("name", AttributeValue::String(metrics_param.pod_name.clone()))
+        }
+
+        let mut buffer = String::new();
+        let metrics: CgroupMeasurements = gather_value(&mut self.cgroup_v2_metric_file, &mut buffer)?;
+
+        let diff_tot = match self.time_tot.update(metrics.cpu_time_total) {
             CounterDiffUpdate::FirstTime => None,
             CounterDiffUpdate::Difference(diff) | CounterDiffUpdate::CorrectedDifference(diff) => Some(diff),
         };
-        let diff_usr = match self.time_usr.update(metrics.time_used_user_mode) {
+        let diff_usr = match self.time_usr.update(metrics.cpu_time_user_mode) {
             CounterDiffUpdate::FirstTime => None,
             CounterDiffUpdate::Difference(diff) => Some(diff),
             CounterDiffUpdate::CorrectedDifference(diff) => Some(diff),
         };
-        let diff_sys = match self.time_sys.update(metrics.time_used_system_mode) {
+        let diff_sys = match self.time_sys.update(metrics.cpu_time_system_mode) {
             CounterDiffUpdate::FirstTime => None,
             CounterDiffUpdate::Difference(diff) => Some(diff),
             CounterDiffUpdate::CorrectedDifference(diff) => Some(diff),
         };
-        let consumer = ResourceConsumer::ControlGroup {
-            path: (self.cgroup_v2_metric_file.path.to_string_lossy().to_string().into()),
-        };
+
+        // Push cpu total usage measure for user and system
         if let Some(value_tot) = diff_tot {
-            let p_tot: MeasurementPoint = MeasurementPoint::new(
+            let p_tot = create_measurement_point(
                 timestamp,
-                self.time_used_tot,
-                Resource::LocalMachine,
-                consumer.clone(),
+                self.cpu_time_tot,
+                self.cgroup_v2_metric_file.consumer_cpu.clone(),
                 value_tot,
-            )
-            .with_attr("name", AttributeValue::String(metrics.name.clone()));
+                &metrics,
+            );
             measurements.push(p_tot);
         }
+
+        // Push cpu usage measure for user
         if let Some(value_usr) = diff_usr {
-            let p_usr: MeasurementPoint = MeasurementPoint::new(
+            let p_usr = create_measurement_point(
                 timestamp,
-                self.time_used_user_mode,
-                Resource::LocalMachine,
-                consumer.clone(),
+                self.cpu_time_user_mode,
+                self.cgroup_v2_metric_file.consumer_cpu.clone(),
                 value_usr,
-            )
-            .with_attr("name", AttributeValue::String(metrics.name.clone()));
+                &metrics,
+            );
             measurements.push(p_usr);
         }
+
+        // Push cpu usage measure for system
         if let Some(value_sys) = diff_sys {
-            let p_sys: MeasurementPoint = MeasurementPoint::new(
+            let p_sys = create_measurement_point(
                 timestamp,
-                self.time_used_system_mode,
-                Resource::LocalMachine,
-                consumer.clone(),
+                self.cpu_time_system_mode,
+                self.cgroup_v2_metric_file.consumer_cpu.clone(),
                 value_sys,
-            )
-            .with_attr("name", AttributeValue::String(metrics.name.clone()));
+                &metrics,
+            );
             measurements.push(p_sys);
         }
+
+        // Push anonymous used memory measure corresponding to running process and various allocated memory
+        let mem_anon_value = metrics.memory_anonymous;
+        let m_anon = create_measurement_point(
+            timestamp,
+            self.memory_anon,
+            self.cgroup_v2_metric_file.consumer_memory.clone(),
+            mem_anon_value,
+            &metrics,
+        );
+        measurements.push(m_anon);
+
+        // Push files memory measure, corresponding to open files and descriptors
+        let mem_file_value = metrics.memory_file;
+        let m_file = create_measurement_point(
+            timestamp,
+            self.memory_file,
+            self.cgroup_v2_metric_file.consumer_memory.clone(),
+            mem_file_value,
+            &metrics,
+        );
+        measurements.push(m_file);
+
+        // Push kernel memory measure
+        let mem_kernel_value = metrics.memory_kernel;
+        let m_ker = create_measurement_point(
+            timestamp,
+            self.memory_kernel,
+            self.cgroup_v2_metric_file.consumer_memory.clone(),
+            mem_kernel_value,
+            &metrics,
+        );
+        measurements.push(m_ker);
+
+        // Push pagetables memory measure
+        let mem_pagetables_value = metrics.memory_pagetables;
+        let m_pgt = create_measurement_point(
+            timestamp,
+            self.memory_pagetables,
+            self.cgroup_v2_metric_file.consumer_memory.clone(),
+            mem_pagetables_value,
+            &metrics,
+        );
+        measurements.push(m_pgt);
+
+        // Push total memory used by cgroup measure
+        let mem_total_value = mem_anon_value + mem_file_value + mem_kernel_value + mem_pagetables_value;
+        let m_tot = create_measurement_point(
+            timestamp,
+            self.memory_total,
+            self.cgroup_v2_metric_file.consumer_memory.clone(),
+            mem_total_value,
+            &metrics,
+        );
+        measurements.push(m_tot);
+
         Ok(())
     }
 }

--- a/plugin-cgroupv2/src/oar3/utils.rs
+++ b/plugin-cgroupv2/src/oar3/utils.rs
@@ -70,7 +70,7 @@ fn list_metric_file_in_dir(root_directory_path: &Path) -> anyhow::Result<Vec<Cgr
             let file_memory = File::open(&path_cloned_memory)
                 .with_context(|| format!("Failed to open file {}", path_cloned_memory.display()))?;
 
-            // CPU ressource consumer for cpu.stat file in cgroup
+            // CPU resource consumer for cpu.stat file in cgroup
             let consumer_cpu = ResourceConsumer::ControlGroup {
                 path: path_cloned_cpu
                     .to_str()
@@ -78,7 +78,7 @@ fn list_metric_file_in_dir(root_directory_path: &Path) -> anyhow::Result<Vec<Cgr
                     .to_string()
                     .into(),
             };
-            // Memory ressource consumer for cpu.stat file in cgroup
+            // Memory resource consumer for cpu.stat file in cgroup
             let consumer_memory = ResourceConsumer::ControlGroup {
                 path: path_cloned_memory
                     .to_str()
@@ -251,7 +251,7 @@ mod tests {
         let file_cpu = File::open(&path_cpu).unwrap();
         let file_memory = File::open(&path_memory).unwrap();
 
-        // CPU ressource consumer for cpu.stat file in cgroup
+        // CPU resource consumer for cpu.stat file in cgroup
         let consumer_cpu = ResourceConsumer::ControlGroup {
             path: path_cpu
                 .to_str()
@@ -259,7 +259,7 @@ mod tests {
                 .to_string()
                 .into(),
         };
-        // Memory ressource consumer for memory.stat file in cgroup
+        // Memory resource consumer for memory.stat file in cgroup
         let consumer_memory = ResourceConsumer::ControlGroup {
             path: path_memory
                 .to_str()
@@ -343,7 +343,7 @@ mod tests {
             Ok(file_memory) => file_memory,
         };
 
-        // CPU ressource consumer for cpu.stat file in cgroup
+        // CPU resource consumer for cpu.stat file in cgroup
         let consumer_cpu = ResourceConsumer::ControlGroup {
             path: path_cpu
                 .to_str()
@@ -351,7 +351,7 @@ mod tests {
                 .to_string()
                 .into(),
         };
-        // Memory ressource consumer for memory.stat file in cgroup
+        // Memory resource consumer for memory.stat file in cgroup
         let consumer_memory = ResourceConsumer::ControlGroup {
             path: path_memory
                 .to_str()

--- a/plugin-cgroupv2/src/oar3/utils.rs
+++ b/plugin-cgroupv2/src/oar3/utils.rs
@@ -1,4 +1,5 @@
-use anyhow::*;
+use alumet::resources::ResourceConsumer;
+use anyhow::{Context, Result};
 use std::{
     fs::{self, File},
     io::{Read, Seek},
@@ -8,7 +9,7 @@ use std::{
     vec,
 };
 
-use crate::cgroupv2::CgroupV2Metric;
+use crate::cgroupv2::CgroupMeasurements;
 
 /// CgroupV2MetricFile represents a file containing cgroup v2 data about cpu usage.
 ///
@@ -17,51 +18,82 @@ use crate::cgroupv2::CgroupV2Metric;
 pub struct CgroupV2MetricFile {
     /// Name of the pod.
     pub name: String,
-    /// Path to the file.
-    pub path: PathBuf,
-    /// Opened file descriptor.
-    pub file: File,
+    /// Path to the cgroup cpu stat file.
+    pub consumer_cpu: ResourceConsumer,
+    /// Path to the cgroup memory stat file.
+    pub consumer_memory: ResourceConsumer,
+    /// Opened file descriptor for cgroup cpu stat.
+    pub file_cpu: File,
+    /// Opened file descriptor for cgroup memory stat.
+    pub file_memory: File,
 }
 
 impl CgroupV2MetricFile {
-    /// Create a new CgroupV2MetricFile structure from a name, a path and a File
-    fn new(name: String, path_entry: PathBuf, file: File) -> CgroupV2MetricFile {
+    /// Create a new CgroupV2MetricFile structure from a name, a path and a File.
+    fn new(
+        name: String,
+        consumer_cpu: ResourceConsumer,
+        consumer_memory: ResourceConsumer,
+        file_cpu: File,
+        file_memory: File,
+    ) -> CgroupV2MetricFile {
         CgroupV2MetricFile {
             name,
-            path: path_entry,
-            file,
+            consumer_cpu,
+            consumer_memory,
+            file_cpu,
+            file_memory,
         }
     }
 }
 
-/// Check if a specific file is a dir. Used to know if cgroup v2 are used
-pub fn is_accessible_dir(path: &Path) -> bool {
-    path.is_dir()
-}
-
 /// Returns a Vector of CgroupV2MetricFile associated to pods available under a given directory.
 fn list_metric_file_in_dir(root_directory_path: &Path) -> anyhow::Result<Vec<CgroupV2MetricFile>> {
-    let mut vec_file_metric: Vec<CgroupV2MetricFile> = Vec::new();
+    let mut vec_file_metric = Vec::new();
     let entries = fs::read_dir(root_directory_path)?;
 
     // For each Entry in the directory
     for entry in entries {
         let path = entry?.path();
-        let mut path_cloned = path.clone();
+        let mut path_cloned_cpu = path.clone();
+        let mut path_cloned_memory = path.clone();
 
-        path_cloned.push("cpu.stat");
-        if path_cloned.exists() && path_cloned.is_file() {
+        path_cloned_cpu.push("cpu.stat");
+        path_cloned_memory.push("memory.stat");
+
+        if (path_cloned_cpu.exists() && path_cloned_cpu.is_file())
+            && (path_cloned_memory.exists() && path_cloned_memory.is_file())
+        {
             let file_name = path.file_name().ok_or_else(|| anyhow::anyhow!("No file name found"))?;
-            let file: File =
-                File::open(&path_cloned).with_context(|| format!("failed to open file {}", path_cloned.display()))?;
+            let file_cpu = File::open(&path_cloned_cpu)
+                .with_context(|| format!("Failed to open file {}", path_cloned_cpu.display()))?;
+            let file_memory = File::open(&path_cloned_memory)
+                .with_context(|| format!("Failed to open file {}", path_cloned_memory.display()))?;
+
+            // CPU ressource consumer for cpu.stat file in cgroup
+            let consumer_cpu = ResourceConsumer::ControlGroup {
+                path: path_cloned_cpu
+                    .to_str()
+                    .expect("Path to 'cpu.stat' must be valid UTF8")
+                    .to_string()
+                    .into(),
+            };
+            // Memory ressource consumer for cpu.stat file in cgroup
+            let consumer_memory = ResourceConsumer::ControlGroup {
+                path: path_cloned_memory
+                    .to_str()
+                    .expect("Path to 'memory.stat' must to be valid UTF8")
+                    .to_string()
+                    .into(),
+            };
+
             // Let's create the new metric and push it to the vector of metrics
             vec_file_metric.push(CgroupV2MetricFile {
-                name: file_name
-                    .to_str()
-                    .with_context(|| format!("Filename is not valid UTF-8: {:?}", path))?
-                    .to_string(),
-                path: path.clone(),
-                file,
+                name: file_name.to_str().context("Filename is not valid UTF-8")?.to_string(),
+                consumer_cpu,
+                consumer_memory,
+                file_cpu,
+                file_memory,
             });
         }
     }
@@ -94,61 +126,80 @@ pub fn list_all_file(root_directory_path: &Path) -> anyhow::Result<Vec<CgroupV2M
     Ok(final_list_metric_file)
 }
 
-/// Extracts the metrics from the file.
-pub fn gather_value(file: &mut CgroupV2MetricFile, content_buffer: &mut String) -> anyhow::Result<CgroupV2Metric> {
-    content_buffer.clear(); //Clear before use
-    file.file
+/// Extracts the metrics from data files of cgroup.
+///
+/// # Arguments
+///
+/// - `CgroupV2MetricFile` : Get structure parameters to use cgroup data.
+/// - `content_buffer` : Buffer where we store content of cgroup data file.
+///
+/// # Return
+///
+/// - Error if CPU data file is not found.
+pub fn gather_value(file: &mut CgroupV2MetricFile, content_buffer: &mut String) -> anyhow::Result<CgroupMeasurements> {
+    content_buffer.clear();
+
+    // CPU cgroup data
+    file.file_cpu
         .read_to_string(content_buffer)
-        .with_context(|| format!("Unable to gather cgroup v2 metrics by reading file {}", file.name))?;
-    file.file.rewind()?;
+        .context("Unable to gather cgroup v2 CPU metrics by reading file")?;
+    if content_buffer.is_empty() {
+        return Err(anyhow::anyhow!("CPU stat file is empty for {}", file.name));
+    }
+    file.file_cpu.rewind()?;
+
+    // Memory cgroup data
+    file.file_memory
+        .read_to_string(content_buffer)
+        .context("Unable to gather cgroup v2 memory metrics by reading file")?;
+    if content_buffer.is_empty() {
+        return Err(anyhow::anyhow!("Memory stat file is empty for {}", file.name));
+    }
+    file.file_memory.rewind()?;
+
     let mut new_metric =
-        CgroupV2Metric::from_str(content_buffer).with_context(|| format!("failed to parse {}", file.name))?;
-    new_metric.name = file.name.clone();
+        CgroupMeasurements::from_str(content_buffer).with_context(|| format!("failed to parse {}", file.name))?;
+
+    new_metric.pod_name = file.name.clone();
+
     Ok(new_metric)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
 
-    #[test]
-    fn test_is_cgroups_v2() {
-        let tmp = std::env::temp_dir();
-        let root: std::path::PathBuf = tmp.join("test-alumet-plugin-oar/is_cgroupv2");
-        if root.exists() {
-            std::fs::remove_dir_all(&root).unwrap();
-        }
-        let cgroupv2_dir = root.join("myDirCgroup");
-        std::fs::create_dir_all(&cgroupv2_dir).unwrap();
-        assert!(is_accessible_dir(Path::new(&cgroupv2_dir)));
-        assert!(!is_accessible_dir(std::path::Path::new(
-            "test-alumet-plugin-oar/is_cgroupv2/myDirCgroup_bad"
-        )));
-    }
-
+    // Test `list_metric_file_in_dir` function to simulate arborescence of kubernetes pods
     #[test]
     fn test_list_metric_file_in_dir() {
-        let tmp = std::env::temp_dir();
-        let root: std::path::PathBuf = tmp.join("test-alumet-plugin-oar/kubepods-folder.slice/");
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join("test-alumet-plugin-oar/kubepods-folder.slice/");
+
         if root.exists() {
             std::fs::remove_dir_all(&root).unwrap();
         }
-        let burstable_dir = root.join("kubepods-burstable.slice/");
-        std::fs::create_dir_all(&burstable_dir).unwrap();
 
-        let a = burstable_dir.join("32a1942cb9a81912549c152a49b5f9b1");
-        let b = burstable_dir.join("d9209de2b4b526361248c9dcf3e702c0");
-        let c = burstable_dir.join("ccq5da1942a81912549c152a49b5f9b1");
-        let d = burstable_dir.join("d87dz3z8z09de2b4b526361248c902c0");
-        std::fs::create_dir_all(&a).unwrap();
-        std::fs::create_dir_all(&b).unwrap();
-        std::fs::create_dir_all(&c).unwrap();
-        std::fs::create_dir_all(&d).unwrap();
-        std::fs::write(a.join("cpu.stat"), "en").unwrap();
-        std::fs::write(b.join("cpu.stat"), "fr").unwrap();
-        std::fs::write(c.join("cpu.stat"), "sv").unwrap();
-        std::fs::write(d.join("cpu.stat"), "ne").unwrap();
-        let list_met_file: anyhow::Result<Vec<CgroupV2MetricFile>> = list_metric_file_in_dir(&burstable_dir);
+        let dir = root.join("kubepods-burstable.slice/");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let sub_dir = [
+            dir.join("32a1942cb9a81912549c152a49b5f9b1"),
+            dir.join("d9209de2b4b526361248c9dcf3e702c0"),
+            dir.join("ccq5da1942a81912549c152a49b5f9b1"),
+            dir.join("d87dz3z8z09de2b4b526361248c902c0"),
+        ];
+
+        for i in 0..4 {
+            std::fs::create_dir_all(&sub_dir[i]).unwrap();
+        }
+
+        for i in 0..4 {
+            std::fs::write(sub_dir[i].join("cpu.stat"), "test_cpu").unwrap();
+            std::fs::write(sub_dir[i].join("memory.stat"), "test_memory").unwrap();
+        }
+
+        let list_met_file = list_metric_file_in_dir(&dir);
         let list_pod_name = [
             "32a1942cb9a81912549c152a49b5f9b1",
             "d9209de2b4b526361248c9dcf3e702c0",
@@ -167,30 +218,94 @@ mod tests {
                 }
             }
             Err(err) => {
-                log::error!("Error reading list_met_file: {:?}", err);
+                log::error!("Reading list_met_file: {:?}", err);
                 assert!(false);
             }
         }
+
         assert!(true);
     }
+
+    // Test `gather_value` function with invalid data
     #[test]
-    fn test_gather_value() {
-        let tmp = std::env::temp_dir();
-        let root: std::path::PathBuf = tmp.join("test-alumet-plugin-oar/kubepods-gather.slice/");
+    fn test_gather_value_with_invalid_data() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join("test-alumet-plugin-oar/kubepods-invalid-gather.slice/");
+
         if root.exists() {
             std::fs::remove_dir_all(&root).unwrap();
         }
-        let burstable_dir = root.join("kubepods-burstable.slice/");
-        std::fs::create_dir_all(&burstable_dir).unwrap();
 
-        let a = burstable_dir.join("kubepods-burstable-pod32a1942cb9a81912549c152a49b5f9b1.slice/");
+        let dir = root.join("kubepods-burstable.slice/");
+        std::fs::create_dir_all(&dir).unwrap();
 
-        std::fs::create_dir_all(&a).unwrap();
-        let path_file = a.join("cpu.stat");
+        let sub_dir = dir.join("kubepods-burstable-pod32a1942cb9a81912549c152a49b5f9b1.slice/");
+        std::fs::create_dir_all(&sub_dir).unwrap();
+
+        let path_cpu = sub_dir.join("cpu.stat");
+        let path_memory = sub_dir.join("memory.stat");
+
+        std::fs::write(&path_cpu, "invalid_cpu_data").unwrap();
+        std::fs::write(&path_memory, "invalid_memory_data").unwrap();
+
+        let file_cpu = File::open(&path_cpu).unwrap();
+        let file_memory = File::open(&path_memory).unwrap();
+
+        // CPU ressource consumer for cpu.stat file in cgroup
+        let consumer_cpu = ResourceConsumer::ControlGroup {
+            path: path_cpu
+                .to_str()
+                .expect("Path to 'cpu.stat' must be valid UTF8")
+                .to_string()
+                .into(),
+        };
+        // Memory ressource consumer for memory.stat file in cgroup
+        let consumer_memory = ResourceConsumer::ControlGroup {
+            path: path_memory
+                .to_str()
+                .expect("Path to 'memory.stat' must to be valid UTF8")
+                .to_string()
+                .into(),
+        };
+
+        let mut metric_file = CgroupV2MetricFile {
+            name: "test-pod".to_string(),
+            consumer_cpu,
+            consumer_memory,
+            file_cpu,
+            file_memory,
+        };
+
+        let mut content_buffer = String::new();
+        let result = gather_value(&mut metric_file, &mut content_buffer);
+
+        result.expect("gather_value get invalid data");
+    }
+
+    // Test `gather_value` function with valid values
+    #[test]
+    fn test_gather_value_with_valid_values() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join("test-alumet-plugin-oar/kubepods-gather.slice/");
+
+        if root.exists() {
+            std::fs::remove_dir_all(&root).unwrap();
+        }
+
+        let dir = root.join("kubepods-burstable.slice/");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let sub_dir = dir.join("kubepods-burstable-pod32a1942cb9a81912549c152a49b5f9b1.slice/");
+        std::fs::create_dir_all(&sub_dir).unwrap();
+
+        let path_cpu = sub_dir.join("cpu.stat");
+        let path_memory = sub_dir.join("memory.stat");
+
         std::fs::write(
-            path_file.clone(),
+            path_cpu.clone(),
             format!(
-                "usage_usec 8335557927\n
+                "
+                usage_usec 8335557927\n
                 user_usec 4728882396\n
                 system_usec 3606675531\n
                 nr_periods 0\n
@@ -200,31 +315,111 @@ mod tests {
         )
         .unwrap();
 
-        let file = match File::open(&path_file) {
-            Err(why) => panic!("couldn't open {}: {}", path_file.display(), why),
-            Ok(file) => file,
+        std::fs::write(
+            path_memory.clone(),
+            format!(
+                "
+                anon 8335557927
+                file 4728882396
+                kernel_stack 3686400
+                pagetables 0
+                percpu 16317568
+                sock 12288
+                shmem 233824256
+                file_mapped 0
+                file_dirty 20480,
+                ...."
+            ),
+        )
+        .unwrap();
+
+        let file_cpu = match File::open(&path_cpu) {
+            Err(why) => panic!("ERROR : Couldn't open {}: {}", path_cpu.display(), why),
+            Ok(file_cpu) => file_cpu,
         };
 
-        let mut my_cgroup_test_file: CgroupV2MetricFile =
-            CgroupV2MetricFile::new("testing_pod".to_string(), path_file, file);
-        let mut content_file = String::new();
-        let res_metric = gather_value(&mut my_cgroup_test_file, &mut content_file);
-        if let Ok(CgroupV2Metric {
-            name,
-            time_used_tot,
-            time_used_user_mode,
-            time_used_system_mode,
-            uid: _uid,
+        let file_memory = match File::open(&path_memory) {
+            Err(why) => panic!("ERROR : Couldn't open {}: {}", path_memory.display(), why),
+            Ok(file_memory) => file_memory,
+        };
+
+        // CPU ressource consumer for cpu.stat file in cgroup
+        let consumer_cpu = ResourceConsumer::ControlGroup {
+            path: path_cpu
+                .to_str()
+                .expect("Path to 'cpu.stat' must be valid UTF8")
+                .to_string()
+                .into(),
+        };
+        // Memory ressource consumer for memory.stat file in cgroup
+        let consumer_memory = ResourceConsumer::ControlGroup {
+            path: path_memory
+                .to_str()
+                .expect("Path to 'memory.stat' must to be valid UTF8")
+                .to_string()
+                .into(),
+        };
+
+        let mut cgroup = CgroupV2MetricFile::new(
+            "testing_pod".to_string(),
+            consumer_cpu,
+            consumer_memory,
+            file_cpu,
+            file_memory,
+        );
+
+        let mut content = String::new();
+        let result = gather_value(&mut cgroup, &mut content);
+
+        if let Ok(CgroupMeasurements {
+            pod_name,
+            cpu_time_total,
+            cpu_time_user_mode,
+            cpu_time_system_mode,
+            memory_anonymous,
+            memory_file,
+            memory_kernel,
+            memory_pagetables,
+            pod_uid: _uid,
             namespace: _ns,
             node: _nd,
-        }) = res_metric
+        }) = result
         {
-            assert_eq!(name, "testing_pod".to_owned());
-            assert_eq!(time_used_tot, 8335557927);
-            assert_eq!(time_used_user_mode, 4728882396);
-            assert_eq!(time_used_system_mode, 3606675531);
-        } else {
-            assert!(false);
+            assert_eq!(pod_name, "testing_pod".to_owned());
+            assert_eq!(cpu_time_total, 8335557927);
+            assert_eq!(cpu_time_user_mode, 4728882396);
+            assert_eq!(cpu_time_system_mode, 3606675531);
+            assert_eq!(memory_anonymous, 8335557927);
+            assert_eq!(memory_file, 4728882396);
+            assert_eq!(memory_kernel, 3686400);
+            assert_eq!(memory_pagetables, 0);
         }
+    }
+
+    // Test `list_all_file` function with different file system
+    #[test]
+    fn test_list_all_file() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+
+        let path = root.join("non_existent");
+        let result = list_all_file(&path);
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
+
+        let result = list_all_file(root);
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
+
+        let sub_dir = root.join("sub_dir");
+        fs::create_dir(&sub_dir).unwrap();
+
+        let list_file_name = ["file1.txt", "file2.txt", "file3.txt", "file4.txt"];
+        for i in 0..4 {
+            File::create(sub_dir.join(list_file_name[i])).unwrap();
+        }
+
+        let result = list_all_file(root);
+        assert!(result.is_ok());
     }
 }

--- a/plugin-relay/src/client/plugin.rs
+++ b/plugin-relay/src/client/plugin.rs
@@ -48,7 +48,7 @@ mod config {
     #[derive(Serialize, Deserialize)]
     #[serde(deny_unknown_fields)]
     pub struct RetryConfig {
-        /// Maximum number of retrys before giving up.
+        /// Maximum number of retries before giving up.
         pub max_times: u16,
 
         /// Initial delay between two attempts.


### PR DESCRIPTION
- Factorization of code in poll function to simplify push of metric with the MeasurementPoint
- Correction with Cyprien of an issue to locate precisely the ".slice" folder content
- Adding data extraction from the "memory.stat" file in kubes to push following values :
- Anonyme active and inactive used memory
- Active and inactive file memory
- Interprocess communication shared memory
- Mapped files in memory
- Total memory = Anon memory + File memory + Shared memory + Mapped Files memory