### PR TITLE
feat(plugin-oar2): add attributes to harmonize with other plugins

### DIFF
--- a/plugin-cgroupv1/src/cgroupv1.rs
+++ b/plugin-cgroupv1/src/cgroupv1.rs
@@ -119,6 +119,7 @@ impl Cgroupv1Probe {
                         )))?,
                         cpu_time_delta_value,
                     )
+                    .with_attr("kind", "total")
                     .with_attr_vec(additional_attrs.clone()),
                 );
             }
@@ -139,6 +140,7 @@ impl Cgroupv1Probe {
                     )))?,
                     memory_usage_u64,
                 )
+                .with_attr("kind", "resident")
                 .with_attr_vec(additional_attrs.clone()),
             );
         }


### PR DESCRIPTION
Resolve issue while oar2 is  not harmonized with other plugins for **memory_usage** and **cpu_time_delta** metrics which have missing attributes.
