### PR TITLE
feat(options): config can be passed as environment variable now

### DIFF
--- a/app-agent/Cargo.toml
+++ b/app-agent/Cargo.toml
@@ -9,7 +9,7 @@ description = "Metric collector agent to install on each node."
 [dependencies]
 alumet = { path = "../alumet" }
 anyhow = "1.0.88"
-clap = { version = "4.5.17", features = ["derive"] }
+clap = { version = "4.5.17", features = ["derive", "env"] }
 env_logger = "0.11.5"
 humantime-serde = "1.1.1"
 log = "0.4.22"

--- a/app-agent/src/options.rs
+++ b/app-agent/src/options.rs
@@ -56,7 +56,7 @@ pub mod cli {
     #[derive(Args, Clone)]
     pub struct CommonArgs {
         /// Path to the config file.
-        #[arg(long, default_value = "alumet-config.toml")]
+        #[arg(long, env = "ALUMET_CONFIG", default_value = "alumet-config.toml")]
         pub config: String, // not used in Configurator, but directly by main()
 
         /// If set, the config file must exist, otherwise the agent will fail to start with an error.


### PR DESCRIPTION
Fix #59
You can now use both:

- *--config path/to/config/file*
- *export CONFIG=path/to/config/file*

To use alumet