### PR TITLE
Make metric registration more configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,7 @@ dependencies = [
  "indoc",
  "libc",
  "log",
+ "num_enum",
  "ordered-float",
  "serde",
  "serial_test",
@@ -2117,6 +2118,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "num_threads"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2741,6 +2763,15 @@ checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
 dependencies = [
  "proc-macro2",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]

--- a/alumet/Cargo.toml
+++ b/alumet/Cargo.toml
@@ -31,6 +31,7 @@ thiserror = "1.0.63"
 fancy-regex = "0.13.0"
 futures = "0.3.30"
 ordered-float = "4.6.0"
+num_enum = "0.7.3"
 
 # Dependencies for Linux builds only.
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/alumet/src/metrics/duplicate.rs
+++ b/alumet/src/metrics/duplicate.rs
@@ -1,0 +1,55 @@
+use super::Metric;
+
+/// Specifies when a new metric registration is considered to be a duplicate
+/// of an existing metric.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DuplicateCriteria {
+    /// If a metric with the same name already exists, that's a duplicate.
+    Strict,
+    /// If a metric with the exact same definition exists, ignore the new metric.
+    /// If a metric with the same name but a **different** definition exists, that's a duplicate.
+    Different,
+    /// If a metric with a compatible definition exists, ignore the new metric.
+    /// If a metric with the same name but an **incompatible** definition exists, that's a duplicate.
+    ///
+    /// # Compatible metrics
+    /// Two metric definitions are deemed "compatible" if [`are_compatible`] returns `true`.
+    Incompatible,
+}
+
+#[derive(Clone, Debug)]
+pub enum DuplicateReaction {
+    Error,
+    Rename { suffix: String },
+}
+
+/// Checks whether two metric definitions are compatible.
+///
+/// # Compatible metrics
+/// Two metric definitions are compatible if they have the same name, unit and value type.
+/// The description is ignored.
+///
+/// # Transitivity
+/// This relation is transitive: `are_compatible(a, b) == are_compatible(b, a)`
+pub(super) fn are_compatible(m1: &Metric, m2: &Metric) -> bool {
+    m1.name == m2.name && m1.unit == m2.unit && m1.value_type == m2.value_type
+}
+
+/// Checks whether two metric definitions are identical, that is, all their fields are equal.
+///
+/// # Transitivity
+/// This relation is transitive: `are_identical(a, b) == are_identical(b, a)`
+pub(super) fn are_identical(m1: &Metric, m2: &Metric) -> bool {
+    are_compatible(m1, m2) && m1.description == m2.description
+}
+
+impl DuplicateCriteria {
+    /// Applies the criteria: is `m1` a duplicate of `m2`?
+    pub fn are_duplicate(self, m1: &Metric, m2: &Metric) -> bool {
+        match self {
+            DuplicateCriteria::Strict => m1.name == m2.name,
+            DuplicateCriteria::Different => !are_identical(m1, m2),
+            DuplicateCriteria::Incompatible => !are_compatible(m1, m2),
+        }
+    }
+}

--- a/alumet/src/metrics/error.rs
+++ b/alumet/src/metrics/error.rs
@@ -2,26 +2,23 @@ use std::fmt;
 
 use crate::measurement::WrappedMeasurementType;
 
+use super::duplicate::DuplicateCriteria;
+
 /// Error which can occur when creating a new metric.
 ///
 /// This error is returned when the metric cannot be registered because of a conflict,
 /// that is, another metric with the same name has already been registered.
 #[derive(Debug, Clone)]
 pub struct MetricCreationError {
-    pub key: String,
-}
-
-impl MetricCreationError {
-    pub fn new(metric_name: String) -> MetricCreationError {
-        MetricCreationError { key: metric_name }
-    }
+    pub name: String,
+    pub criteria: DuplicateCriteria,
 }
 
 impl std::error::Error for MetricCreationError {}
 
 impl fmt::Display for MetricCreationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "This metric has already been registered: {}", self.key)
+        write!(f, "This metric has already been registered: {}", self.name)
     }
 }
 

--- a/alumet/src/metrics/mod.rs
+++ b/alumet/src/metrics/mod.rs
@@ -1,6 +1,7 @@
 //! Definition and management of metrics.
 
 pub mod def;
+pub mod duplicate;
 pub mod error;
 pub mod online;
 pub mod registry;

--- a/alumet/src/pipeline/builder.rs
+++ b/alumet/src/pipeline/builder.rs
@@ -66,7 +66,7 @@ pub struct Builder {
 
     /// How many `MeasurementBuffer` can be stored in the channel that sources write to.
     source_channel_size: usize,
-    
+
     /// Enables or disables the "simplified pipeline" optimization.
     /// Set this to `false` if you plan to add more outputs at runtime, while there is only one output at the beginning.
     allow_simplified_pipeline: bool,
@@ -119,7 +119,7 @@ impl Builder {
     pub fn source_channel_size(&mut self) -> &mut usize {
         &mut self.source_channel_size
     }
-    
+
     pub fn allow_simplified_pipeline(&mut self) -> &mut bool {
         &mut self.allow_simplified_pipeline
     }

--- a/alumet/src/pipeline/control/messages.rs
+++ b/alumet/src/pipeline/control/messages.rs
@@ -26,6 +26,12 @@ pub struct RequestMessage<Body, Response> {
 
 #[derive(Debug)]
 pub enum EmptyResponseBody {
+    Single(SpecificBody),
+    Mixed(Vec<SpecificBody>),
+}
+
+#[derive(Debug)]
+pub enum SpecificBody {
     Source(source::control::ControlMessage),
     Transform(transform::control::ControlMessage),
     Output(output::control::ControlMessage),

--- a/alumet/src/pipeline/control/request/source.rs
+++ b/alumet/src/pipeline/control/request/source.rs
@@ -74,7 +74,7 @@ impl SourceRequestBuilder {
 
 impl SourceRequest {
     fn into_body(self) -> messages::EmptyResponseBody {
-        messages::EmptyResponseBody::Source(self.msg)
+        messages::EmptyResponseBody::Single(messages::SpecificBody::Source(self.msg))
     }
 }
 

--- a/alumet/src/pipeline/control/request/transform.rs
+++ b/alumet/src/pipeline/control/request/transform.rs
@@ -45,7 +45,7 @@ impl TransformRequestBuilder {
 
 impl TransformRequest {
     fn into_body(self) -> messages::EmptyResponseBody {
-        messages::EmptyResponseBody::Transform(self.msg)
+        messages::EmptyResponseBody::Single(messages::SpecificBody::Transform(self.msg))
     }
 }
 

--- a/alumet/src/pipeline/elements/output/builder.rs
+++ b/alumet/src/pipeline/elements/output/builder.rs
@@ -33,6 +33,16 @@ impl From<SendOutputBuilder> for OutputBuilder {
     }
 }
 
+impl std::fmt::Debug for SendOutputBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Blocking(_) => f.debug_tuple("Blocking").field(&"Box<dyn _>").finish(),
+            Self::Async(_) => f.debug_tuple("Async").field(&"Box<dyn _>").finish(),
+        }
+    }
+}
+
+
 /// Trait for builders of blocking outputs.
 ///
 ///  # Example

--- a/alumet/src/pipeline/elements/output/builder.rs
+++ b/alumet/src/pipeline/elements/output/builder.rs
@@ -42,7 +42,6 @@ impl std::fmt::Debug for SendOutputBuilder {
     }
 }
 
-
 /// Trait for builders of blocking outputs.
 ///
 ///  # Example

--- a/alumet/src/pipeline/elements/output/control.rs
+++ b/alumet/src/pipeline/elements/output/control.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use num_enum::{FromPrimitive, IntoPrimitive};
 use std::sync::{
     atomic::{AtomicU8, Ordering},
     Arc, Mutex,
@@ -46,31 +47,15 @@ pub struct CreateManyMessage {
 }
 
 /// State of a (managed) output task.
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(Clone, Debug, PartialEq, Eq, Copy, IntoPrimitive, FromPrimitive)]
 #[repr(u8)]
 pub enum TaskState {
     Run,
     RunDiscard,
     Pause,
-    StopNow,
     StopFinish,
-}
-
-impl From<u8> for TaskState {
-    fn from(value: u8) -> Self {
-        const RUN: u8 = TaskState::Run as u8;
-        const RUN_DISCARD: u8 = TaskState::RunDiscard as u8;
-        const PAUSE: u8 = TaskState::Pause as u8;
-        const STOP_FINISH: u8 = TaskState::StopFinish as u8;
-
-        match value {
-            RUN => TaskState::Run,
-            RUN_DISCARD => TaskState::RunDiscard,
-            PAUSE => TaskState::Pause,
-            STOP_FINISH => TaskState::StopFinish,
-            _ => TaskState::StopNow,
-        }
-    }
+    #[num_enum(default)]
+    StopNow,
 }
 
 pub enum SingleOutputController {

--- a/alumet/src/pipeline/elements/output/run.rs
+++ b/alumet/src/pipeline/elements/output/run.rs
@@ -81,6 +81,12 @@ pub async fn run_blocking_output<Rx: channel::MeasurementReceiver>(
                     control::TaskState::Run => {
                         receive = true;
                     }
+                    control::TaskState::RunDiscard => {
+                        // Resume the output but discard the data that is in the buffer.
+                        // The output will only see the measurements that are sent after this point.
+                        rx = rx.discard_pending();
+                        receive = true;
+                    }
                     control::TaskState::Pause => {
                         receive = false;
                     }

--- a/alumet/src/pipeline/elements/source/control.rs
+++ b/alumet/src/pipeline/elements/source/control.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 
 use anyhow::Context;
+use num_enum::{FromPrimitive, IntoPrimitive};
 use tokio::runtime;
 use tokio::sync::mpsc;
 use tokio::task::{JoinError, JoinSet};
@@ -77,25 +78,13 @@ pub(super) enum Reconfiguration {
 }
 
 /// State of a (managed) source task.
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(Clone, Debug, PartialEq, Eq, Copy, IntoPrimitive, FromPrimitive)]
 #[repr(u8)]
 pub(super) enum TaskState {
     Run,
     Pause,
+    #[num_enum(default)]
     Stop,
-}
-
-impl From<u8> for TaskState {
-    fn from(value: u8) -> Self {
-        const RUN: u8 = TaskState::Run as u8;
-        const PAUSE: u8 = TaskState::Pause as u8;
-
-        match value {
-            RUN => TaskState::Run,
-            PAUSE => TaskState::Pause,
-            _ => TaskState::Stop,
-        }
-    }
 }
 
 /// Controls the sources of a measurement pipeline.

--- a/alumet/src/pipeline/elements/source/task_controller.rs
+++ b/alumet/src/pipeline/elements/source/task_controller.rs
@@ -67,7 +67,7 @@ impl SingleSourceController {
                 Reconfiguration::SetState(TaskState::Stop) => {
                     shutdown_token.cancel();
                 }
-                _ => todo!("invalid command for autonomous source"),
+                _ => log::warn!("unsupported command received for autonomous source, ignoring"),
             },
         }
     }

--- a/alumet/src/pipeline/util/stream.rs
+++ b/alumet/src/pipeline/util/stream.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::task::AtomicWaker;
+use num_enum::{FromPrimitive, IntoPrimitive};
 use tokio_stream::Stream;
 
 /// A [`Stream`] wrapper that allows to pause, unpause and stop the stream.
@@ -23,11 +24,12 @@ pub struct SharedStreamState {
 }
 
 /// State of a (managed) output task.
-#[derive(Clone, Debug, PartialEq, Eq, Copy)]
+#[derive(Clone, Debug, PartialEq, Eq, Copy, IntoPrimitive, FromPrimitive)]
 #[repr(u8)]
 pub enum StreamState {
     Run,
     Pause,
+    #[num_enum(default)]
     Stop,
 }
 
@@ -102,19 +104,6 @@ impl<S: Stream> Stream for ControlledStream<S> {
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
-    }
-}
-
-impl From<u8> for StreamState {
-    fn from(value: u8) -> Self {
-        const RUN: u8 = StreamState::Run as u8;
-        const PAUSE: u8 = StreamState::Pause as u8;
-
-        match value {
-            RUN => StreamState::Run,
-            PAUSE => StreamState::Pause,
-            _ => StreamState::Stop,
-        }
     }
 }
 

--- a/alumet/src/plugin/phases.rs
+++ b/alumet/src/plugin/phases.rs
@@ -4,6 +4,7 @@ use std::marker::PhantomData;
 
 use crate::measurement::{MeasurementType, WrappedMeasurementType};
 use crate::metrics::def::{Metric, RawMetricId, TypedMetricId};
+use crate::metrics::duplicate::{DuplicateCriteria, DuplicateReaction};
 use crate::metrics::error::MetricCreationError;
 use crate::metrics::online::listener::{MetricListener, MetricListenerBuilder};
 use crate::metrics::online::{MetricReader, MetricSender};
@@ -73,7 +74,10 @@ impl<'a> AlumetPluginStart<'a> {
             value_type: T::wrapped_type(),
             unit: unit.into(),
         };
-        let untyped_id = self.pipeline_builder.metrics.register(m)?;
+        let untyped_id =
+            self.pipeline_builder
+                .metrics
+                .register(m, DuplicateCriteria::Different, DuplicateReaction::Error)?;
         Ok(TypedMetricId(untyped_id, PhantomData))
     }
 
@@ -96,7 +100,9 @@ impl<'a> AlumetPluginStart<'a> {
             value_type,
             unit: unit.into(),
         };
-        self.pipeline_builder.metrics.register(m)
+        self.pipeline_builder
+            .metrics
+            .register(m, DuplicateCriteria::Different, DuplicateReaction::Error)
     }
 
     /// Adds a _managed_ measurement source to the Alumet pipeline.

--- a/alumet/tests/metric_duplicates.rs
+++ b/alumet/tests/metric_duplicates.rs
@@ -1,0 +1,59 @@
+use std::time::Duration;
+
+use alumet::{
+    agent::plugin::PluginSet, plugin::rust::AlumetPlugin, static_plugins, test::StartupExpectations, units::Unit,
+};
+
+struct TestPlugin;
+
+impl AlumetPlugin for TestPlugin {
+    fn name() -> &'static str {
+        "test"
+    }
+
+    fn version() -> &'static str {
+        "0"
+    }
+
+    fn init(_config: alumet::plugin::ConfigTable) -> anyhow::Result<Box<Self>> {
+        Ok(Box::new(Self))
+    }
+
+    fn default_config() -> anyhow::Result<Option<alumet::plugin::ConfigTable>> {
+        Ok(None)
+    }
+
+    fn start(&mut self, alumet: &mut alumet::plugin::AlumetPluginStart) -> anyhow::Result<()> {
+        alumet.create_metric::<u64>("m1", Unit::Second, "test metric")?;
+        alumet.create_metric::<u64>("m1", Unit::Second, "test metric")?;
+        alumet
+            .create_metric::<f64>("m1", Unit::Second, "test metric")
+            .expect_err("incompatible metric registration should fail");
+        alumet
+            .create_metric::<u64>("m1", Unit::Watt, "test metric")
+            .expect_err("incompatible metric registration should fail");
+        alumet.create_metric::<f64>("m2", Unit::Second, "test metric 2, different from test metric 1")?;
+        alumet.create_metric::<u64>("m3", Unit::Watt, "test metric")?;
+        Ok(())
+    }
+
+    fn stop(&mut self) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn plugin_metric_registration() {
+    const TIMEOUT: Duration = Duration::from_millis(250);
+    let plugins = PluginSet::from(static_plugins![TestPlugin]);
+    let expectations = StartupExpectations::new()
+        .expect_metric::<u64>("m1", Unit::Second)
+        .expect_metric::<f64>("m2", Unit::Second)
+        .expect_metric::<u64>("m3", Unit::Watt);
+    let agent = alumet::agent::Builder::new(plugins)
+        .with_expectations(expectations)
+        .build_and_start()
+        .expect("agent should build");
+    agent.pipeline.control_handle().shutdown();
+    agent.wait_for_shutdown(TIMEOUT).expect("error while running");
+}

--- a/plugin-aggregation/src/lib.rs
+++ b/plugin-aggregation/src/lib.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use alumet::{
-    metrics::{online::MetricSender, Metric, RawMetricId},
+    metrics::{duplicate::DuplicateReaction, online::MetricSender, Metric, RawMetricId},
     plugin::{
         rust::{deserialize_config, serialize_config, AlumetPlugin},
         ConfigTable,
@@ -118,7 +118,7 @@ async fn register_new_metrics(
     metric_correspondence_table: Arc<RwLock<HashMap<RawMetricId, RawMetricId>>>,
 ) -> anyhow::Result<()> {
     let result = metric_sender
-        .create_metrics(new_metrics, alumet::metrics::online::DuplicateStrategy::Error)
+        .create_metrics(new_metrics, DuplicateReaction::Error)
         .await
         .map_err(|a| anyhow!("{a}"))?;
 

--- a/plugin-relay/src/server/metrics.rs
+++ b/plugin-relay/src/server/metrics.rs
@@ -2,10 +2,7 @@
 
 use alumet::{
     measurement::MeasurementBuffer,
-    metrics::{
-        online::{DuplicateStrategy, MetricSender},
-        Metric, RawMetricId,
-    },
+    metrics::{duplicate::DuplicateReaction, online::MetricSender, Metric, RawMetricId},
 };
 use anyhow::{anyhow, Context};
 
@@ -44,7 +41,7 @@ impl MetricConverter {
             .inner
             .create_metrics(
                 metric_defs,
-                DuplicateStrategy::Rename {
+                DuplicateReaction::Rename {
                     suffix: format!("relay-client-{client}"),
                 },
             )


### PR DESCRIPTION
New options to choose (not always available in public plugin API, on purpose):
- `DuplicateCriteria`: defines the rules that make a new metric a duplicate.
- `DuplicateReaction`: what to do when there is a duplicate

Resolves #137.
