### PR TITLE
Fix/relay client as attribute

### DIFF
--- a/plugin-relay/proto/SPEC.md
+++ b/plugin-relay/proto/SPEC.md
@@ -1,1 +1,0 @@
-# Alumet relay protocol

--- a/plugin-relay/src/protocol.rs
+++ b/plugin-relay/src/protocol.rs
@@ -168,6 +168,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> MessageStream<S> {
         Ok(())
     }
 
+    #[allow(unused)]
     pub async fn read_timeout(&mut self, timeout: Duration) -> Result<Result<MessageBody<'static>, Error>, Elapsed> {
         tokio::time::timeout(timeout, self.read_message()).await
     }
@@ -263,6 +264,7 @@ impl MessageStream<TcpStream> {
         self.stream.peer_addr()
     }
 
+    #[allow(unused)]
     pub fn local_addr(&self) -> Result<std::net::SocketAddr, std::io::Error> {
         self.stream.local_addr()
     }


### PR DESCRIPTION
For @TwilCynder :)
Now, the name of the relay client is always attached to every measurement point, as an attribute `relay_client`.