### PR TITLE
add docker images build/push to release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,6 +87,17 @@ jobs:
       release-version: ${{ needs.gather-informations.outputs.release }}
       tag: ${{ needs.gather-informations.outputs.tag }}
 
+  build-docker:
+    needs:
+      - gather-informations
+      - build-rpm
+      - build-deb
+    uses: alumet-dev/packaging/.github/workflows/build_docker.yaml@main
+    with:
+      arch: x86_64
+      version: ${{ needs.gather-informations.outputs.version }}
+      release-version: ${{ needs.gather-informations.outputs.release }}
+
   attach-artifacts:
     needs:
       - build-rpm
@@ -156,3 +167,38 @@ jobs:
         run: |
           find rpm -type f -exec gh release upload ${{ steps.get_latest_release_and_delete_old_artifacts.outputs.release_tag }} {} \;
           find deb -type f -exec gh release upload ${{ steps.get_latest_release_and_delete_old_artifacts.outputs.release_tag }} {} \;
+
+  push-docker:
+    needs:
+      - build-docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create docker artifacts directory
+        run: mkdir docker-artifacts
+
+      - name: Download docker images artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: "**/*.docker.tar"
+          path: ./docker-artifacts
+          merge-multiple: true
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push images
+        run: |
+          tars=$(find ./docker-artifacts -type f)
+          for tar in $tars
+            do
+              image_tags=$(docker load -q -i $tar | sed 's/Loaded image: //g')
+              for image_tag in $image_tags
+                do
+                  docker push $image_tag
+                done
+            done
+


### PR DESCRIPTION
This will add the necessary steps to build and push docker images to GHCR.
Note that for now pushing to ghcr is in hard and we could iterate later to push to other repositories (tag part is in alumet-dev/packaging and login part in alumet-dev/alumet .