### PR TITLE
plugin-procfs automatically increases file descriptors soft limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2327,6 +2327,7 @@ dependencies = [
  "pretty_assertions",
  "procfs",
  "regex",
+ "rlimit",
  "serde",
  "toml",
 ]
@@ -2753,6 +2754,15 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rlimit"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/plugin-procfs/Cargo.toml
+++ b/plugin-procfs/Cargo.toml
@@ -11,6 +11,7 @@ log = "0.4.22"
 procfs = "0.16.0"
 regex = "1.10.6"
 serde = { version = "1.0.210", features = ["derive"] }
+rlimit = "0.10.2"
 
 [lints]
 workspace = true


### PR DESCRIPTION
Automatically increase alumet process's file descriptors soft limit when plugin-procfs starts in order to prevent 'Too many open files' error that happened because procfs plugin opens lot of files.

It starts without condition (we could, later, add a configuration option - plugin side - to disable this behavior in some scenarios where administrator would like to manage this limit precisely).

The current implementation will check for the process hard limit and will update soft limit to reach the hard limit. This way the user has still control on the overall process limit - by defining the hard limit.

A future implementation could also be located in Alumet's core to perform the same operation for all the plugins.