### PR TITLE
ci: Ensure that the git history of each PR branch is linear

### DIFF
--- a/.github/workflows/check_doc.yaml
+++ b/.github/workflows/check_doc.yaml
@@ -1,4 +1,3 @@
----
 name: Check documentation
 on: [pull_request, push]
 
@@ -8,7 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - name: Spell check everything
         uses: streetsidesoftware/cspell-action@v6
         with:

--- a/.github/workflows/check_git.yaml
+++ b/.github/workflows/check_git.yaml
@@ -1,0 +1,21 @@
+name: Ensure a clean Git history
+on: [pull_request]
+
+jobs:
+  git-checkup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Check that the Git history is linear
+        run: |
+          NB_MERGE_COMMITS_ON_BRANCH=$(git rev-list --merges --count ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }})
+          if [ $NB_MERGE_COMMITS_ON_BRANCH -ne 0 ]; then
+            echo "::error::The git history of your branch is non-linear: $NB_MERGE_COMMITS_ON_BRANCH merge commits detected"
+            echo "::error::When updating your branch, you must rebase instead of merging."
+            exit 1
+          fi


### PR DESCRIPTION
A new action enforces the model "rebase, then merge" where each feature branch has a linear history, but can be merged into master with a merge commit. If the PR branch contains a merge commit, the check will fail.