### PR TITLE
ci(release): change trigger for CI workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: "Create the release"
 
 on:
   release:
-    types: ["created", "published", "prereleased"]
+    types: ["published"]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Only trigger on publish event.

See more [here ](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#release)