### PR TITLE
Refactor cgroupv2 plugin - metrics harmonization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,14 +40,18 @@ jobs:
             - v2-dependency-cache
       - run:
           name: Compile Alumet core
-          command: "cargo build -p alumet"
-      # build libraries and agents now to avoid a timeout in the tests
+          command: cargo build -p alumet
       - run:
           name: Build all libraries
-          command: "cargo build"
+          command: cargo build
       - run:
-          name: Build the agents
+          name: Build the agent binary
           command: cargo build -p alumet-agent --bins --all-features
+      # compile tests first to avoid a timeout during execution
+      - run:
+          name: Compile Tests
+          command: cargo test --all-features --no-run
+      # run tests with a timeout to detect a bit earlier if there's a test that hangs indefinitely
       - run:
           name: Run Tests (including doc tests)
           command: cargo test --all-features -- --show-output

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1982,24 +1982,6 @@ dependencies = [
 
 [[package]]
 name = "mockito"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f9fece9bd97ab74339fe19f4bcaf52b76dcc18e5364c7977c1838f76b38de9"
-dependencies = [
- "assert-json-diff",
- "colored",
- "httparse",
- "lazy_static",
- "log",
- "rand 0.8.5",
- "regex",
- "serde_json",
- "serde_urlencoded",
- "similar",
-]
-
-[[package]]
-name = "mockito"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7760e0e418d9b7e5777c0374009ca4c93861b9066f18cb334a20ce50ab63aa48"
@@ -2491,7 +2473,7 @@ dependencies = [
  "gethostname",
  "humantime-serde",
  "log",
- "mockito 0.31.1",
+ "mockito",
  "notify",
  "reqwest",
  "serde",
@@ -2541,7 +2523,7 @@ dependencies = [
  "alumet",
  "anyhow",
  "log",
- "mockito 1.7.0",
+ "mockito",
  "reqwest",
  "serde",
  "tokio",

--- a/plugin-cgroupv2/Cargo.toml
+++ b/plugin-cgroupv2/Cargo.toml
@@ -29,4 +29,4 @@ workspace = true
 
 [dev-dependencies]
 tempfile = "3.5"
-mockito = "0.31"
+mockito = "1.7.0"

--- a/plugin-cgroupv2/src/k8s/probe.rs
+++ b/plugin-cgroupv2/src/k8s/probe.rs
@@ -15,14 +15,12 @@ pub struct K8SProbe {
     pub time_tot: CounterDiff,
     pub time_usr: CounterDiff,
     pub time_sys: CounterDiff,
-    pub cpu_time_tot: TypedMetricId<u64>,
-    pub cpu_time_user_mode: TypedMetricId<u64>,
-    pub cpu_time_system_mode: TypedMetricId<u64>,
+    pub cpu_time_delta: TypedMetricId<u64>,
+    pub memory_usage: TypedMetricId<u64>,
     pub memory_anon: TypedMetricId<u64>,
     pub memory_file: TypedMetricId<u64>,
     pub memory_kernel: TypedMetricId<u64>,
     pub memory_pagetables: TypedMetricId<u64>,
-    pub memory_total: TypedMetricId<u64>,
 }
 
 impl K8SProbe {
@@ -38,14 +36,12 @@ impl K8SProbe {
             time_tot: counter_tot,
             time_usr: counter_usr,
             time_sys: counter_sys,
-            cpu_time_tot: metric.cpu_time_total,
-            cpu_time_user_mode: metric.cpu_time_user_mode,
-            cpu_time_system_mode: metric.cpu_time_system_mode,
+            cpu_time_delta: metric.cpu_time_delta,
+            memory_usage: metric.memory_usage,
             memory_anon: metric.memory_anonymous,
             memory_file: metric.memory_file,
             memory_kernel: metric.memory_kernel,
             memory_pagetables: metric.memory_pagetables,
-            memory_total: metric.memory_total,
         })
     }
 }
@@ -87,11 +83,12 @@ impl alumet::pipeline::Source for K8SProbe {
         if let Some(value_tot) = diff_tot {
             let p_tot = create_measurement_point(
                 timestamp,
-                self.cpu_time_tot,
+                self.cpu_time_delta,
                 self.cgroup_v2_metric_file.consumer_cpu.clone(),
                 value_tot,
                 &metrics,
-            );
+            )
+            .with_attr("kind", "total");
             measurements.push(p_tot);
         }
 
@@ -99,11 +96,12 @@ impl alumet::pipeline::Source for K8SProbe {
         if let Some(value_usr) = diff_usr {
             let p_usr = create_measurement_point(
                 timestamp,
-                self.cpu_time_user_mode,
+                self.cpu_time_delta,
                 self.cgroup_v2_metric_file.consumer_cpu.clone(),
                 value_usr,
                 &metrics,
-            );
+            )
+            .with_attr("kind", "user");
             measurements.push(p_usr);
         }
 
@@ -111,20 +109,33 @@ impl alumet::pipeline::Source for K8SProbe {
         if let Some(value_sys) = diff_sys {
             let p_sys = create_measurement_point(
                 timestamp,
-                self.cpu_time_system_mode,
+                self.cpu_time_delta,
                 self.cgroup_v2_metric_file.consumer_cpu.clone(),
                 value_sys,
                 &metrics,
-            );
+            )
+            .with_attr("kind", "system");
             measurements.push(p_sys);
         }
+
+        // Push resident memory usage corresponding to running process
+        let mem_usage_value = metrics.memory_usage_resident;
+        let m_usage_resident = create_measurement_point(
+            timestamp,
+            self.memory_usage,
+            self.cgroup_v2_metric_file.consumer_memory_current.clone(),
+            mem_usage_value,
+            &metrics,
+        )
+        .with_attr("kind", "resident");
+        measurements.push(m_usage_resident);
 
         // Push anonymous used memory measure corresponding to running process and various allocated memory
         let mem_anon_value = metrics.memory_anonymous;
         let m_anon = create_measurement_point(
             timestamp,
             self.memory_anon,
-            self.cgroup_v2_metric_file.consumer_memory.clone(),
+            self.cgroup_v2_metric_file.consumer_memory_stat.clone(),
             mem_anon_value,
             &metrics,
         );
@@ -135,7 +146,7 @@ impl alumet::pipeline::Source for K8SProbe {
         let m_file = create_measurement_point(
             timestamp,
             self.memory_file,
-            self.cgroup_v2_metric_file.consumer_memory.clone(),
+            self.cgroup_v2_metric_file.consumer_memory_stat.clone(),
             mem_file_value,
             &metrics,
         );
@@ -146,7 +157,7 @@ impl alumet::pipeline::Source for K8SProbe {
         let m_ker = create_measurement_point(
             timestamp,
             self.memory_kernel,
-            self.cgroup_v2_metric_file.consumer_memory.clone(),
+            self.cgroup_v2_metric_file.consumer_memory_stat.clone(),
             mem_kernel_value,
             &metrics,
         );
@@ -157,22 +168,11 @@ impl alumet::pipeline::Source for K8SProbe {
         let m_pgt = create_measurement_point(
             timestamp,
             self.memory_pagetables,
-            self.cgroup_v2_metric_file.consumer_memory.clone(),
+            self.cgroup_v2_metric_file.consumer_memory_stat.clone(),
             mem_pagetables_value,
             &metrics,
         );
         measurements.push(m_pgt);
-
-        // Push total memory used by cgroup measure
-        let mem_total_value = mem_anon_value + mem_file_value + mem_kernel_value + mem_pagetables_value;
-        let m_tot = create_measurement_point(
-            timestamp,
-            self.memory_total,
-            self.cgroup_v2_metric_file.consumer_memory.clone(),
-            mem_total_value,
-            &metrics,
-        );
-        measurements.push(m_tot);
 
         Ok(())
     }

--- a/plugin-cgroupv2/src/k8s/utils.rs
+++ b/plugin-cgroupv2/src/k8s/utils.rs
@@ -466,7 +466,7 @@ pub async fn get_pod_name(
 #[cfg(test)]
 mod tests {
     use super::{super::plugin::TokenRetrieval, *};
-    use mockito::mock;
+    use mockito::Server;
     use serde_json::json;
     use std::{fs::File, path::PathBuf};
     use tempfile::tempdir;
@@ -1007,7 +1007,9 @@ mod tests {
 
         let node = "pod1";
         let url = format!("/api/v1/pods/?fieldSelector=spec.nodeName={}", node);
-        let _mock = mock("GET", url.as_str())
+        let mut server = Server::new_async().await;
+        let _mock = server
+            .mock("GET", url.as_str())
             .with_status(200)
             .with_header("Content-Type", "application/json")
             .with_body(
@@ -1040,14 +1042,17 @@ mod tests {
                 })
                 .to_string(),
             )
-            .create();
+            .create_async()
+            .await;
 
-        let kubernetes_api_url = &mockito::server_url();
+        let kubernetes_api_url = server.url();
         let mut token = Token::new(TokenRetrieval::File);
 
         token.path = Some(path.to_str().unwrap().to_owned());
 
-        let result = get_existing_pods(node, kubernetes_api_url, &token).await.unwrap();
+        let result = get_existing_pods(node, kubernetes_api_url.as_str(), &token)
+            .await
+            .unwrap();
 
         assert_eq!(
             result.get("hash1").unwrap(),
@@ -1078,7 +1083,9 @@ mod tests {
 
         let node = "pod1";
         let url = format!("/api/v1/pods/?fieldSelector=spec.nodeName={}", node);
-        let _mock = mock("GET", url.as_str())
+        let mut server = Server::new_async().await;
+        let _mock = server
+            .mock("GET", url.as_str())
             .with_status(200)
             .with_header("Content-Type", "application/json")
             .with_body(
@@ -1097,14 +1104,17 @@ mod tests {
                 })
                 .to_string(),
             )
-            .create();
+            .create_async()
+            .await;
 
-        let kubernetes_api_url = &mockito::server_url();
+        let kubernetes_api_url = server.url();
         let mut token = Token::new(TokenRetrieval::File);
 
         token.path = Some(path.to_str().unwrap().to_owned());
 
-        let result = get_existing_pods(node, kubernetes_api_url, &token).await.unwrap();
+        let result = get_existing_pods(node, kubernetes_api_url.as_str(), &token)
+            .await
+            .unwrap();
 
         assert_eq!(
             result.get("hash1").unwrap(),
@@ -1129,7 +1139,9 @@ mod tests {
         std::fs::write(&path, TOKEN_CONTENT).unwrap();
 
         let node = "pod1";
-        let _mock = mock("GET", "invalid")
+        let mut server = Server::new_async().await;
+        let _mock = server
+            .mock("GET", "invalid")
             .with_status(200)
             .with_header("Content-Type", "application/json")
             .with_body(
@@ -1144,14 +1156,15 @@ mod tests {
                 })
                 .to_string(),
             )
-            .create();
+            .create_async()
+            .await;
 
-        let kubernetes_api_url = &mockito::server_url();
+        let kubernetes_api_url = server.url();
         let mut token = Token::new(TokenRetrieval::File);
 
         token.path = Some(path.to_str().unwrap().to_owned());
 
-        let result = get_existing_pods(node, kubernetes_api_url, &token).await;
+        let result = get_existing_pods(node, kubernetes_api_url.as_str(), &token).await;
         assert!(result.is_ok());
 
         let map = result.unwrap();
@@ -1176,7 +1189,9 @@ mod tests {
 
         let node = "pod1";
         let url = format!("/api/v1/pods/?fieldSelector=spec.nodeName={}", node);
-        let _mock = mock("GET", url.as_str())
+        let mut server = Server::new_async().await;
+        let _mock = server
+            .mock("GET", url.as_str())
             .with_status(200)
             .with_header("Content-Type", "application/json")
             .with_body(
@@ -1185,14 +1200,15 @@ mod tests {
                 })
                 .to_string(),
             )
-            .create();
+            .create_async()
+            .await;
 
-        let kubernetes_api_url = &mockito::server_url();
+        let kubernetes_api_url = server.url();
         let mut token = Token::new(TokenRetrieval::File);
 
         token.path = Some(path.to_str().unwrap().to_owned());
 
-        let result = get_existing_pods(node, kubernetes_api_url, &token).await;
+        let result = get_existing_pods(node, kubernetes_api_url.as_str(), &token).await;
         assert!(result.is_ok());
 
         let map = result.unwrap();
@@ -1264,7 +1280,9 @@ mod tests {
 
         let node = "pod1";
         let url = format!("/api/v1/pods/?fieldSelector=spec.nodeName={}", node);
-        let _mock = mock("GET", url.as_str())
+        let mut server = Server::new_async().await;
+        let _mock = server
+            .mock("GET", url.as_str())
             .with_status(200)
             .with_header("Content-Type", "application/json")
             .with_body(
@@ -1297,15 +1315,18 @@ mod tests {
                 })
                 .to_string(),
             )
-            .create();
+            .create_async()
+            .await;
 
         let uid = "hash1";
-        let kubernetes_api_url = &mockito::server_url();
+        let kubernetes_api_url = server.url();
         let mut token = Token::new(TokenRetrieval::File);
 
         token.path = Some(path.to_str().unwrap().to_owned());
 
-        let result = get_pod_name(uid, node, kubernetes_api_url, &token).await.unwrap();
+        let result = get_pod_name(uid, node, kubernetes_api_url.as_str(), &token)
+            .await
+            .unwrap();
         assert_eq!(result.0, "pod1");
         assert_eq!(result.1, "default");
         assert_eq!(result.2, "node1");
@@ -1330,7 +1351,9 @@ mod tests {
 
         let node = "pod1";
         let url = format!("/api/v1/pods/?fieldSelector=spec.nodeName={}", node);
-        let _mock = mock("GET", url.as_str())
+        let mut server = Server::new_async().await;
+        let _mock = server
+            .mock("GET", url.as_str())
             .with_status(200)
             .with_header("Content-Type", "application/json")
             .with_body(
@@ -1350,15 +1373,18 @@ mod tests {
                 })
                 .to_string(),
             )
-            .create();
+            .create_async()
+            .await;
 
         let uid = "hash1";
-        let kubernetes_api_url = &mockito::server_url();
+        let kubernetes_api_url = server.url();
         let mut token = Token::new(TokenRetrieval::File);
 
         token.path = Some(path.to_str().unwrap().to_owned());
 
-        let result = get_pod_name(uid, node, kubernetes_api_url, &token).await.unwrap();
+        let result = get_pod_name(uid, node, kubernetes_api_url.as_str(), &token)
+            .await
+            .unwrap();
         assert_eq!(result.0, "");
         assert_eq!(result.1, "default");
         assert_eq!(result.2, "");
@@ -1381,7 +1407,9 @@ mod tests {
         std::fs::write(&path, TOKEN_CONTENT).unwrap();
 
         let node = "pod1";
-        let _mock = mock("GET", "invalid")
+        let mut server = Server::new_async().await;
+        let _mock = server
+            .mock("GET", "invalid")
             .with_status(200)
             .with_header("Content-Type", "application/json")
             .with_body(
@@ -1396,15 +1424,16 @@ mod tests {
                 })
                 .to_string(),
             )
-            .create();
+            .create_async()
+            .await;
 
         let uid = "hash1";
-        let kubernetes_api_url = &mockito::server_url();
+        let kubernetes_api_url = server.url();
         let mut token = Token::new(TokenRetrieval::File);
 
         token.path = Some(path.to_str().unwrap().to_owned());
 
-        let result = get_pod_name(uid, node, kubernetes_api_url, &token).await;
+        let result = get_pod_name(uid, node, kubernetes_api_url.as_str(), &token).await;
         assert!(result.is_ok());
 
         let (name, namespace, node) = result.unwrap();
@@ -1431,7 +1460,9 @@ mod tests {
 
         let node = "pod1";
         let url = format!("/api/v1/pods/?fieldSelector=spec.nodeName={}", node);
-        let _mock = mock("GET", url.as_str())
+        let mut server = Server::new_async().await;
+        let _mock = server
+            .mock("GET", url.as_str())
             .with_status(200)
             .with_header("Content-Type", "application/json")
             .with_body(
@@ -1464,15 +1495,16 @@ mod tests {
                 })
                 .to_string(),
             )
-            .create();
+            .create_async()
+            .await;
 
         let uid = "invalid";
-        let kubernetes_api_url = &mockito::server_url();
+        let kubernetes_api_url = server.url();
         let mut token = Token::new(TokenRetrieval::File);
 
         token.path = Some(path.to_str().unwrap().to_owned());
 
-        let result = get_pod_name(uid, node, kubernetes_api_url, &token).await;
+        let result = get_pod_name(uid, node, kubernetes_api_url.as_str(), &token).await;
         assert!(result.is_ok());
 
         let (name, namespace, node) = result.unwrap();
@@ -1499,7 +1531,9 @@ mod tests {
 
         let node = "pod1";
         let url = format!("/api/v1/pods/?fieldSelector=spec.nodeName={}", node);
-        let _mock = mock("GET", url.as_str())
+        let mut server = Server::new_async().await;
+        let _mock = server
+            .mock("GET", url.as_str())
             .with_status(200)
             .with_header("Content-Type", "application/json")
             .with_body(
@@ -1508,15 +1542,16 @@ mod tests {
                 })
                 .to_string(),
             )
-            .create();
+            .create_async()
+            .await;
 
         let uid = "invalid";
-        let kubernetes_api_url = &mockito::server_url();
+        let kubernetes_api_url = server.url();
         let mut token = Token::new(TokenRetrieval::File);
 
         token.path = Some(path.to_str().unwrap().to_owned());
 
-        let result = get_pod_name(uid, node, kubernetes_api_url, &token).await;
+        let result = get_pod_name(uid, node, kubernetes_api_url.as_str(), &token).await;
         assert!(result.is_ok());
 
         let (name, namespace, node) = result.unwrap();

--- a/plugin-cgroupv2/src/k8s/utils.rs
+++ b/plugin-cgroupv2/src/k8s/utils.rs
@@ -22,11 +22,15 @@ pub struct CgroupV2MetricFile {
     /// Path to the cgroup cpu stat file.
     pub consumer_cpu: ResourceConsumer,
     /// Path to the cgroup memory stat file.
-    pub consumer_memory: ResourceConsumer,
+    pub consumer_memory_stat: ResourceConsumer,
+    /// Path to the cgroup memory current file.
+    pub consumer_memory_current: ResourceConsumer,
     /// Opened file descriptor for cgroup cpu stat.
     pub file_cpu: File,
     /// Opened file descriptor for cgroup memory stat.
-    pub file_memory: File,
+    pub file_memory_stat: File,
+    /// Opened file descriptor for cgroup memory current.
+    pub file_memory_current: File,
     /// UID of the pod.
     pub uid: String,
     /// Namespace of the pod.
@@ -52,7 +56,8 @@ fn list_metric_file_in_dir(
     for entry in entries {
         let path = entry?.path();
         let mut path_cloned_cpu = path.clone();
-        let mut path_cloned_memory = path.clone();
+        let mut path_cloned_memory_stat = path.clone();
+        let mut path_cloned_memory_current = path.clone();
 
         if path.is_dir() {
             let file_name = path.file_name().ok_or_else(|| anyhow::anyhow!("No file name found"))?;
@@ -78,7 +83,8 @@ fn list_metric_file_in_dir(
             let uid = dir_uid_mod.strip_prefix(&new_prefix).unwrap_or(dir_uid_mod);
 
             path_cloned_cpu.push("cpu.stat");
-            path_cloned_memory.push("memory.stat");
+            path_cloned_memory_stat.push("memory.stat");
+            path_cloned_memory_current.push("memory.current");
 
             let name_to_seek_raw = uid.strip_prefix("pod").unwrap_or(uid);
             let name_to_seek = name_to_seek_raw.replace('_', "-"); // Replace _ with - to match with hashmap
@@ -91,8 +97,10 @@ fn list_metric_file_in_dir(
 
             let file_cpu = File::open(&path_cloned_cpu)
                 .with_context(|| format!("failed to open file {}", path_cloned_cpu.display()))?;
-            let file_memory = File::open(&path_cloned_memory)
-                .with_context(|| format!("failed to open file {}", path_cloned_memory.display()))?;
+            let file_memory_stat = File::open(&path_cloned_memory_stat)
+                .with_context(|| format!("failed to open file {}", path_cloned_memory_stat.display()))?;
+            let file_memory_current = File::open(&path_cloned_memory_current)
+                .with_context(|| format!("failed to open file {}", path_cloned_memory_current.display()))?;
 
             // CPU resource consumer for cpu.stat file in cgroup
             let consumer_cpu = ResourceConsumer::ControlGroup {
@@ -103,10 +111,18 @@ fn list_metric_file_in_dir(
                     .into(),
             };
             // Memory resource consumer for memory.stat file in cgroup
-            let consumer_memory = ResourceConsumer::ControlGroup {
-                path: path_cloned_memory
+            let consumer_memory_stat = ResourceConsumer::ControlGroup {
+                path: path_cloned_memory_stat
                     .to_str()
                     .expect("Path to 'memory.stat' must to be valid UTF8")
+                    .to_string()
+                    .into(),
+            };
+            // Memory resource consumer for memory.stat file in cgroup
+            let consumer_memory_current = ResourceConsumer::ControlGroup {
+                path: path_cloned_memory_current
+                    .to_str()
+                    .expect("Path to 'memory.current' must to be valid UTF8")
                     .to_string()
                     .into(),
             };
@@ -116,8 +132,10 @@ fn list_metric_file_in_dir(
                 name: name.clone(),
                 consumer_cpu,
                 file_cpu,
-                consumer_memory,
-                file_memory,
+                consumer_memory_stat,
+                file_memory_stat,
+                consumer_memory_current,
+                file_memory_current,
                 uid: uid.to_owned(),
                 namespace: namespace.clone(),
                 node: node.clone(),
@@ -191,17 +209,28 @@ pub fn gather_value(file: &mut CgroupV2MetricFile, content_buffer: &mut String) 
     }
     file.file_cpu.rewind()?;
 
-    // Memory cgroup data
-    file.file_memory
+    // Memory stat cgroup data
+    file.file_memory_stat
         .read_to_string(content_buffer)
         .context("Unable to gather cgroup v2 memory metrics by reading file")?;
     if content_buffer.is_empty() {
         return Err(anyhow::anyhow!("Memory stat file is empty for {}", file.name));
     }
-    file.file_memory.rewind()?;
+    file.file_memory_stat.rewind()?;
 
     let mut new_metric =
         CgroupMeasurements::from_str(content_buffer).with_context(|| format!("failed to parse {}", file.name))?;
+
+    // Memory current cgroup data
+    content_buffer.clear();
+    file.file_memory_current
+        .read_to_string(content_buffer)
+        .context("Unable to get cgroup v2 memory current metric by reading file")?;
+    file.file_memory_current.rewind()?;
+
+    new_metric
+        .load_memory_current_from_str(content_buffer)
+        .with_context(|| format!("failed to parse {}", file.name))?;
 
     new_metric.pod_name = file.name.clone();
     new_metric.namespace = file.namespace.clone();
@@ -481,7 +510,8 @@ mod tests {
 
         for i in 0..4 {
             std::fs::write(sub_dir[i].join("cpu.stat"), "test_cpu").unwrap();
-            std::fs::write(sub_dir[i].join("memory.stat"), "test_memory").unwrap();
+            std::fs::write(sub_dir[i].join("memory.stat"), "test_memory_stat").unwrap();
+            std::fs::write(sub_dir[i].join("memory.current"), "test_memory_current").unwrap();
         }
 
         let list_met_file = list_metric_file_in_dir(&dir, "", "", &Token::new(TokenRetrieval::Kubectl));
@@ -511,11 +541,11 @@ mod tests {
         assert!(true);
     }
 
-    // Test `gather_value` function with invalid data
+    // Test `gather_value` function with invalid memory.current data
     #[test]
-    fn test_gather_value_with_invalid_data() {
+    fn test_gather_value_with_invalid_memory_current_data() {
         let tmp = tempdir().unwrap();
-        let root = tmp.path().join("test-alumet-plugin-k8s/kubepods-invalid-gather.slice/");
+        let root = tmp.path().join("test-alumet-plugin-oar/kubepods-invalid-gather.slice/");
 
         if root.exists() {
             std::fs::remove_dir_all(&root).unwrap();
@@ -528,13 +558,44 @@ mod tests {
         std::fs::create_dir_all(&sub_dir).unwrap();
 
         let path_cpu = sub_dir.join("cpu.stat");
-        let path_memory = sub_dir.join("memory.stat");
+        let path_memory_stat = sub_dir.join("memory.stat");
+        let path_memory_current = sub_dir.join("memory.current");
 
-        std::fs::write(&path_cpu, "invalid_cpu_data").unwrap();
-        std::fs::write(&path_memory, "invalid_memory_data").unwrap();
+        std::fs::write(
+            &path_cpu,
+            format!(
+                "
+                usage_usec 8335557927\n
+                user_usec 4728882396\n
+                system_usec 3606675531\n
+                nr_periods 0\n
+                nr_throttled 0\n
+                throttled_usec 0"
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            &path_memory_stat,
+            format!(
+                "
+                anon 8335557927
+                file 4728882396
+                kernel_stack 3686400
+                pagetables 0
+                percpu 16317568
+                sock 12288
+                shmem 233824256
+                file_mapped 0
+                file_dirty 20480
+                ...."
+            ),
+        )
+        .unwrap();
+        std::fs::write(&path_memory_current, "invalid_memory_current_data").unwrap();
 
         let file_cpu = File::open(&path_cpu).unwrap();
-        let file_memory = File::open(&path_memory).unwrap();
+        let file_memory_stat = File::open(&path_memory_stat).unwrap();
+        let file_memory_current = File::open(&path_memory_current).unwrap();
 
         // CPU resource consumer for cpu.stat file in cgroup
         let consumer_cpu = ResourceConsumer::ControlGroup {
@@ -545,10 +606,18 @@ mod tests {
                 .into(),
         };
         // Memory resource consumer for memory.stat file in cgroup
-        let consumer_memory = ResourceConsumer::ControlGroup {
-            path: path_memory
+        let consumer_memory_stat = ResourceConsumer::ControlGroup {
+            path: path_memory_stat
                 .to_str()
                 .expect("Path to 'memory.stat' must to be valid UTF8")
+                .to_string()
+                .into(),
+        };
+        // Memory resource consumer for memory.current file in cgroup
+        let consumer_memory_current = ResourceConsumer::ControlGroup {
+            path: path_memory_current
+                .to_str()
+                .expect("Path to 'memory.current' must to be valid UTF8")
                 .to_string()
                 .into(),
         };
@@ -556,18 +625,144 @@ mod tests {
         let mut metric_file = CgroupV2MetricFile {
             name: "test-pod".to_string(),
             consumer_cpu,
-            consumer_memory,
+            consumer_memory_stat,
+            consumer_memory_current,
             file_cpu,
-            file_memory,
-            uid: "test-uid".to_string(),
-            namespace: "default".to_string(),
-            node: "test-node".to_string(),
+            file_memory_stat,
+            file_memory_current,
+            uid: "uid_test".to_string(),
+            namespace: "namespace_test".to_string(),
+            node: "node_test".to_owned(),
         };
 
         let mut content_buffer = String::new();
         let result = gather_value(&mut metric_file, &mut content_buffer);
+        if let Ok(CgroupMeasurements {
+            pod_name,
+            cpu_time_total,
+            cpu_time_user_mode,
+            cpu_time_system_mode,
+            memory_usage_resident,
+            memory_anonymous,
+            memory_file,
+            memory_kernel,
+            memory_pagetables,
+            pod_uid,
+            namespace,
+            node,
+        }) = result
+        {
+            assert_eq!(pod_name, "test-pod".to_owned());
+            assert_eq!(cpu_time_total, 8335557927);
+            assert_eq!(cpu_time_user_mode, 4728882396);
+            assert_eq!(cpu_time_system_mode, 3606675531);
+            assert_eq!(memory_usage_resident, 0);
+            assert_eq!(memory_anonymous, 8335557927);
+            assert_eq!(memory_file, 4728882396);
+            assert_eq!(memory_kernel, 3686400);
+            assert_eq!(memory_pagetables, 0);
+            assert_eq!(pod_uid, "uid_test");
+            assert_eq!(namespace, "namespace_test");
+            assert_eq!(node, "node_test");
+        }
+    }
 
-        result.expect("gather_value get invalid data");
+    // Test `gather_value` function with invalid metric and cpu stat data
+    #[test]
+    fn test_gather_value_with_invalid_cpu_metric_stat_data() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join("test-alumet-plugin-oar/kubepods-invalid-gather.slice/");
+
+        if root.exists() {
+            std::fs::remove_dir_all(&root).unwrap();
+        }
+
+        let dir = root.join("kubepods-burstable.slice/");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let sub_dir = dir.join("kubepods-burstable-pod32a1942cb9a81912549c152a49b5f9b1.slice/");
+        std::fs::create_dir_all(&sub_dir).unwrap();
+
+        let path_cpu = sub_dir.join("cpu.stat");
+        let path_memory_stat = sub_dir.join("memory.stat");
+        let path_memory_current = sub_dir.join("memory.current");
+
+        std::fs::write(&path_cpu, "invalid_cpu_data").unwrap();
+        std::fs::write(&path_memory_stat, "invalid_memory_stat_data").unwrap();
+        std::fs::write(&path_memory_current, "6112023").unwrap();
+
+        let file_cpu = File::open(&path_cpu).unwrap();
+        let file_memory_stat = File::open(&path_memory_stat).unwrap();
+        let file_memory_current = File::open(&path_memory_current).unwrap();
+
+        // CPU resource consumer for cpu.stat file in cgroup
+        let consumer_cpu = ResourceConsumer::ControlGroup {
+            path: path_cpu
+                .to_str()
+                .expect("Path to 'cpu.stat' must be valid UTF8")
+                .to_string()
+                .into(),
+        };
+        // Memory resource consumer for memory.stat file in cgroup
+        let consumer_memory_stat = ResourceConsumer::ControlGroup {
+            path: path_memory_stat
+                .to_str()
+                .expect("Path to 'memory.stat' must to be valid UTF8")
+                .to_string()
+                .into(),
+        };
+        // Memory resource consumer for memory.current file in cgroup
+        let consumer_memory_current = ResourceConsumer::ControlGroup {
+            path: path_memory_current
+                .to_str()
+                .expect("Path to 'memory.current' must to be valid UTF8")
+                .to_string()
+                .into(),
+        };
+
+        let mut metric_file = CgroupV2MetricFile {
+            name: "test-pod".to_string(),
+            consumer_cpu,
+            consumer_memory_stat,
+            consumer_memory_current,
+            file_cpu,
+            file_memory_stat,
+            file_memory_current,
+            uid: "uid_test".to_string(),
+            namespace: "namespace_test".to_string(),
+            node: "node_test".to_owned(),
+        };
+
+        let mut content_buffer = String::new();
+        let result = gather_value(&mut metric_file, &mut content_buffer);
+        if let Ok(CgroupMeasurements {
+            pod_name,
+            cpu_time_total,
+            cpu_time_user_mode,
+            cpu_time_system_mode,
+            memory_usage_resident,
+            memory_anonymous,
+            memory_file,
+            memory_kernel,
+            memory_pagetables,
+            pod_uid,
+            namespace,
+            node,
+        }) = result
+        {
+            assert_eq!(pod_name, "test-pod".to_owned());
+            assert_eq!(cpu_time_total, 0);
+            assert_eq!(cpu_time_user_mode, 0);
+            assert_eq!(cpu_time_system_mode, 0);
+            assert_eq!(memory_usage_resident, 6112023);
+            assert_eq!(memory_anonymous, 0);
+            assert_eq!(memory_file, 0);
+            assert_eq!(memory_kernel, 0);
+            assert_eq!(memory_pagetables, 0);
+            assert_eq!(pod_uid, "uid_test");
+            assert_eq!(namespace, "namespace_test");
+            assert_eq!(node, "node_test");
+        }
     }
 
     // Test `gather_value` function with valid values
@@ -587,7 +782,8 @@ mod tests {
         std::fs::create_dir_all(&sub_dir).unwrap();
 
         let path_cpu = sub_dir.join("cpu.stat");
-        let path_memory = sub_dir.join("memory.stat");
+        let path_memory_stat = sub_dir.join("memory.stat");
+        let path_memory_current = sub_dir.join("memory.current");
 
         std::fs::write(
             path_cpu.clone(),
@@ -604,7 +800,7 @@ mod tests {
         .unwrap();
 
         std::fs::write(
-            path_memory.clone(),
+            path_memory_stat.clone(),
             format!(
                 "
                 anon 8335557927
@@ -621,14 +817,28 @@ mod tests {
         )
         .unwrap();
 
+        std::fs::write(
+            path_memory_current.clone(),
+            format!(
+                "6112023
+                ...."
+            ),
+        )
+        .unwrap();
+
         let file_cpu = match File::open(&path_cpu) {
             Err(why) => panic!("ERROR : Couldn't open {}: {}", path_cpu.display(), why),
             Ok(file_cpu) => file_cpu,
         };
 
-        let file_memory = match File::open(&path_memory) {
-            Err(why) => panic!("ERROR : Couldn't open {}: {}", path_memory.display(), why),
-            Ok(file_memory) => file_memory,
+        let file_memory_stat = match File::open(&path_memory_stat) {
+            Err(why) => panic!("ERROR : Couldn't open {}: {}", path_memory_stat.display(), why),
+            Ok(file_memory_stat) => file_memory_stat,
+        };
+
+        let file_memory_current = match File::open(&path_memory_current) {
+            Err(why) => panic!("ERROR : Couldn't open {}: {}", path_memory_current.display(), why),
+            Ok(file_memory_current) => file_memory_current,
         };
 
         // CPU resource consumer for cpu.stat file in cgroup
@@ -640,10 +850,18 @@ mod tests {
                 .into(),
         };
         // Memory resource consumer for memory.stat file in cgroup
-        let consumer_memory = ResourceConsumer::ControlGroup {
-            path: path_memory
+        let consumer_memory_stat = ResourceConsumer::ControlGroup {
+            path: path_memory_stat
                 .to_str()
                 .expect("Path to 'memory.stat' must to be valid UTF8")
+                .to_string()
+                .into(),
+        };
+        // Memory resource consumer for memory.current file in cgroup
+        let consumer_memory_current = ResourceConsumer::ControlGroup {
+            path: path_memory_current
+                .to_str()
+                .expect("Path to 'memory.current' must to be valid UTF8")
                 .to_string()
                 .into(),
         };
@@ -652,8 +870,10 @@ mod tests {
             name: "testing_pod".to_string(),
             consumer_cpu,
             file_cpu,
-            consumer_memory,
-            file_memory,
+            consumer_memory_stat,
+            file_memory_stat,
+            consumer_memory_current,
+            file_memory_current,
             uid: "uid_test".to_string(),
             namespace: "namespace_test".to_string(),
             node: "node_test".to_owned(),
@@ -671,6 +891,7 @@ mod tests {
             cpu_time_total,
             cpu_time_user_mode,
             cpu_time_system_mode,
+            memory_usage_resident,
             memory_anonymous,
             memory_file,
             memory_kernel,
@@ -684,6 +905,7 @@ mod tests {
             assert_eq!(cpu_time_total, 8335557927);
             assert_eq!(cpu_time_user_mode, 4728882396);
             assert_eq!(cpu_time_system_mode, 3606675531);
+            assert_eq!(memory_usage_resident, 6112023);
             assert_eq!(memory_anonymous, 8335557927);
             assert_eq!(memory_file, 4728882396);
             assert_eq!(memory_kernel, 3686400);

--- a/plugin-cgroupv2/src/oar3/utils.rs
+++ b/plugin-cgroupv2/src/oar3/utils.rs
@@ -21,11 +21,15 @@ pub struct CgroupV2MetricFile {
     /// Path to the cgroup cpu stat file.
     pub consumer_cpu: ResourceConsumer,
     /// Path to the cgroup memory stat file.
-    pub consumer_memory: ResourceConsumer,
+    pub consumer_memory_stat: ResourceConsumer,
+    /// Path to the cgroup memory current file.
+    pub consumer_memory_current: ResourceConsumer,
     /// Opened file descriptor for cgroup cpu stat.
     pub file_cpu: File,
     /// Opened file descriptor for cgroup memory stat.
-    pub file_memory: File,
+    pub file_memory_stat: File,
+    /// Opened file descriptor for cgroup memory current.
+    pub file_memory_current: File,
 }
 
 impl CgroupV2MetricFile {
@@ -33,16 +37,20 @@ impl CgroupV2MetricFile {
     fn new(
         name: String,
         consumer_cpu: ResourceConsumer,
-        consumer_memory: ResourceConsumer,
+        consumer_memory_stat: ResourceConsumer,
+        consumer_memory_current: ResourceConsumer,
         file_cpu: File,
-        file_memory: File,
+        file_memory_stat: File,
+        file_memory_current: File,
     ) -> CgroupV2MetricFile {
         CgroupV2MetricFile {
             name,
             consumer_cpu,
-            consumer_memory,
+            consumer_memory_stat,
+            consumer_memory_current,
             file_cpu,
-            file_memory,
+            file_memory_stat,
+            file_memory_current,
         }
     }
 }
@@ -56,19 +64,24 @@ fn list_metric_file_in_dir(root_directory_path: &Path) -> anyhow::Result<Vec<Cgr
     for entry in entries {
         let path = entry?.path();
         let mut path_cloned_cpu = path.clone();
-        let mut path_cloned_memory = path.clone();
+        let mut path_cloned_memory_stat = path.clone();
+        let mut path_cloned_memory_current = path.clone();
 
         path_cloned_cpu.push("cpu.stat");
-        path_cloned_memory.push("memory.stat");
+        path_cloned_memory_stat.push("memory.stat");
+        path_cloned_memory_current.push("memory.current");
 
         if (path_cloned_cpu.exists() && path_cloned_cpu.is_file())
-            && (path_cloned_memory.exists() && path_cloned_memory.is_file())
+            && (path_cloned_memory_stat.exists() && path_cloned_memory_stat.is_file())
+            && (path_cloned_memory_current.exists() && path_cloned_memory_current.is_file())
         {
             let file_name = path.file_name().ok_or_else(|| anyhow::anyhow!("No file name found"))?;
             let file_cpu = File::open(&path_cloned_cpu)
                 .with_context(|| format!("Failed to open file {}", path_cloned_cpu.display()))?;
-            let file_memory = File::open(&path_cloned_memory)
-                .with_context(|| format!("Failed to open file {}", path_cloned_memory.display()))?;
+            let file_memory_stat = File::open(&path_cloned_memory_stat)
+                .with_context(|| format!("Failed to open file {}", path_cloned_memory_stat.display()))?;
+            let file_memory_current = File::open(&path_cloned_memory_current)
+                .with_context(|| format!("Failed to open file {}", path_cloned_memory_current.display()))?;
 
             // CPU resource consumer for cpu.stat file in cgroup
             let consumer_cpu = ResourceConsumer::ControlGroup {
@@ -78,11 +91,19 @@ fn list_metric_file_in_dir(root_directory_path: &Path) -> anyhow::Result<Vec<Cgr
                     .to_string()
                     .into(),
             };
-            // Memory resource consumer for cpu.stat file in cgroup
-            let consumer_memory = ResourceConsumer::ControlGroup {
-                path: path_cloned_memory
+            // Memory resource consumer for memory.stat file in cgroup
+            let consumer_memory_stat = ResourceConsumer::ControlGroup {
+                path: path_cloned_memory_stat
                     .to_str()
                     .expect("Path to 'memory.stat' must to be valid UTF8")
+                    .to_string()
+                    .into(),
+            };
+            // Memory resource consumer for memory.current file in cgroup
+            let consumer_memory_current = ResourceConsumer::ControlGroup {
+                path: path_cloned_memory_current
+                    .to_str()
+                    .expect("Path to 'memory.current' must to be valid UTF8")
                     .to_string()
                     .into(),
             };
@@ -91,9 +112,11 @@ fn list_metric_file_in_dir(root_directory_path: &Path) -> anyhow::Result<Vec<Cgr
             vec_file_metric.push(CgroupV2MetricFile {
                 name: file_name.to_str().context("Filename is not valid UTF-8")?.to_string(),
                 consumer_cpu,
-                consumer_memory,
+                consumer_memory_stat,
+                consumer_memory_current,
                 file_cpu,
-                file_memory,
+                file_memory_stat,
+                file_memory_current,
             });
         }
     }
@@ -149,16 +172,27 @@ pub fn gather_value(file: &mut CgroupV2MetricFile, content_buffer: &mut String) 
     file.file_cpu.rewind()?;
 
     // Memory cgroup data
-    file.file_memory
+    file.file_memory_stat
         .read_to_string(content_buffer)
-        .context("Unable to gather cgroup v2 memory metrics by reading file")?;
+        .context("Unable to gather cgroup v2 memory stat metrics by reading file")?;
     if content_buffer.is_empty() {
         return Err(anyhow::anyhow!("Memory stat file is empty for {}", file.name));
     }
-    file.file_memory.rewind()?;
+    file.file_memory_stat.rewind()?;
 
     let mut new_metric =
         CgroupMeasurements::from_str(content_buffer).with_context(|| format!("failed to parse {}", file.name))?;
+
+    // Memory current cgroup data
+    content_buffer.clear();
+    file.file_memory_current
+        .read_to_string(content_buffer)
+        .context("Unable to get cgroup v2 memory current metric by reading file")?;
+    file.file_memory_current.rewind()?;
+
+    new_metric
+        .load_memory_current_from_str(content_buffer)
+        .with_context(|| format!("failed to parse {}", file.name))?;
 
     new_metric.pod_name = file.name.clone();
 
@@ -196,7 +230,8 @@ mod tests {
 
         for i in 0..4 {
             std::fs::write(sub_dir[i].join("cpu.stat"), "test_cpu").unwrap();
-            std::fs::write(sub_dir[i].join("memory.stat"), "test_memory").unwrap();
+            std::fs::write(sub_dir[i].join("memory.stat"), "test_memory_stat").unwrap();
+            std::fs::write(sub_dir[i].join("memory.current"), "test_memory_current").unwrap();
         }
 
         let list_met_file = list_metric_file_in_dir(&dir);
@@ -226,9 +261,9 @@ mod tests {
         assert!(true);
     }
 
-    // Test `gather_value` function with invalid data
+    // Test `gather_value` function with invalid memory.current data
     #[test]
-    fn test_gather_value_with_invalid_data() {
+    fn test_gather_value_with_invalid_memory_current_data() {
         let tmp = tempdir().unwrap();
         let root = tmp.path().join("test-alumet-plugin-oar/kubepods-invalid-gather.slice/");
 
@@ -243,13 +278,44 @@ mod tests {
         std::fs::create_dir_all(&sub_dir).unwrap();
 
         let path_cpu = sub_dir.join("cpu.stat");
-        let path_memory = sub_dir.join("memory.stat");
+        let path_memory_stat = sub_dir.join("memory.stat");
+        let path_memory_current = sub_dir.join("memory.current");
 
-        std::fs::write(&path_cpu, "invalid_cpu_data").unwrap();
-        std::fs::write(&path_memory, "invalid_memory_data").unwrap();
+        std::fs::write(
+            &path_cpu,
+            format!(
+                "
+                usage_usec 8335557927\n
+                user_usec 4728882396\n
+                system_usec 3606675531\n
+                nr_periods 0\n
+                nr_throttled 0\n
+                throttled_usec 0"
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            &path_memory_stat,
+            format!(
+                "
+                anon 8335557927
+                file 4728882396
+                kernel_stack 3686400
+                pagetables 0
+                percpu 16317568
+                sock 12288
+                shmem 233824256
+                file_mapped 0
+                file_dirty 20480
+                ...."
+            ),
+        )
+        .unwrap();
+        std::fs::write(&path_memory_current, "invalid_memory_current_data").unwrap();
 
         let file_cpu = File::open(&path_cpu).unwrap();
-        let file_memory = File::open(&path_memory).unwrap();
+        let file_memory_stat = File::open(&path_memory_stat).unwrap();
+        let file_memory_current = File::open(&path_memory_current).unwrap();
 
         // CPU resource consumer for cpu.stat file in cgroup
         let consumer_cpu = ResourceConsumer::ControlGroup {
@@ -260,10 +326,18 @@ mod tests {
                 .into(),
         };
         // Memory resource consumer for memory.stat file in cgroup
-        let consumer_memory = ResourceConsumer::ControlGroup {
-            path: path_memory
+        let consumer_memory_stat = ResourceConsumer::ControlGroup {
+            path: path_memory_stat
                 .to_str()
                 .expect("Path to 'memory.stat' must to be valid UTF8")
+                .to_string()
+                .into(),
+        };
+        // Memory resource consumer for memory.current file in cgroup
+        let consumer_memory_current = ResourceConsumer::ControlGroup {
+            path: path_memory_current
+                .to_str()
+                .expect("Path to 'memory.current' must to be valid UTF8")
                 .to_string()
                 .into(),
         };
@@ -271,15 +345,132 @@ mod tests {
         let mut metric_file = CgroupV2MetricFile {
             name: "test-pod".to_string(),
             consumer_cpu,
-            consumer_memory,
+            consumer_memory_stat,
+            consumer_memory_current,
             file_cpu,
-            file_memory,
+            file_memory_stat,
+            file_memory_current,
         };
 
         let mut content_buffer = String::new();
         let result = gather_value(&mut metric_file, &mut content_buffer);
+        if let Ok(CgroupMeasurements {
+            pod_name,
+            cpu_time_total,
+            cpu_time_user_mode,
+            cpu_time_system_mode,
+            memory_usage_resident,
+            memory_anonymous,
+            memory_file,
+            memory_kernel,
+            memory_pagetables,
+            pod_uid: _uid,
+            namespace: _ns,
+            node: _nd,
+        }) = result
+        {
+            assert_eq!(pod_name, "test-pod".to_owned());
+            assert_eq!(cpu_time_total, 8335557927);
+            assert_eq!(cpu_time_user_mode, 4728882396);
+            assert_eq!(cpu_time_system_mode, 3606675531);
+            assert_eq!(memory_usage_resident, 0);
+            assert_eq!(memory_anonymous, 8335557927);
+            assert_eq!(memory_file, 4728882396);
+            assert_eq!(memory_kernel, 3686400);
+            assert_eq!(memory_pagetables, 0);
+        }
+    }
 
-        result.expect("gather_value get invalid data");
+    // Test `gather_value` function with invalid data
+    #[test]
+    fn test_gather_value_with_invalid_cpu_metric_stat_data() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path().join("test-alumet-plugin-oar/kubepods-invalid-gather.slice/");
+
+        if root.exists() {
+            std::fs::remove_dir_all(&root).unwrap();
+        }
+
+        let dir = root.join("kubepods-burstable.slice/");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let sub_dir = dir.join("kubepods-burstable-pod32a1942cb9a81912549c152a49b5f9b1.slice/");
+        std::fs::create_dir_all(&sub_dir).unwrap();
+
+        let path_cpu = sub_dir.join("cpu.stat");
+        let path_memory_stat = sub_dir.join("memory.stat");
+        let path_memory_current = sub_dir.join("memory.current");
+
+        std::fs::write(&path_cpu, "invalid_cpu_data").unwrap();
+        std::fs::write(&path_memory_stat, "invalid_memory_stat_data").unwrap();
+        std::fs::write(&path_memory_current, "6112023").unwrap();
+
+        let file_cpu = File::open(&path_cpu).unwrap();
+        let file_memory_stat = File::open(&path_memory_stat).unwrap();
+        let file_memory_current = File::open(&path_memory_current).unwrap();
+
+        // CPU resource consumer for cpu.stat file in cgroup
+        let consumer_cpu = ResourceConsumer::ControlGroup {
+            path: path_cpu
+                .to_str()
+                .expect("Path to 'cpu.stat' must be valid UTF8")
+                .to_string()
+                .into(),
+        };
+        // Memory resource consumer for memory.stat file in cgroup
+        let consumer_memory_stat = ResourceConsumer::ControlGroup {
+            path: path_memory_stat
+                .to_str()
+                .expect("Path to 'memory.stat' must to be valid UTF8")
+                .to_string()
+                .into(),
+        };
+        // Memory resource consumer for memory.current file in cgroup
+        let consumer_memory_current = ResourceConsumer::ControlGroup {
+            path: path_memory_current
+                .to_str()
+                .expect("Path to 'memory.current' must to be valid UTF8")
+                .to_string()
+                .into(),
+        };
+
+        let mut metric_file = CgroupV2MetricFile {
+            name: "test-pod".to_string(),
+            consumer_cpu,
+            consumer_memory_stat,
+            consumer_memory_current,
+            file_cpu,
+            file_memory_stat,
+            file_memory_current,
+        };
+
+        let mut content_buffer = String::new();
+        let result = gather_value(&mut metric_file, &mut content_buffer);
+        if let Ok(CgroupMeasurements {
+            pod_name,
+            cpu_time_total,
+            cpu_time_user_mode,
+            cpu_time_system_mode,
+            memory_usage_resident,
+            memory_anonymous,
+            memory_file,
+            memory_kernel,
+            memory_pagetables,
+            pod_uid: _uid,
+            namespace: _ns,
+            node: _nd,
+        }) = result
+        {
+            assert_eq!(pod_name, "test-pod".to_owned());
+            assert_eq!(cpu_time_total, 0);
+            assert_eq!(cpu_time_user_mode, 0);
+            assert_eq!(cpu_time_system_mode, 0);
+            assert_eq!(memory_usage_resident, 6112023);
+            assert_eq!(memory_anonymous, 0);
+            assert_eq!(memory_file, 0);
+            assert_eq!(memory_kernel, 0);
+            assert_eq!(memory_pagetables, 0);
+        }
     }
 
     // Test `gather_value` function with valid values
@@ -299,7 +490,8 @@ mod tests {
         std::fs::create_dir_all(&sub_dir).unwrap();
 
         let path_cpu = sub_dir.join("cpu.stat");
-        let path_memory = sub_dir.join("memory.stat");
+        let path_memory_stat = sub_dir.join("memory.stat");
+        let path_memory_current = sub_dir.join("memory.current");
 
         std::fs::write(
             path_cpu.clone(),
@@ -316,7 +508,7 @@ mod tests {
         .unwrap();
 
         std::fs::write(
-            path_memory.clone(),
+            path_memory_stat.clone(),
             format!(
                 "
                 anon 8335557927
@@ -327,8 +519,17 @@ mod tests {
                 sock 12288
                 shmem 233824256
                 file_mapped 0
-                file_dirty 20480,
+                file_dirty 20480
                 ...."
+            ),
+        )
+        .unwrap();
+
+        std::fs::write(
+            path_memory_current.clone(),
+            format!(
+                "6112023
+                " // the \n (ending line) is expected
             ),
         )
         .unwrap();
@@ -338,9 +539,14 @@ mod tests {
             Ok(file_cpu) => file_cpu,
         };
 
-        let file_memory = match File::open(&path_memory) {
-            Err(why) => panic!("ERROR : Couldn't open {}: {}", path_memory.display(), why),
-            Ok(file_memory) => file_memory,
+        let file_memory_stat = match File::open(&path_memory_stat) {
+            Err(why) => panic!("ERROR : Couldn't open {}: {}", path_memory_stat.display(), why),
+            Ok(file_memory_stat) => file_memory_stat,
+        };
+
+        let file_memory_current = match File::open(&path_memory_current) {
+            Err(why) => panic!("ERROR : Couldn't open {}: {}", path_memory_current.display(), why),
+            Ok(file_memory_current) => file_memory_current,
         };
 
         // CPU resource consumer for cpu.stat file in cgroup
@@ -352,10 +558,18 @@ mod tests {
                 .into(),
         };
         // Memory resource consumer for memory.stat file in cgroup
-        let consumer_memory = ResourceConsumer::ControlGroup {
-            path: path_memory
+        let consumer_memory_stat = ResourceConsumer::ControlGroup {
+            path: path_memory_stat
                 .to_str()
                 .expect("Path to 'memory.stat' must to be valid UTF8")
+                .to_string()
+                .into(),
+        };
+        // Memory resource consumer for memory.current file in cgroup
+        let consumer_memory_current = ResourceConsumer::ControlGroup {
+            path: path_memory_current
+                .to_str()
+                .expect("Path to 'memory.current' must to be valid UTF8")
                 .to_string()
                 .into(),
         };
@@ -363,9 +577,11 @@ mod tests {
         let mut cgroup = CgroupV2MetricFile::new(
             "testing_pod".to_string(),
             consumer_cpu,
-            consumer_memory,
+            consumer_memory_stat,
+            consumer_memory_current,
             file_cpu,
-            file_memory,
+            file_memory_stat,
+            file_memory_current,
         );
 
         let mut content = String::new();
@@ -376,6 +592,7 @@ mod tests {
             cpu_time_total,
             cpu_time_user_mode,
             cpu_time_system_mode,
+            memory_usage_resident,
             memory_anonymous,
             memory_file,
             memory_kernel,
@@ -389,6 +606,7 @@ mod tests {
             assert_eq!(cpu_time_total, 8335557927);
             assert_eq!(cpu_time_user_mode, 4728882396);
             assert_eq!(cpu_time_system_mode, 3606675531);
+            assert_eq!(memory_usage_resident, 6112023);
             assert_eq!(memory_anonymous, 8335557927);
             assert_eq!(memory_file, 4728882396);
             assert_eq!(memory_kernel, 3686400);


### PR DESCRIPTION
This PR aims to harmonize collected metrics with plugins cgroupv1 and procfs.

In that direction we kept only one cpu related metric called `cpu_time_delta` and gather old cgroup_cpu_usage_total, cgroup_cpu_usage_user and cgroup_cpu_usage_system that are still collected but as a single metric with different `kind` attributes (total, usage and system).

Also added a new metric `memory_usage`.
This metric is sourced from memory.current file from cgroupv2.
It represents the resident (RSS) memory (kind attribute), that makes it consistend with metrics collected in cgroupv1 and procfs.
Removed the metric cgroup_memory_total that was calculated based on other cgroup_memory measurements, since it's recommended to collect memory.current to have the total memory currently used by a process (a bit like top does for example), it didn't make sense anymore to try to compute it on our side.

Made some renaming especially on memory.stat related variables as now we collect two different files related to metrics it make sense to explicit it.