### PR TITLE
Refactor/plugin cgroupv1 for harmonized metrics across plugins

### DIFF
--- a/plugin-cgroupv1/src/cgroupv1.rs
+++ b/plugin-cgroupv1/src/cgroupv1.rs
@@ -3,7 +3,7 @@ use alumet::{
     measurement::{MeasurementPoint, Timestamp},
     metrics::{error::MetricCreationError, TypedMetricId},
     pipeline::elements::error::PollError,
-    plugin::AlumetPluginStart,
+    plugin::{util::CounterDiffUpdate, AlumetPluginStart},
     resources::Resource,
     units::{PrefixedUnit, Unit},
 };
@@ -24,7 +24,7 @@ impl Metrics {
 
         Ok(Self {
             cpu_metric: alumet.create_metric::<u64>(
-                "cpu_time",
+                "cpu_time_delta",
                 nsec,
                 "Total CPU time consumed by the cgroup (in nanoseconds).",
             )?,
@@ -42,7 +42,7 @@ pub fn gather_value(job_source: &mut OAR2Probe, timestamp: Timestamp) -> Result<
     cpu_usage_file.rewind()?;
     let mut buffer = String::new();
     cpu_usage_file.read_to_string(&mut buffer)?;
-    let cpu_usage_u64 = buffer.trim().parse::<u64>()?;
+    let total_cpu_time = buffer.trim().parse::<u64>()?;
     buffer.clear();
     let memory_usage_file = &mut job_source.oar2_metric_file.cgroup_memory_file;
     memory_usage_file.rewind()?;
@@ -58,17 +58,26 @@ pub fn gather_value(job_source: &mut OAR2Probe, timestamp: Timestamp) -> Result<
             job_source.oar2_metric_file.memory_file_path.clone(),
             memory_usage_u64,
         )
-        .with_attr("oar_job_id", job_source.oar2_metric_file.job_id.clone()),
+        .with_attr("job_id", job_source.oar2_metric_file.job_id.clone()),
     );
-    measurement_point_vector.push(
-        MeasurementPoint::new(
-            timestamp,
-            job_source.cpu_metric,
-            Resource::LocalMachine,
-            job_source.oar2_metric_file.cpu_file_path.clone(),
-            cpu_usage_u64,
-        )
-        .with_attr("oar_job_id", job_source.oar2_metric_file.job_id.clone()),
-    );
+
+    let cpu_time_delta = match job_source.cpu_metric_counter_diff.update(total_cpu_time) {
+        CounterDiffUpdate::FirstTime => None,
+        CounterDiffUpdate::Difference(diff) => Some(diff),
+        CounterDiffUpdate::CorrectedDifference(diff) => Some(diff),
+    };
+    if let Some(cpu_time_delta_value) = cpu_time_delta {
+        measurement_point_vector.push(
+            MeasurementPoint::new(
+                timestamp,
+                job_source.cpu_metric,
+                Resource::LocalMachine,
+                job_source.oar2_metric_file.cpu_file_path.clone(),
+                cpu_time_delta_value,
+            )
+            .with_attr("job_id", job_source.oar2_metric_file.job_id.clone()),
+        );
+    }
+
     Ok(measurement_point_vector)
 }

--- a/plugin-cgroupv1/src/oar2/plugin.rs
+++ b/plugin-cgroupv1/src/oar2/plugin.rs
@@ -6,6 +6,7 @@ use alumet::{
     },
     plugin::{
         rust::{deserialize_config, serialize_config, AlumetPlugin},
+        util::CounterDiff,
         AlumetPluginStart, AlumetPostStart, ConfigTable,
     },
     resources::ResourceConsumer,
@@ -113,6 +114,7 @@ impl AlumetPlugin for Oar2Plugin {
                     cgroup_memory_file,
                 };
                 let initial_source = Box::new(OAR2Probe {
+                    cpu_metric_counter_diff: CounterDiff::with_max_value(u64::MAX.into()),
                     cpu_metric: metrics.cpu_metric,
                     memory_metric: metrics.memory_metric,
                     oar2_metric_file: metric_file,
@@ -197,6 +199,7 @@ impl AlumetPlugin for Oar2Plugin {
                                 (File::open(&cpu_file_path), File::open(&memory_file_path))
                             {
                                 let new_source = Box::new(OAR2Probe {
+                                    cpu_metric_counter_diff: CounterDiff::with_max_value(u64::MAX.into()),
                                     cpu_metric: job_detect.cpu_metric,
                                     memory_metric: job_detect.memory_metric,
                                     oar2_metric_file: metric_file,

--- a/plugin-cgroupv1/src/oar2/probe.rs
+++ b/plugin-cgroupv1/src/oar2/probe.rs
@@ -2,6 +2,7 @@ use alumet::{
     measurement::{MeasurementAccumulator, Timestamp},
     metrics::TypedMetricId,
     pipeline::{elements::error::PollError, Source},
+    plugin::util::CounterDiff,
 };
 use std::result::Result::Ok;
 
@@ -9,8 +10,8 @@ use super::utils::OpenedCgroupv1;
 
 use crate::cgroupv1::gather_value;
 
-#[derive(Debug)]
 pub struct OAR2Probe {
+    pub cpu_metric_counter_diff: CounterDiff,
     pub cpu_metric: TypedMetricId<u64>,
     pub memory_metric: TypedMetricId<u64>,
     pub oar2_metric_file: OpenedCgroupv1,


### PR DESCRIPTION
This PR do some refactoring on cgroupv1 plugin to continue harmonization work across metrics, especially related to metrics unit, names and types.