### PR TITLE
ci(release): add concurrency for only one run of workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,10 @@ on:
     types: ["created", "published", "prereleased"]
   workflow_dispatch:
 
+concurrency:
+  group: "release-workflow"
+  cancel-in-progress: true
+
 jobs:
   gather-informations:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add concurrency for only one run of workflow.