### PR TITLE
New plugin to send measurements to OpenSearch/ElasticSearch directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,7 @@ dependencies = [
  "plugin-cgroupv1",
  "plugin-cgroupv2",
  "plugin-csv",
+ "plugin-elasticsearch",
  "plugin-energy-attribution",
  "plugin-energy-estimation-tdp",
  "plugin-influxdb",
@@ -184,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "assert-json-diff"
@@ -809,6 +810,15 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "enum-as-inner"
@@ -2509,6 +2519,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "plugin-elasticsearch"
+version = "0.1.0"
+dependencies = [
+ "alumet",
+ "anyhow",
+ "base64 0.22.1",
+ "log",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "time",
+ "toml",
+]
+
+[[package]]
 name = "plugin-energy-attribution"
 version = "0.1.0"
 dependencies = [
@@ -3085,6 +3110,7 @@ checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -3112,6 +3138,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.26.2",
@@ -3651,6 +3678,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.9.0",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "plugin-relay",
     "plugin-socket-control",
     "plugin-mongodb",
+    "plugin-elasticsearch",
     "test-dynamic-plugins",
 ]
 

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -29,6 +29,7 @@ plugin-opentelemetry = { path = "../plugin-opentelemetry" }
 plugin-aggregation = { path = "../plugin-aggregation" }
 plugin-energy-attribution = { path = "../plugin-energy-attribution" }
 plugin-energy-estimation-tdp = { path = "../plugin-energy-estimation-tdp" }
+plugin-elasticsearch = { path = "../plugin-elasticsearch" }
 
 # Linux-only dependencies
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/agent/src/bin/main.rs
+++ b/agent/src/bin/main.rs
@@ -33,6 +33,7 @@ fn load_plugins_metadata() -> Vec<PluginMetadata> {
         plugin_aggregation::AggregationPlugin,
         plugin_energy_attribution::EnergyAttributionPlugin,
         plugin_energy_estimation_tdp::EnergyEstimationTdpPlugin,
+        plugin_elasticsearch::ElasticSearchPlugin,
     ];
 
     // plugins that only work on Linux

--- a/plugin-elasticsearch/Cargo.toml
+++ b/plugin-elasticsearch/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "plugin-elasticsearch"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+reqwest = { version = "0.12.15", features = ["blocking", "json"] }
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.140"
+alumet = { path = "../alumet" }
+time = { version = "0.3.41", features = ["formatting"] }
+anyhow = "1.0.98"
+base64 = "0.22.1"
+log = "0.4.27"
+
+[lints]
+workspace = true
+
+[dev-dependencies]
+toml = "0.8.20"

--- a/plugin-elasticsearch/README.md
+++ b/plugin-elasticsearch/README.md
@@ -1,0 +1,60 @@
+# ElasticSearch / OpenSearch plugin
+
+The `elasticsearch` plugin inserts Alumet measurements into ElasticSearch or OpenSearch (the API that we use is identical in both projects).
+
+## Configuration
+
+The default configuration is as follows.
+
+```toml
+[plugins.elasticsearch]
+server_url = "http://localhost:9200"
+allow_insecure = false
+index_prefix = "alumet"
+metric_unit_as_index_suffix = false
+
+[plugins.elasticsearch.auth.basic]
+user = "TODO"
+password = "TODO"
+```
+
+### Authentication
+
+Multiple auth schemes are supported.
+
+#### Basic auth
+
+You can give the username and password in the config:
+
+```toml
+[plugins.elasticsearch.auth.basic]
+user = "TODO"
+password = "TODO"
+```
+
+Or ask the plugin to read them from a file, which must contain the username and password separated by a colon (`:`):
+
+```toml
+[plugins.elasticsearch.auth.basic_file]
+file = "basic_auth.txt"
+```
+
+Example file `basic_auth.txt`:
+
+```txt
+user:password
+```
+
+#### API key auth
+
+```toml
+[plugins.elasticsearch.auth.api_key]
+key = "your key here"
+```
+
+#### Bearer auth
+
+```toml
+[plugins.elasticsearch.auth.bearer]
+token = "your token here"
+```

--- a/plugin-elasticsearch/src/api.rs
+++ b/plugin-elasticsearch/src/api.rs
@@ -1,0 +1,5 @@
+mod client;
+mod de;
+mod ser;
+
+pub use client::{ApiAuthentication, Client, ConnectionSettings, DataSettings};

--- a/plugin-elasticsearch/src/api/client.rs
+++ b/plugin-elasticsearch/src/api/client.rs
@@ -1,0 +1,173 @@
+use std::{collections::HashMap, fmt::Debug};
+
+use alumet::{
+    measurement::MeasurementBuffer,
+    pipeline::{control::request, elements::output::OutputContext},
+};
+use anyhow::Context;
+use reqwest::{
+    header::{HeaderMap, HeaderValue, InvalidHeaderValue},
+    Url,
+};
+
+use super::ser::{CreateIndexTemplate, IndexTemplate, Serializer};
+
+// OpenSearch/ElasticSearch API client.
+pub struct Client {
+    serializer: Serializer,
+    client: reqwest::blocking::Client,
+    server_url: Url,
+}
+
+pub struct ConnectionSettings {
+    pub auth: ApiAuthentication,
+    pub server_url: Url,
+    pub allow_insecure: bool,
+}
+
+pub struct DataSettings {
+    pub index_prefix: String,
+    pub metric_unit_as_index_suffix: bool,
+}
+
+pub enum ApiAuthentication {
+    ApiKey { key: String },
+    Basic { user: String, password: String },
+    Bearer { token: String },
+}
+
+pub fn user_agent_string() -> String {
+    let core_version = alumet::VERSION;
+    let plugin_crate_name = env!("CARGO_PKG_NAME");
+    let plugin_version = env!("CARGO_PKG_VERSION");
+    let user_agent = format!("Alumet/{core_version} {plugin_crate_name}/{plugin_version}");
+    log::debug!("Client user agent: {user_agent}");
+    user_agent
+}
+
+impl Client {
+    pub fn new(conn: ConnectionSettings, data: DataSettings) -> anyhow::Result<Self> {
+        let mut builder = reqwest::blocking::ClientBuilder::new();
+        if conn.allow_insecure {
+            builder = builder
+                .danger_accept_invalid_certs(true)
+                .danger_accept_invalid_hostnames(true);
+        }
+        builder = builder
+            .user_agent(user_agent_string())
+            .default_headers(HeaderMap::from_iter(vec![(
+                reqwest::header::AUTHORIZATION,
+                conn.auth
+                    .into_header_value()
+                    .context("auth should make a valid http header")?,
+            )]));
+        let client = builder.build().context("failed to initialize HTTP client")?;
+        Ok(Self {
+            client,
+            server_url: conn.server_url,
+            serializer: Serializer {
+                index_prefix: data.index_prefix,
+                metric_unit_as_index_suffix: data.metric_unit_as_index_suffix,
+            },
+        })
+    }
+
+    pub fn create_index_template(&self) -> anyhow::Result<()> {
+        const TEMPLATE_NAME: &str = "alumet_index_template";
+
+        let template = IndexTemplate {
+            mappings: self.serializer.common_index_mappings(),
+        };
+        let index_pattern = format!("{}-*", self.serializer.index_prefix);
+        let create = CreateIndexTemplate {
+            index_patterns: vec![index_pattern],
+            template,
+            priority: 80,
+            version: 3,
+            meta: HashMap::from_iter([("origin".to_string(), "Alumet measurements".to_string())]),
+        };
+
+        // Create the template (or update it if it exists).
+        // Note: server_url is turned into a string with a trailing '/'.
+        let url = format!("{}_index_template/{TEMPLATE_NAME}", self.server_url);
+        let request = self.client.put(url).json(&create);
+        log::trace!("sending {request:?}");
+
+        let response = request.send().context("could not send request")?;
+        log::trace!("got response {response:?}");
+
+        Self::handle_response(response)?;
+        Ok(())
+    }
+
+    pub fn bulk_insert_measurements(&self, m: &MeasurementBuffer, ctx: &OutputContext) -> anyhow::Result<()> {
+        let url = self.server_url.join("_bulk").unwrap();
+
+        let body = self
+            .serializer
+            .body_bulk_create_docs(m, ctx)
+            .context("measurements serialization failed")?;
+
+        log::trace!("serialized measurements:\n{body}");
+        let request = self.client.put(url).body(body).header(
+            reqwest::header::CONTENT_TYPE,
+            HeaderValue::from_static("application/x-ndjson"),
+        );
+        log::trace!("sending {request:?}");
+        let response = request.send().context("could not send request")?;
+
+        log::trace!("got response {response:?}");
+        Self::handle_response(response)?;
+        // let failed_items = response
+        // .json::<super::de::FilteredBulkCreateResponse>()
+        // .context("response deserialization failed")?;
+        // if !failed_items.items.is_empty() {
+        // return Err(anyhow::anyhow!("bulk insert failed: {failed_items:?}"));
+        // }
+        Ok(())
+    }
+
+    fn handle_response(response: reqwest::blocking::Response) -> anyhow::Result<()> {
+        let status = response.status();
+        if status.is_client_error() || status.is_server_error() {
+            let status_msg = format!("{} {}", status.as_str(), status.canonical_reason().unwrap_or_default());
+            let body = response
+                .text()
+                .with_context(|| format!("failed to decode response body for error {status:?}"))?;
+            Err(anyhow::anyhow!("server responded with error: {status_msg}\n{body}"))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl ApiAuthentication {
+    pub fn into_header_value(self) -> Result<HeaderValue, InvalidHeaderValue> {
+        use base64::prelude::BASE64_STANDARD;
+        use base64::write::EncoderWriter;
+        use std::io::Write;
+
+        let mut header = match self {
+            ApiAuthentication::ApiKey { key } => {
+                let header_value = format!("ApiKey {key}");
+                HeaderValue::from_str(&header_value)
+            }
+            ApiAuthentication::Basic { user, password } => {
+                // Unfortunately, reqwest::util::basic_auth is not accessible from the outside,
+                // so we must implement it here.
+                let mut buf = b"Basic ".to_vec();
+                {
+                    let mut encoder = EncoderWriter::new(&mut buf, &BASE64_STANDARD);
+                    let _ = write!(encoder, "{user}:{password}");
+                }
+                HeaderValue::from_bytes(&buf)
+            }
+            ApiAuthentication::Bearer { token } => {
+                let header_value = format!("Bearer {token}");
+                HeaderValue::from_str(&header_value)
+            }
+        }?;
+        header.set_sensitive(true);
+        Ok(header)
+    }
+}

--- a/plugin-elasticsearch/src/api/de.rs
+++ b/plugin-elasticsearch/src/api/de.rs
@@ -1,0 +1,78 @@
+use serde::Deserialize;
+
+/// A response to a "create" query with the following filter (set as a query parameter):
+/// `filter_path=items.*.error`
+///
+/// # Example response
+///
+/// ```json
+/// {
+/// "items": [
+///     {
+///       "create": {
+///         "error": {
+///           "type": "version_conflict_engine_exception",
+///           "reason": "[tt1392214]: version conflict, document already exists",
+///           "index": "movies",
+///           "index_uuid": "yhizhusbSWmP0G7OJnmcLg",
+///           "shard": "0",
+///         }
+///       }
+///     }
+/// }
+/// ```
+///
+/// # Unfiltered example response
+///
+/// This is not what we are parsing here, but it shows the difference.
+///
+/// ```json
+/// {
+///     "took": 30,
+///     "errors": false,
+///     "items": [
+///        {
+///           "create": {
+///              "_index": "test",
+///              "_id": "1",
+///              "_version": 1,
+///              "result": "created",
+///              "_shards": {
+///                 "total": 2,
+///                 "successful": 1,
+///                 "failed": 0
+///              },
+///              "status": 201,
+///              "_seq_no" : 0,
+///              "_primary_term": 1
+///           }
+///        }
+///     ]
+/// }
+/// ```
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FilteredBulkCreateResponse {
+    pub items: Vec<FailedCreateResult>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FailedCreateResult {
+    pub create: CreateError,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CreateError {
+    pub error: ErrorDetails,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ErrorDetails {
+    pub r#type: String,
+    pub reason: String,
+    pub index: String,
+    pub index_uuid: String,
+    pub shard: String,
+}

--- a/plugin-elasticsearch/src/api/ser.rs
+++ b/plugin-elasticsearch/src/api/ser.rs
@@ -1,0 +1,157 @@
+//! Implementation of a small subset of the REST API of OpenSearch/ElasticSearch.
+
+use alumet::{
+    measurement::{MeasurementBuffer, MeasurementPoint, WrappedMeasurementValue},
+    pipeline::elements::output::OutputContext,
+};
+
+use serde::{ser::Error, ser::SerializeMap, Serialize};
+use serde_json::json;
+use std::{collections::HashMap, time::SystemTime};
+use time::{format_description::well_known::Rfc3339, UtcDateTime};
+
+/// OpenSearch/ElasticSearch serializer helper.
+pub struct Serializer {
+    /// Each index will be named like `"{index_prefix}-{metric_name}"`
+    pub index_prefix: String,
+
+    pub metric_unit_as_index_suffix: bool,
+}
+
+impl Serializer {
+    /// Generates the mappings for an index.
+    pub fn common_index_mappings(&self) -> serde_json::Value {
+        fn field_with_type(field: &str, data_type: &str) -> (String, serde_json::Value) {
+            (
+                field.to_string(),
+                json!({
+                    "type": data_type
+                }),
+            )
+        }
+
+        let index_props = serde_json::Map::from_iter([
+            field_with_type("@timestamp", "date_nanos"),
+            field_with_type("resource_kind", "keyword"),
+            field_with_type("resource_id", "keyword"),
+            field_with_type("consumer_kind", "keyword"),
+            field_with_type("consumer_id", "keyword"),
+        ]);
+
+        json!({
+            "properties": index_props
+        })
+    }
+
+    /// Generates the body of a bulk document creation request.
+    ///
+    /// Each measurement point is created as a separate document with a `@timestamp` field.
+    /// The remaining fields depend on the client settings.
+    pub fn body_bulk_create_docs(
+        &self,
+        measurement_points: &MeasurementBuffer,
+        ctx: &OutputContext,
+    ) -> std::io::Result<String> {
+        // The bulk body is made of (action, document) pairs.
+        // Each element is serialized as a json object and separated by a newline at the end.
+        let mut bytes = Vec::new();
+        for m in measurement_points {
+            // TODO provide m.metric.fetch_definition(ctx) ?
+
+            self.serialize_bulk_action(&mut bytes, m, ctx)?;
+            bytes.push(b'\n');
+
+            self.serialize_bulk_document(&mut bytes, m, ctx)?;
+            bytes.push(b'\n');
+        }
+
+        // SAFETY: serde_json outputs valid utf8 chars
+        Ok(unsafe { String::from_utf8_unchecked(bytes) })
+    }
+
+    fn serialize_bulk_action(
+        &self,
+        buf: &mut Vec<u8>,
+        m: &MeasurementPoint,
+        ctx: &OutputContext,
+    ) -> serde_json::Result<()> {
+        let index = {
+            // {prefix}-{metric} or {prefix}-{metric}-{suffix}
+            let metric = ctx.metrics.by_id(&m.metric).unwrap();
+            let metric_name = metric.name.to_owned();
+            let index_prefix = &self.index_prefix;
+            let mut buf = String::from(index_prefix);
+            buf.push('-');
+            buf.push_str(&metric_name);
+            if self.metric_unit_as_index_suffix {
+                let index_suffix = metric.unit.unique_name();
+                buf.push('-');
+                buf.push_str(&index_suffix);
+            };
+            buf
+        };
+        let action = BulkAction::Create { index };
+        serde_json::to_writer(buf, &action)
+    }
+
+    fn serialize_bulk_document(
+        &self,
+        buf: &mut Vec<u8>,
+        measurement: &MeasurementPoint,
+        _ctx: &OutputContext,
+    ) -> serde_json::Result<()> {
+        let doc = DocMeasurement { measurement };
+        serde_json::to_writer(buf, &doc)
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+enum BulkAction {
+    Create {
+        #[serde(rename = "_index")]
+        index: String,
+    },
+}
+
+/// A structure that allows a custom serialization of MeasurementPoints.
+struct DocMeasurement<'a> {
+    measurement: &'a MeasurementPoint,
+}
+
+impl Serialize for DocMeasurement<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(6))?;
+        let datetime = UtcDateTime::from(SystemTime::from(self.measurement.timestamp));
+        let datetime = datetime.format(&Rfc3339).map_err(S::Error::custom)?;
+        map.serialize_entry("@timestamp", &datetime)?;
+        map.serialize_entry("resource_kind", self.measurement.resource.kind())?;
+        // TODO there should be a nicer way to get a &str from a resource id without allocating a string
+        map.serialize_entry("resource_id", &self.measurement.resource.id_display().to_string())?;
+        map.serialize_entry("consumer_kind", &self.measurement.consumer.kind())?;
+        map.serialize_entry("consumer_id", &self.measurement.consumer.id_display().to_string())?;
+        match self.measurement.value {
+            WrappedMeasurementValue::F64(v) => map.serialize_entry("value", &v)?,
+            WrappedMeasurementValue::U64(v) => map.serialize_entry("value", &v)?,
+        };
+        map.end()
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct CreateIndexTemplate {
+    pub index_patterns: Vec<String>,
+    pub template: IndexTemplate,
+    pub priority: u32,
+    pub version: u32,
+    #[serde(rename = "_meta")]
+    pub meta: HashMap<String, String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct IndexTemplate {
+    pub mappings: serde_json::Value,
+}

--- a/plugin-elasticsearch/src/lib.rs
+++ b/plugin-elasticsearch/src/lib.rs
@@ -1,0 +1,4 @@
+mod api;
+mod plugin;
+
+pub use plugin::ElasticSearchPlugin;

--- a/plugin-elasticsearch/src/plugin.rs
+++ b/plugin-elasticsearch/src/plugin.rs
@@ -1,0 +1,192 @@
+use alumet::{
+    measurement::MeasurementBuffer,
+    pipeline::{
+        elements::{error::WriteError, output::OutputContext},
+        Output,
+    },
+    plugin::{
+        rust::{deserialize_config, serialize_config, AlumetPlugin},
+        AlumetPluginStart, ConfigTable,
+    },
+};
+use anyhow::Context;
+
+use crate::api;
+
+pub struct ElasticSearchPlugin {
+    config: Option<config::Config>,
+}
+
+impl AlumetPlugin for ElasticSearchPlugin {
+    fn name() -> &'static str {
+        "elasticsearch"
+    }
+
+    fn version() -> &'static str {
+        env!("CARGO_PKG_VERSION")
+    }
+
+    fn init(config: ConfigTable) -> anyhow::Result<Box<Self>> {
+        let config = deserialize_config(config)?;
+        Ok(Box::new(ElasticSearchPlugin { config }))
+    }
+
+    fn default_config() -> anyhow::Result<Option<ConfigTable>> {
+        let default = config::Config::default();
+        Ok(Some(serialize_config(default)?))
+    }
+
+    fn start(&mut self, alumet: &mut AlumetPluginStart) -> anyhow::Result<()> {
+        let config = self.config.take().unwrap();
+
+        // Parse url
+        let url = &config.server_url;
+        let url = reqwest::Url::parse(url).with_context(|| format!("invalid server url '{}'", &url))?;
+
+        // Parse auth settings
+        let auth = api::ApiAuthentication::try_from(config.auth).context("invalid auth config")?;
+
+        // Create the client
+        let client = api::Client::new(
+            api::ConnectionSettings {
+                auth,
+                server_url: url,
+                allow_insecure: config.allow_insecure,
+            },
+            api::DataSettings {
+                index_prefix: config.index_prefix,
+                metric_unit_as_index_suffix: config.metric_unit_as_index_suffix,
+            },
+        )
+        .context("failed to initialize api client")?;
+
+        // Create a template for elastic indices that will be populated by the output.
+        log::info!("Creating template for Alumet indices...");
+        client
+            .create_index_template()
+            .context("failed to create index template")?;
+
+        // Add the output
+        log::info!("Creating measurements output...");
+        let out = ElasticSearchOutput { client };
+        alumet.add_blocking_output("api", Box::new(out))?;
+
+        Ok(())
+    }
+
+    fn stop(&mut self) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+struct ElasticSearchOutput {
+    client: api::Client,
+}
+
+impl Output for ElasticSearchOutput {
+    fn write(&mut self, measurements: &MeasurementBuffer, ctx: &OutputContext) -> Result<(), WriteError> {
+        if !measurements.is_empty() {
+            self.client
+                .bulk_insert_measurements(measurements, ctx)
+                .context("failed to send measurements")?;
+        }
+        Ok(())
+    }
+}
+
+mod config {
+    use std::path::PathBuf;
+
+    use anyhow::Context;
+    use serde::{Deserialize, Serialize};
+
+    use crate::api;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct Config {
+        pub server_url: String,
+        pub auth: AuthConfig,
+        pub allow_insecure: bool,
+        pub index_prefix: String,
+        pub metric_unit_as_index_suffix: bool,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    #[serde(rename_all = "snake_case")]
+    pub enum AuthConfig {
+        ApiKey { key: String },
+        Basic { user: String, password: String },
+        BasicFile { file: String },
+        Bearer { token: String },
+    }
+
+    impl Default for Config {
+        fn default() -> Self {
+            Self {
+                server_url: String::from("http://localhost:9200"),
+                auth: AuthConfig::Basic {
+                    user: String::from("TODO"),
+                    password: String::from("TODO"),
+                },
+                allow_insecure: false,
+                index_prefix: String::from("alumet"),
+                metric_unit_as_index_suffix: false,
+            }
+        }
+    }
+
+    impl TryFrom<AuthConfig> for api::ApiAuthentication {
+        type Error = anyhow::Error;
+
+        fn try_from(value: AuthConfig) -> Result<Self, Self::Error> {
+            match value {
+                AuthConfig::ApiKey { key } => Ok(api::ApiAuthentication::ApiKey { key }),
+                AuthConfig::Basic { user, password } => Ok(api::ApiAuthentication::Basic { user, password }),
+                AuthConfig::BasicFile { file } => {
+                    let content = std::fs::read_to_string(PathBuf::from(&file))
+                        .with_context(|| format!("failed to read {file}"))?;
+                    if let Some((user, password)) = content.trim().split_once(':') {
+                        Ok(api::ApiAuthentication::Basic {
+                            user: user.to_string(),
+                            password: password.to_string(),
+                        })
+                    } else {
+                        Err(anyhow::anyhow!(
+                            "file '{file}' should contain one line of the form user:password"
+                        ))
+                    }
+                }
+                AuthConfig::Bearer { token } => Ok(api::ApiAuthentication::Bearer { token }),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::plugin::config::AuthConfig;
+
+    use super::config::Config;
+
+    #[test]
+    fn parse_config() {
+        let config = "
+            [auth.api_key]
+            key = \"abcd\"
+        ";
+        let parsed: Config = toml::from_str(config).unwrap();
+        println!("{parsed:?}");
+        assert!(matches!(parsed.auth, AuthConfig::ApiKey { key } if key == "abcd"));
+
+        let config = "
+            [auth.basic]
+            user = \"bob\"
+            password = \"very_secure\"
+        ";
+        let parsed: Config = toml::from_str(config).unwrap();
+        println!("{parsed:?}");
+        assert!(
+            matches!(parsed.auth, AuthConfig::Basic { user, password } if user == "bob" && password == "very_secure")
+        );
+    }
+}


### PR DESCRIPTION
The OpenTelemetry plugin is not enough, because it requires an intermediary program to translate between the otel protocol and the OpenSearch/ElasticSearch REST API.