### PR TITLE
tests(plugin-rapl): refactored and added unit + integration tests

### DIFF
--- a/.github/workflows/check_git.yaml
+++ b/.github/workflows/check_git.yaml
@@ -19,23 +19,3 @@ jobs:
             echo "::error::When updating your branch, you must rebase instead of merging."
             exit 1
           fi
-
-      - name: Check that conventional commits are used
-        shell: bash
-        run: |
-          exit_code=0
-
-          commit_type_regex='build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test'
-          commit_scope_regex='\([a-zA-Z0-9_\-\.]+\)'
-          commit_summary_regex='([a-z0-9_ \.\-\`])+'
-          commit_body_regex='((\n|\r\n){2}[\s\S]+)'
-          commit_message_regex="(^(${commit_type_regex})(${commit_scope_regex})?(\!)?: ${commit_summary_regex}${commit_body_regex}?)"
-
-          while IFS= read -r commit_hash; do
-            if [[ ! "$(git log --format=%B -n 1 $commit_hash)" =~ $commit_message_regex ]]; then
-              echo "::error::Commit messages must follow conventional commits, but \"${commit_hash}\" doesn't."
-              exit_code=1
-            fi
-          done <<< "$(git log --abbrev-commit --format='%h' --no-merges ${{ github.event.pull_request.base.sha }}..)"
-
-          exit $exit_code

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2101,6 +2101,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2204,9 +2216,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.1"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openssl"
@@ -2712,9 +2724,13 @@ dependencies = [
  "humantime-serde",
  "indoc",
  "log",
+ "nix",
+ "once_cell",
  "perf-event-open-sys2",
  "regex",
  "serde",
+ "tempfile",
+ "toml",
 ]
 
 [[package]]

--- a/plugin-rapl/Cargo.toml
+++ b/plugin-rapl/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 
 [features]
 
-
 [dependencies]
 alumet = { path = "../alumet" }
 anyhow = "1.0.88"
@@ -17,6 +16,13 @@ log = "0.4.22"
 perf-event-open-sys2 = "5.0.6"
 regex = "1.10.6"
 serde = { version = "1.0.210", features = ["derive"] }
+once_cell = "1.21.3"
+
+[dev-dependencies]
+alumet = {path = "../alumet", features = ["test"]}
+toml = "0.8.19"
+tempfile = "3.20.0"
+nix = "0.30.1"
 
 [lints]
 workspace = true

--- a/plugin-rapl/src/domains.rs
+++ b/plugin-rapl/src/domains.rs
@@ -60,3 +60,25 @@ impl RaplDomainType {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rapl_domain_type_from_str() -> anyhow::Result<()> {
+        let expectations = vec![
+            ("package", Ok(RaplDomainType::Package)),
+            ("pkg", Ok(RaplDomainType::Package)),
+            ("pp0", Ok(RaplDomainType::PP0)),
+            ("pp1", Ok(RaplDomainType::PP1)),
+            ("dram", Ok(RaplDomainType::Dram)),
+            ("platform", Ok(RaplDomainType::Platform)),
+            ("unknown", Err("unknown".to_string())),
+        ];
+        for (input, expectation) in expectations {
+            assert_eq!(input.parse::<RaplDomainType>(), expectation);
+        }
+        Ok(())
+    }
+}

--- a/plugin-rapl/src/perf_event.rs
+++ b/plugin-rapl/src/perf_event.rs
@@ -11,10 +11,10 @@ use std::{
     fs::{self, File},
     io::{self, Read},
     os::fd::FromRawFd,
-    path::Path,
+    path::{Path, PathBuf},
 };
 
-use super::cpus::CpuId;
+use super::cpus::{self, CpuId};
 use super::domains::RaplDomainType;
 
 // See https://github.com/torvalds/linux/commit/4788e5b4b2338f85fa42a712a182d8afd65d7c58
@@ -22,8 +22,13 @@ use super::domains::RaplDomainType;
 
 pub(crate) const PERF_MAX_ENERGY: u64 = u64::MAX;
 pub(crate) const PERF_SYSFS_DIR: &str = "/sys/devices/power";
+const PERMISSION_ADVICE: &str = "Try to set kernel.perf_event_paranoid to 0 or -1, or to give CAP_PERFMON to the application's binary (CAP_SYS_ADMIN before Linux 5.8).";
 
-#[derive(Debug, Clone)]
+/// manages power events instantiations
+pub struct PowerEventFactory;
+
+/// describes power event metadata
+#[derive(Debug, Clone, PartialEq)]
 pub struct PowerEvent {
     /// The name of the power event, as reported by the sysfs. This corresponds to a RAPL **domain name**, like "pkg".
     pub name: String,
@@ -36,6 +41,136 @@ pub struct PowerEvent {
     /// The scale to apply in order to get joules (`energy_j = count * scale`).
     /// Should be "0x1.0p-32" (thus, f32 is fine)
     pub scale: f32,
+}
+
+/// manages power event counter collection
+struct OpenedPowerEvent {
+    fd: File,
+    scale: f64,
+    domain: RaplDomainType,
+    resource: Resource,
+    counter: CounterDiff,
+}
+
+/// Energy probe based on perf_event for intel RAPL.
+pub struct PerfEventProbe {
+    /// Id of the metric to push.
+    metric: TypedMetricId<f64>,
+    /// Ready-to-use power events with additional metadata.
+    events: Vec<OpenedPowerEvent>,
+}
+
+/// Retrieves all RAPL power events from /sys/devices/power base path.
+/// See all_power_events_from_path comments for more details
+pub fn all_power_events() -> Result<Vec<PowerEvent>> {
+    all_power_events_from_path(Path::new(PERF_SYSFS_DIR))
+}
+
+/// Retrieves all RAPL power events from a given base path (eg: /sys/devices/power)
+/// There can be more than just `cores`, `pkg` and `dram`.
+/// For instance, there can be `gpu` and
+/// [`psys`](https://patchwork.kernel.org/project/linux-pm/patch/1458253409-13318-1-git-send-email-srinivas.pandruvada@linux.intel.com/).
+pub fn all_power_events_from_path(base_path: &Path) -> Result<Vec<PowerEvent>> {
+    let mut events: Vec<PowerEvent> = Vec::new();
+
+    // Find all the events
+    let power_event_dir = base_path.join("events");
+    for e in fs::read_dir(&power_event_dir).context(format!(
+        "Could not read {}. {PERMISSION_ADVICE}",
+        power_event_dir
+            .into_os_string()
+            .into_string()
+            .expect("error while converting power_event_dir to string")
+    ))? {
+        let entry = e?;
+        let path = entry.path();
+        if let Some(power_event) = PowerEventFactory::from_path(&path)? {
+            events.push(power_event);
+        }
+    }
+    Ok(events)
+}
+
+impl PowerEventFactory {
+    /// creates a new PowerEvent from an event base path. In case the path is not identified as a RAPL event one, None will be returned.
+    /// (eg: /sys/devices/power/events/energy-cores)
+    pub fn from_path(base_path: &Path) -> anyhow::Result<Option<PowerEvent>> {
+        let name = match Self::name_from_base_path(base_path)? {
+            Some(name) => name,
+            None => return Ok(None),
+        };
+        let code = Self::code_from_base_path(base_path)?;
+        let unit = Self::unit_from_base_path(base_path)?;
+        let scale = Self::scale_from_base_path(base_path)?;
+        let domain = Self::domain_type_from_name(&name).with_context(|| format!("Unknown RAPL perf event {name}"))?;
+
+        Ok(Some(PowerEvent {
+            name,
+            domain,
+            code,
+            unit,
+            scale,
+        }))
+    }
+
+    fn name_from_base_path(path: &Path) -> Result<Option<String>> {
+        if !path.is_file() {
+            return Ok(None);
+        }
+
+        let file_name = path
+            .file_name()
+            .with_context(|| format!("path has no file name: {:?}", path))?
+            .to_string_lossy();
+
+        if file_name.contains('.') {
+            return Ok(None);
+        }
+
+        match file_name.strip_prefix("energy-") {
+            Some(event_name) => Ok(Some(event_name.to_owned())),
+            None => Ok(None),
+        }
+    }
+
+    fn domain_type_from_name(name: &str) -> Option<RaplDomainType> {
+        match name {
+            "cores" => Some(RaplDomainType::PP0),
+            "gpu" => Some(RaplDomainType::PP1),
+            "psys" => Some(RaplDomainType::Platform),
+            "pkg" => Some(RaplDomainType::Package),
+            "ram" => Some(RaplDomainType::Dram),
+            _ => None,
+        }
+    }
+
+    fn code_from_base_path(path: &Path) -> Result<u8> {
+        let read = fs::read_to_string(path).with_context(|| format!("Could not read {path:?}. {PERMISSION_ADVICE}"))?;
+        let code_str = read
+            .trim_end()
+            .strip_prefix("event=0x")
+            .with_context(|| format!("Failed to strip {path:?}: '{read}'"))?;
+        let code = u8::from_str_radix(code_str, 16).with_context(|| format!("Failed to parse {path:?}: '{read}'"))?; // hexadecimal
+        Ok(code)
+    }
+
+    fn unit_from_base_path(path: &Path) -> Result<String> {
+        let mut path = path.to_path_buf();
+        path.set_extension("unit");
+        let unit_str = fs::read_to_string(path)?.trim_end().to_string();
+        Ok(unit_str)
+    }
+
+    fn scale_from_base_path(path: &Path) -> Result<f32> {
+        let mut path = path.to_path_buf();
+        path.set_extension("scale");
+        let read = fs::read_to_string(&path)?;
+        let scale = read
+            .trim_end()
+            .parse()
+            .with_context(|| format!("Failed to parse {path:?}: '{read}'"))?;
+        Ok(scale)
+    }
 }
 
 impl PowerEvent {
@@ -65,142 +200,117 @@ impl PowerEvent {
             Ok(result)
         }
     }
+
+    /// creates a new OpenedPowerEvent from Self by opening the file using file descriptor provided by perf_event
+    fn open(&self, pmu_type: u32, cpu: u32, socket: u32) -> anyhow::Result<OpenedPowerEvent> {
+        let raw_fd = self.perf_event_open(pmu_type, cpu)?;
+        let fd = unsafe { File::from_raw_fd(raw_fd) };
+        Ok(OpenedPowerEvent {
+            fd,
+            scale: self.scale as f64,
+            domain: self.domain,
+            resource: self.domain.to_resource(socket),
+            counter: CounterDiff::with_max_value(PERF_MAX_ENERGY),
+        })
+    }
 }
 
-/// Retrieves the type of the RAPL PMU (Power Monitoring Unit) in the Linux kernel.
-pub fn pmu_type() -> Result<u32> {
-    let path = Path::new("/sys/devices/power/type");
-    let read = fs::read_to_string(path).with_context(|| format!("Failed to read {path:?}"))?;
-    let typ = read
-        .trim_end()
-        .parse()
-        .with_context(|| format!("Failed to parse {path:?}: '{read}'"))?;
-    Ok(typ)
-}
-
-/// Retrieves all RAPL power events exposed in sysfs.
-/// There can be more than just `cores`, `pkg` and `dram`.
-/// For instance, there can be `gpu` and
-/// [`psys`](https://patchwork.kernel.org/project/linux-pm/patch/1458253409-13318-1-git-send-email-srinivas.pandruvada@linux.intel.com/).
-pub fn all_power_events() -> Result<Vec<PowerEvent>> {
-    const ADVICE: &str = "Try to set kernel.perf_event_paranoid to 0 or -1, or to adjust file permissions.";
-
-    let mut events: Vec<PowerEvent> = Vec::new();
-
-    fn read_event_code(path: &Path) -> Result<u8> {
-        let read = fs::read_to_string(path).with_context(|| format!("Could not read {path:?}. {ADVICE}"))?;
-        let code_str = read
-            .trim_end()
-            .strip_prefix("event=0x")
-            .with_context(|| format!("Failed to strip {path:?}: '{read}'"))?;
-        let code = u8::from_str_radix(code_str, 16).with_context(|| format!("Failed to parse {path:?}: '{read}'"))?; // hexadecimal
-        Ok(code)
-    }
-
-    fn read_event_unit(main: &Path) -> Result<String> {
-        let mut path = main.to_path_buf();
-        path.set_extension("unit");
-        let unit_str = fs::read_to_string(path)?.trim_end().to_string();
-        Ok(unit_str)
-    }
-
-    fn read_event_scale(main: &Path) -> Result<f32> {
-        let mut path = main.to_path_buf();
-        path.set_extension("scale");
-        let read = fs::read_to_string(&path)?;
-        let scale = read
-            .trim_end()
-            .parse()
-            .with_context(|| format!("Failed to parse {path:?}: '{read}'"))?;
-        Ok(scale)
-    }
-
-    fn parse_event_name(name: &str) -> Option<RaplDomainType> {
-        match name {
-            "cores" => Some(RaplDomainType::PP0),
-            "gpu" => Some(RaplDomainType::PP1),
-            "psys" => Some(RaplDomainType::Platform),
-            "pkg" => Some(RaplDomainType::Package),
-            "ram" => Some(RaplDomainType::Dram),
-            _ => None,
+impl OpenedPowerEvent {
+    fn read_counter_diff_in_joules(&mut self) -> anyhow::Result<Option<f64>> {
+        match self.read_counter_diff()? {
+            Some(diff) => Ok(Some((diff as f64) * self.scale)),
+            None => Ok(None),
         }
     }
 
-    // Find all the events
-    let power_event_dir = "/sys/devices/power/events";
-    for e in fs::read_dir(power_event_dir).with_context(|| format!("Could not read {power_event_dir}. {ADVICE}"))? {
-        let entry = e?;
-        let path = entry.path();
-        let file_name = path.file_name().unwrap().to_string_lossy();
-        // only list the main file, not *.unit nor *.scale
-        if path.is_file() && !file_name.contains('.') {
-            // The files are named "energy-pkg", "energy-dram", ...
-            if let Some(event_name) = file_name.strip_prefix("energy-") {
-                // We have the name of the event, we can read all the info
-                let name = event_name.to_owned();
-                let code = read_event_code(&path)?;
-                let unit = read_event_unit(&path)?;
-                let scale = read_event_scale(&path)?;
-                let domain = parse_event_name(&name).with_context(|| format!("Unknown RAPL perf event {name}"))?;
-                events.push(PowerEvent {
-                    name,
-                    domain,
-                    code,
-                    unit,
-                    scale,
-                })
+    fn read_counter_diff(&mut self) -> anyhow::Result<Option<u64>> {
+        let counter_value = self.read_counter_value().context(format!(
+            "failed to read perf_event {:?} for domain {:?}",
+            self.fd, self.domain
+        ))?;
+
+        // correct any overflows
+        Ok(match self.counter.update(counter_value) {
+            CounterDiffUpdate::FirstTime => None,
+            CounterDiffUpdate::Difference(diff) => Some(diff),
+            CounterDiffUpdate::CorrectedDifference(diff) => {
+                log::debug!("Overflow on perf_event counter for RAPL domain {}", self.domain);
+                Some(diff)
             }
-        }
+        })
     }
-    Ok(events)
-}
 
-fn read_perf_event(fd: &mut File) -> io::Result<u64> {
-    let mut buf = [0u8; 8];
-    // rewind() is INVALID for perf events, we must read "at the cursor" every time
-    let _ = fd.read(&mut buf)?;
-    Ok(u64::from_ne_bytes(buf))
-}
-
-/// Energy probe based on perf_event for intel RAPL.
-pub struct PerfEventProbe {
-    /// Id of the metric to push.
-    metric: TypedMetricId<f64>,
-    /// Ready-to-use power events with additional metadata.
-    events: Vec<OpenedPowerEvent>,
-}
-
-struct OpenedPowerEvent {
-    fd: File,
-    scale: f64,
-    domain: RaplDomainType,
-    resource: Resource,
-    counter: CounterDiff,
+    fn read_counter_value(&mut self) -> io::Result<u64> {
+        let mut buf = [0u8; 8];
+        // rewind() is INVALID for perf events, we must read "at the cursor" every time
+        let _ = self.fd.read(&mut buf)?;
+        Ok(u64::from_ne_bytes(buf))
+    }
 }
 
 impl PerfEventProbe {
-    pub fn new(metric: TypedMetricId<f64>, events_on_cpus: &[(&PowerEvent, &CpuId)]) -> anyhow::Result<PerfEventProbe> {
-        const ADVICE: &str = "Try to set kernel.perf_event_paranoid to 0 or -1, or to give CAP_PERFMON to the application's binary (CAP_SYS_ADMIN before Linux 5.8).";
+    /// creates a new PerfEventProbe by passing an Alumet metric ID for energy measurement and related power events
+    pub fn new(metric: TypedMetricId<f64>, power_events: &Vec<PowerEvent>) -> anyhow::Result<PerfEventProbe> {
+        let all_cpus = cpus::online_cpus()?;
+        let socket_cpus = cpus::cpus_to_monitor_with_perf()
+        .context("I could not determine how to use perf_events to read RAPL energy counters. The Intel RAPL PMU module may not be enabled, is your Linux kernel too old?")?;
 
-        let pmu_type = pmu_type()?;
-        let mut opened = Vec::with_capacity(events_on_cpus.len());
-        for (event, CpuId { cpu, socket }) in events_on_cpus {
-            let raw_fd = event
-                .perf_event_open(pmu_type, *cpu)
-                .with_context(|| format!("perf_event_open failed. {ADVICE}"))?;
-            let fd = unsafe { File::from_raw_fd(raw_fd) };
-            let scale = event.scale as f64;
-            let counter = CounterDiff::with_max_value(PERF_MAX_ENERGY);
-            let opened_event = OpenedPowerEvent {
-                fd,
-                scale,
-                domain: event.domain,
-                resource: event.domain.to_resource(*socket),
-                counter,
-            };
-            opened.push(opened_event)
+        let n_sockets = socket_cpus.len();
+        let n_cpu_cores = all_cpus.len();
+        log::debug!("{n_sockets}/{n_cpu_cores} monitorable CPU (cores) found: {socket_cpus:?}");
+
+        // Build the right combination of perf events.
+        let mut events_on_cpus = Vec::new();
+        for event in power_events {
+            for cpu in &socket_cpus {
+                events_on_cpus.push((event, cpu));
+            }
         }
-        Ok(PerfEventProbe { metric, events: opened })
+        log::debug!("Events to read: {events_on_cpus:?}");
+
+        match pmu_type() {
+            Ok(pmu_type) => {
+                let mut opened = Vec::with_capacity(events_on_cpus.len());
+                for (event, CpuId { cpu, socket }) in events_on_cpus {
+                    match event.open(pmu_type, *cpu, *socket) {
+                        Ok(opened_zone) => opened.push(opened_zone),
+                        Err(e) => {
+                            Self::handle_insufficient_privileges(&e);
+                            return Err(e);
+                        }
+                    }
+                }
+                Ok(PerfEventProbe { metric, events: opened })
+            }
+            Err(e) => {
+                Self::handle_insufficient_privileges(&e);
+                Err(e)
+            }
+        }
+    }
+
+    fn handle_insufficient_privileges(e: &anyhow::Error) {
+        fn resolve_application_path() -> std::io::Result<PathBuf> {
+            std::env::current_exe()?.canonicalize()
+        }
+        let app_path = resolve_application_path()
+            .ok()
+            .and_then(|p| p.to_str().map(|s| s.to_owned()))
+            .unwrap_or(String::from("path/to/agent"));
+        let msg = indoc::formatdoc! {"
+            I could not use perf_events to read RAPL energy counters: {e}.
+            This warning is probably caused by insufficient privileges.
+            To fix this, you have 3 possibilities:
+            1. Grant the CAP_PERFMON (CAP_SYS_ADMIN on Linux < 5.8) capability to the agent binary.
+                sudo setcap cap_perfmon=ep \"{app_path}\"        
+                Note: to grant multiple capabilities to the binary, you must put all the capabilities in the same command.
+                sudo setcap \"cap_sys_nice+ep cap_perfmon=ep\" \"{app_path}\" 
+                    
+            2. Change a kernel setting to allow every process to read the perf_events.
+                sudo sysctl -w kernel.perf_event_paranoid=0
+                    
+            3. Run the agent as root (not recommanded)."};
+        log::warn!("{msg}");
     }
 }
 
@@ -208,21 +318,7 @@ impl alumet::pipeline::Source for PerfEventProbe {
     fn poll(&mut self, measurements: &mut MeasurementAccumulator, timestamp: Timestamp) -> Result<(), PollError> {
         for evt in &mut self.events {
             // read the new value of the perf-events counter
-            let counter_value = read_perf_event(&mut evt.fd)
-                .with_context(|| format!("failed to read perf_event {:?} for domain {:?}", evt.fd, evt.domain))?;
-
-            // correct any overflows
-            let diff = match evt.counter.update(counter_value) {
-                CounterDiffUpdate::FirstTime => None,
-                CounterDiffUpdate::Difference(diff) => Some(diff),
-                CounterDiffUpdate::CorrectedDifference(diff) => {
-                    log::debug!("Overflow on perf_event counter for RAPL domain {}", evt.domain);
-                    Some(diff)
-                }
-            };
-            if let Some(value) = diff {
-                // convert to joules and push
-                let joules = (value as f64) * evt.scale;
+            if let Some(joules) = evt.read_counter_diff_in_joules()? {
                 let consumer = ResourceConsumer::LocalMachine;
                 measurements.push(
                     MeasurementPoint::new(timestamp, self.metric, evt.resource.clone(), consumer, joules)
@@ -238,6 +334,190 @@ impl alumet::pipeline::Source for PerfEventProbe {
             // up to approximately 2^24, which is not enough for the RAPL counter values,
             // so we use a f64 here.
         }
+        Ok(())
+    }
+}
+
+/// Retrieves the type of the RAPL PMU (Power Monitoring Unit) in the Linux kernel.
+fn pmu_type() -> Result<u32> {
+    pmu_type_from_path(Path::new("/sys/devices/power/type"))
+}
+
+/// Retrieves the type of the RAPL PMU (Power Monitoring Unit) in the Linux kernel.
+fn pmu_type_from_path(path: &Path) -> Result<u32> {
+    let read = fs::read_to_string(path).with_context(|| format!("Failed to read {path:?}"))?;
+    let typ = read
+        .trim_end()
+        .parse()
+        .with_context(|| format!("Failed to parse {path:?}: '{read}'"))?;
+    Ok(typ)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests_mock::*;
+
+    use nix::unistd::write;
+    use std::os::fd::OwnedFd;
+    use tempfile::tempdir;
+
+    #[cfg(test)]
+    #[test]
+    fn test_pmu_type() -> anyhow::Result<()> {
+        let tmp = tempdir()?;
+        let base_path = tmp.keep();
+
+        use EntryType::*;
+        let pmu_type_entry = Entry {
+            path: "pmu_type",
+            entry_type: File("32"),
+        };
+        create_mock_layout(base_path.clone(), &[pmu_type_entry])?;
+        let actual = pmu_type_from_path(&base_path.join("pmu_type"))?;
+        let expected = 32;
+
+        assert_eq!(actual, expected);
+
+        Ok(())
+    }
+
+    #[cfg(test)]
+    #[test]
+    fn test_open_all() -> anyhow::Result<()> {
+        let tmp = tempdir()?;
+        let base_path = tmp.keep();
+
+        use EntryType::*;
+        let perf_event_entries = [
+            Entry {
+                path: "events",
+                entry_type: Dir,
+            },
+            Entry {
+                path: "events/energy-cores",
+                entry_type: File("event=0x01"),
+            },
+            Entry {
+                path: "events/energy-cores.scale",
+                entry_type: File("2.3283064365386962890625e-10"),
+            },
+            Entry {
+                path: "events/energy-cores.unit",
+                entry_type: File("Joules"),
+            },
+            Entry {
+                path: "events/energy-pkg",
+                entry_type: File("event=0x02"),
+            },
+            Entry {
+                path: "events/energy-pkg.scale",
+                entry_type: File("2.3283064365386962890625e-10"),
+            },
+            Entry {
+                path: "events/energy-pkg.unit",
+                entry_type: File("Joules"),
+            },
+            Entry {
+                path: "events/energy-psys",
+                entry_type: File("event=0x05"),
+            },
+            Entry {
+                path: "events/energy-psys.scale",
+                entry_type: File("2.3283064365386962890625e-10"),
+            },
+            Entry {
+                path: "events/energy-psys.unit",
+                entry_type: File("Joules"),
+            },
+        ];
+
+        create_mock_layout(base_path.clone(), &perf_event_entries)?;
+
+        let mut actual_power_events = all_power_events_from_path(base_path.as_path())?;
+
+        let mut expected_power_events = vec![
+            PowerEvent {
+                name: "psys".to_string(),
+                domain: RaplDomainType::Platform,
+                code: 5,
+                unit: "Joules".to_string(),
+                scale: 2.3283064365386962890625e-10,
+            },
+            PowerEvent {
+                name: "pkg".to_string(),
+                domain: RaplDomainType::Package,
+                code: 2,
+                unit: "Joules".to_string(),
+                scale: 2.3283064365386962890625e-10,
+            },
+            PowerEvent {
+                name: "cores".to_string(),
+                domain: RaplDomainType::PP0,
+                code: 1,
+                unit: "Joules".to_string(),
+                scale: 2.3283064365386962890625e-10,
+            },
+        ];
+
+        actual_power_events.sort_by_key(|e: &PowerEvent| e.name.clone());
+        expected_power_events.sort_by_key(|e: &PowerEvent| e.name.clone());
+
+        assert_eq!(actual_power_events, expected_power_events);
+
+        Ok(())
+    }
+
+    fn fake_opened_power_event() -> (OpenedPowerEvent, OwnedFd) {
+        use nix::unistd::pipe;
+        use std::os::fd::IntoRawFd;
+        use std::os::unix::io::FromRawFd;
+
+        let (read_fd, write_fd) = pipe().unwrap();
+
+        let file = unsafe { File::from_raw_fd(read_fd.into_raw_fd()) };
+        (
+            OpenedPowerEvent {
+                fd: file,
+                scale: 2.3283064365386962890625e-10,
+                domain: RaplDomainType::Package, // dummy value
+                resource: RaplDomainType::Package.to_resource(0),
+                counter: CounterDiff::with_max_value(PERF_MAX_ENERGY),
+            },
+            write_fd,
+        )
+    }
+
+    #[cfg(test)]
+    #[test]
+    fn test_opened_power_event() -> anyhow::Result<()> {
+        let (mut opened_power_event, write_fd) = fake_opened_power_event();
+
+        let val1 = 42u64.to_ne_bytes();
+        write(&write_fd, &val1)?;
+        let value = opened_power_event.read_counter_value()?;
+        assert_eq!(value, 42);
+
+        let val2 = 43u64.to_ne_bytes();
+        write(&write_fd, &val2)?;
+        let value = opened_power_event.read_counter_value()?;
+        assert_eq!(value, 43);
+
+        let val3 = 44u64.to_ne_bytes();
+        write(&write_fd, &val3)?;
+        let value = opened_power_event.read_counter_diff()?;
+        assert_eq!(value, None);
+
+        let val4 = 45u64.to_ne_bytes();
+        write(&write_fd, &val4)?;
+        let value = opened_power_event.read_counter_diff()?;
+        assert_eq!(value, Some(1));
+
+        let val5 = 4294967341u64.to_ne_bytes();
+        write(&write_fd, &val5)?;
+        let value = opened_power_event.read_counter_diff_in_joules()?;
+        assert_eq!(value, Some(1.0));
+
         Ok(())
     }
 }

--- a/plugin-rapl/src/powercap.rs
+++ b/plugin-rapl/src/powercap.rs
@@ -8,6 +8,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use super::domains::RaplDomainType;
 use alumet::plugin::util::{CounterDiff, CounterDiffUpdate};
 use alumet::resources::Resource;
 use alumet::{
@@ -17,15 +18,14 @@ use alumet::{
 use alumet::{metrics::TypedMetricId, pipeline::elements::error::PollError};
 use anyhow::{anyhow, Context};
 
-use super::domains::RaplDomainType;
-
-const POWERCAP_RAPL_PATH: &str = "/sys/devices/virtual/powercap/intel-rapl";
+pub const POWERCAP_RAPL_PATH: &str = "/sys/devices/virtual/powercap/intel-rapl";
 const POWER_ZONE_PREFIX: &str = "intel-rapl";
 const POWERCAP_ENERGY_UNIT: f64 = 0.000_001; // 1 microJoules
 
 const PERMISSION_ADVICE: &str = "Try to adjust file permissions.";
 
 /// Hierarchy of power zones
+#[derive(Debug)]
 pub struct PowerZoneHierarchy {
     /// All the zones in the same Vec.
     pub flat: Vec<PowerZone>,
@@ -33,8 +33,10 @@ pub struct PowerZoneHierarchy {
     pub top: Vec<PowerZone>,
 }
 
+pub struct PowerZoneFactory;
+
 /// A power zone.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PowerZone {
     /// The name of the zone, as returned by powercap, for instance `package-0` or `core`.
     pub name: String,
@@ -50,11 +52,133 @@ pub struct PowerZone {
     /// On my machine, that zone is named `package-0`.
     pub path: PathBuf,
 
-    /// The sub-zones (can be empty).
-    pub children: Vec<PowerZone>,
-
     /// The id of the socket that "contains" this zone, if applicable (psys has no socket)
     pub socket_id: Option<u32>,
+
+    pub children: Vec<PowerZone>,
+}
+
+/// manages power zone counter collection
+struct OpenedPowerZone {
+    file: File,
+    domain: RaplDomainType,
+    /// The corresponding ResourceId
+    resource: Resource,
+    /// Overflow-correcting counter, to compute the energy consumption difference.
+    counter: CounterDiff,
+}
+
+/// Powercap probe collects Alumet metrics related to power zones
+pub struct PowercapProbe {
+    metric: TypedMetricId<f64>,
+
+    /// Ready-to-use powercap zones with additional metadata
+    zones: Vec<OpenedPowerZone>,
+}
+
+/// Retrieves all Powercap power zones from /sys/devices/virtual/powercap/intel-rapl base path.
+pub fn all_power_zones() -> anyhow::Result<PowerZoneHierarchy> {
+    all_power_zones_from_path(Path::new(POWERCAP_RAPL_PATH))
+}
+
+pub fn all_power_zones_from_path(path: &Path) -> anyhow::Result<PowerZoneHierarchy> {
+    fn collect_zones_recursive(zone: &PowerZone, flat: &mut Vec<PowerZone>) {
+        flat.push(zone.clone());
+        for child in &zone.children {
+            collect_zones_recursive(child, flat);
+        }
+    }
+
+    let mut top = Vec::new();
+    let mut flat = Vec::new();
+    for e in fs::read_dir(path)? {
+        let entry = e?;
+        let path = entry.path();
+        if let Some(zone) = PowerZoneFactory::from_path(&path)? {
+            top.push(zone.clone());
+            collect_zones_recursive(&zone, &mut flat);
+        }
+    }
+
+    top.sort_by_key(|z: &PowerZone| z.path.to_string_lossy().to_string());
+    flat.sort_by_key(|z: &PowerZone| z.path.to_string_lossy().to_string());
+    Ok(PowerZoneHierarchy { top, flat })
+}
+
+impl PowerZoneFactory {
+    /// creates a new PowerZone from a zone base path. In case the path is not identified as a zone path, None will be returned.
+    /// (eg: /sys/devices/virtual/powercap/intel-rapl/intel-rapl:0)
+    fn from_path(path: &Path) -> anyhow::Result<Option<PowerZone>> {
+        Ok(match Self::is_zone_path(path) {
+            true => Some(Self::get_zone_from_path(path)?),
+            false => None,
+        })
+    }
+
+    fn get_zone_from_path(path: &Path) -> anyhow::Result<PowerZone> {
+        let name_path = path.join("name");
+        let name = fs::read_to_string(&name_path)?.trim().to_owned();
+        let socket_id = match Self::socket_id_from_name(&name)? {
+            Some(socket_id) => Some(socket_id),
+            None => {
+                if let Some(parent_path) = path.parent() {
+                    let parent_name_path = parent_path.join("name");
+                    if fs::exists(&parent_name_path)? {
+                        let parent_name = fs::read_to_string(&parent_name_path)?.trim().to_owned();
+                        Self::socket_id_from_name(&parent_name)?
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            }
+        };
+        let domain = Self::domain_from_name(&name).with_context(|| format!("Unknown RAPL powercap zone {name}"))?;
+        let mut children: Vec<PowerZone> = Vec::new();
+        for e in fs::read_dir(path)? {
+            let entry = e?;
+            let child_path = entry.path();
+            if let Some(child) = PowerZoneFactory::from_path(&child_path)? {
+                children.push(child);
+            }
+        }
+        Ok(PowerZone {
+            name,
+            domain,
+            path: path.to_path_buf(),
+            socket_id,
+            children,
+        })
+    }
+
+    fn is_zone_path(path: &Path) -> bool {
+        let file_name = path.file_name().unwrap().to_string_lossy();
+        path.is_dir() && file_name.starts_with(POWER_ZONE_PREFIX)
+    }
+
+    fn socket_id_from_name(name: &str) -> anyhow::Result<Option<u32>> {
+        match name.strip_prefix("package-") {
+            Some(id_str) => {
+                let id: u32 = id_str
+                    .parse()
+                    .with_context(|| format!("failed to extract package id from '{name}'"))?;
+                Ok(Some(id))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn domain_from_name(name: &str) -> Option<RaplDomainType> {
+        match name {
+            "psys" => Some(RaplDomainType::Platform),
+            "core" => Some(RaplDomainType::PP0),
+            "uncore" => Some(RaplDomainType::PP1),
+            "dram" => Some(RaplDomainType::Dram),
+            _ if name.starts_with("package-") => Some(RaplDomainType::Package),
+            _ => None,
+        }
+    }
 }
 
 impl PowerZone {
@@ -64,6 +188,38 @@ impl PowerZone {
 
     pub fn max_energy_path(&self) -> PathBuf {
         self.path.join("max_energy_range_uj")
+    }
+
+    /// creates a new OpenedPowerZone from Self by opening the collection file
+    fn open(&self) -> anyhow::Result<OpenedPowerZone> {
+        let file = File::open(self.energy_path()).with_context(|| {
+            format!(
+                "Could not open {}. {PERMISSION_ADVICE}",
+                self.energy_path().to_string_lossy()
+            )
+        })?;
+
+        let str_max_energy_uj = fs::read_to_string(self.max_energy_path()).with_context(|| {
+            format!(
+                "Could not read {}. {PERMISSION_ADVICE}",
+                self.max_energy_path().to_string_lossy()
+            )
+        })?;
+
+        let max_energy_uj = str_max_energy_uj
+            .trim_end()
+            .parse()
+            .with_context(|| format!("parse max_energy_uj: '{str_max_energy_uj}'"))?;
+
+        let socket = self.socket_id.unwrap_or(0); // put psys in socket 0
+
+        let counter = CounterDiff::with_max_value(max_energy_uj);
+        Ok(OpenedPowerZone {
+            file,
+            domain: self.domain,
+            resource: self.domain.to_resource(socket),
+            counter,
+        })
     }
 
     fn fmt_rec(&self, f: &mut std::fmt::Formatter<'_>, level: i8) -> std::fmt::Result {
@@ -90,125 +246,76 @@ impl Display for PowerZone {
     }
 }
 
-/// Discovers all the RAPL power zones in the powercap sysfs.
-pub fn all_power_zones() -> anyhow::Result<PowerZoneHierarchy> {
-    fn parse_zone_name(name: &str) -> Option<RaplDomainType> {
-        match name {
-            "psys" => Some(RaplDomainType::Platform),
-            "core" => Some(RaplDomainType::PP0),
-            "uncore" => Some(RaplDomainType::PP1),
-            "dram" => Some(RaplDomainType::Dram),
-            _ if name.starts_with("package-") => Some(RaplDomainType::Package),
-            _ => None,
+impl OpenedPowerZone {
+    fn read_counter_diff_in_joules(&mut self, self_reading_buf: &mut Vec<u8>) -> anyhow::Result<Option<f64>> {
+        // convert to joules and push
+        match self.read_counter_diff(self_reading_buf)? {
+            Some(diff) => Ok(Some((diff as f64) * POWERCAP_ENERGY_UNIT)),
+            None => Ok(None),
         }
     }
 
-    /// Recursively explore a power zone
-    fn explore_rec(
-        dir: &Path,
-        parent_socket: Option<u32>,
-        flat: &mut Vec<PowerZone>,
-    ) -> anyhow::Result<Vec<PowerZone>> {
-        let mut zones = Vec::new();
-        for e in fs::read_dir(dir)? {
-            let entry = e?;
-            let path = entry.path();
-            let file_name = path.file_name().unwrap().to_string_lossy();
-
-            if path.is_dir() && file_name.starts_with(POWER_ZONE_PREFIX) {
-                let name_path = path.join("name");
-                let name = fs::read_to_string(&name_path)?.trim().to_owned();
-                let socket_id = {
-                    if let Some(parent_id) = parent_socket {
-                        Some(parent_id)
-                    } else if let Some(id_str) = name.strip_prefix("package-") {
-                        let id: u32 = id_str
-                            .parse()
-                            .with_context(|| format!("Failed to extract package id from '{name}'"))?;
-                        Some(id)
-                    } else {
-                        None
-                    }
-                };
-                let domain = parse_zone_name(&name).with_context(|| format!("Unknown RAPL powercap zone {name}"))?;
-                let children = explore_rec(&path, socket_id, flat)?; // recursively explore
-                let zone = PowerZone {
-                    name,
-                    domain,
-                    path,
-                    children,
-                    socket_id,
-                };
-                zones.push(zone.clone());
-                flat.push(zone);
+    fn read_counter_diff(&mut self, self_reading_buf: &mut Vec<u8>) -> anyhow::Result<Option<u64>> {
+        let energy_uj_value = self.read_counter_value(self_reading_buf)?;
+        // store the value, handle the overflow if there is one
+        Ok(match self.counter.update(energy_uj_value) {
+            CounterDiffUpdate::FirstTime => None,
+            CounterDiffUpdate::Difference(diff) => Some(diff),
+            CounterDiffUpdate::CorrectedDifference(diff) => {
+                log::debug!("Overflow on powercap counter for RAPL domain {}", self.domain);
+                Some(diff)
             }
-        }
-        zones.sort_by_key(|z| z.path.to_string_lossy().to_string());
-        Ok(zones)
+        })
     }
-    let mut flat = Vec::new();
-    let top = explore_rec(Path::new(POWERCAP_RAPL_PATH), None, &mut flat)
-        .with_context(|| format!("Could not explore {POWERCAP_RAPL_PATH}. {PERMISSION_ADVICE}"))?;
-    Ok(PowerZoneHierarchy { flat, top })
-}
 
-/// Powercap probe
-pub struct PowercapProbe {
-    metric: TypedMetricId<f64>,
+    fn read_counter_value(&mut self, self_reading_buf: &mut Vec<u8>) -> anyhow::Result<u64> {
+        // read the file from the beginning
+        self.file
+            .rewind()
+            .with_context(|| format!("failed to rewind {:?}", self.file))?;
+        self.file
+            .read_to_end(self_reading_buf)
+            .with_context(|| format!("failed to read {:?}", self.file))?;
 
-    /// Ready-to-use powercap zones with additional metadata
-    zones: Vec<OpenedZone>,
-}
-
-struct OpenedZone {
-    file: File,
-    domain: RaplDomainType,
-    /// The corresponding ResourceId
-    resource: Resource,
-    /// Overflow-correcting counter, to compute the energy consumption difference.
-    counter: CounterDiff,
+        // parse the content of the file
+        let content = std::str::from_utf8(self_reading_buf)?;
+        content
+            .trim_end()
+            .parse()
+            .with_context(|| format!("failed to parse {:?}: '{content}'", self.file))
+    }
 }
 
 impl PowercapProbe {
-    pub fn new(metric: TypedMetricId<f64>, zones: &[PowerZone]) -> anyhow::Result<PowercapProbe> {
+    /// creates a new PowercapProbe by passing an Alumet metric ID for energy measurement and related power zones
+    pub fn new(metric: TypedMetricId<f64>, zones: &Vec<PowerZone>) -> anyhow::Result<PowercapProbe> {
         if zones.is_empty() {
             return Err(anyhow!("At least one power zone is required for PowercapProbe"))?;
         }
 
         let mut opened = Vec::with_capacity(zones.len());
         for zone in zones {
-            let file = File::open(zone.energy_path()).with_context(|| {
-                format!(
-                    "Could not open {}. {PERMISSION_ADVICE}",
-                    zone.energy_path().to_string_lossy()
-                )
-            })?;
-
-            let str_max_energy_uj = fs::read_to_string(zone.max_energy_path()).with_context(|| {
-                format!(
-                    "Could not read {}. {PERMISSION_ADVICE}",
-                    zone.max_energy_path().to_string_lossy()
-                )
-            })?;
-
-            let max_energy_uj = str_max_energy_uj
-                .trim_end()
-                .parse()
-                .with_context(|| format!("parse max_energy_uj: '{str_max_energy_uj}'"))?;
-
-            let socket = zone.socket_id.unwrap_or(0); // put psys in socket 0
-
-            let counter = CounterDiff::with_max_value(max_energy_uj);
-            let opened_zone = OpenedZone {
-                file,
-                domain: zone.domain,
-                resource: zone.domain.to_resource(socket),
-                counter,
-            };
-            opened.push(opened_zone);
+            match zone.open() {
+                Ok(opened_zone) => opened.push(opened_zone),
+                Err(e) => {
+                    Self::handle_insufficient_privileges(&e);
+                    return Err(e);
+                }
+            }
         }
 
         Ok(PowercapProbe { metric, zones: opened })
+    }
+
+    fn handle_insufficient_privileges(e: &anyhow::Error) {
+        let msg = indoc::formatdoc! {"
+            I could not use the powercap sysfs to read RAPL energy counters: {e}.
+            This is probably caused by insufficient privileges.
+            Please check that you have read access to everything in '{POWERCAP_RAPL_PATH}'.
+        
+            A solution could be:
+                sudo chmod a+r -R {POWERCAP_RAPL_PATH}"};
+        log::error!("{msg}");
     }
 }
 
@@ -220,39 +327,13 @@ impl alumet::pipeline::Source for PowercapProbe {
         let mut zone_reading_buf = Vec::with_capacity(16);
 
         for zone in &mut self.zones {
-            // read the file from the beginning
-            zone.file
-                .rewind()
-                .with_context(|| format!("failed to rewind {:?}", zone.file))?;
-            zone.file
-                .read_to_end(&mut zone_reading_buf)
-                .with_context(|| format!("failed to read {:?}", zone.file))?;
-
-            // parse the content of the file
-            let content = std::str::from_utf8(&zone_reading_buf)?;
-            let counter_value: u64 = content
-                .trim_end()
-                .parse()
-                .with_context(|| format!("failed to parse {:?}: '{content}'", zone.file))?;
-
-            // store the value, handle the overflow if there is one
-            let diff = match zone.counter.update(counter_value) {
-                CounterDiffUpdate::FirstTime => None,
-                CounterDiffUpdate::Difference(diff) => Some(diff),
-                CounterDiffUpdate::CorrectedDifference(diff) => {
-                    log::debug!("Overflow on powercap counter for RAPL domain {}", zone.domain);
-                    Some(diff)
-                }
-            };
-            if let Some(value) = diff {
-                let joules = (value as f64) * POWERCAP_ENERGY_UNIT;
+            if let Some(joules) = zone.read_counter_diff_in_joules(&mut zone_reading_buf)? {
                 let consumer = ResourceConsumer::LocalMachine;
                 measurements.push(
                     MeasurementPoint::new(timestamp, self.metric, zone.resource.clone(), consumer, joules)
                         .with_attr("domain", AttributeValue::String(zone.domain.to_string())),
                 )
-            };
-
+            }
             // clear the buffer, so that we can fill it again
             zone_reading_buf.clear();
         }
@@ -262,22 +343,448 @@ impl alumet::pipeline::Source for PowercapProbe {
 
 #[cfg(test)]
 mod tests {
-    use super::all_power_zones;
+    use super::*;
+    use crate::tests_mock::*;
+
+    use std::path::PathBuf;
+    use tempfile::tempdir;
 
     #[test]
-    fn test_powercap() {
-        if std::env::var_os("CONTINUE_TEST_IF_NO_POWERCAP").is_some() {
-            return;
-        }
+    fn test_opened_zone_energy_uj_counter_read() -> anyhow::Result<()> {
+        let tmp = tempdir()?;
+        let base_path = tmp.keep();
 
-        let zones = all_power_zones().expect("failed to get powercap power zones");
-        println!("---- Hierarchy ----");
-        for z in zones.top {
-            println!("{z}");
-        }
-        println!("---- Flat list ----");
-        for z in zones.flat {
-            println!("{z}")
-        }
+        use EntryType::*;
+
+        let entries = [
+            Entry {
+                path: "enabled",
+                entry_type: File("1"),
+            },
+            Entry {
+                path: "intel-rapl:0",
+                entry_type: Dir,
+            },
+            Entry {
+                path: "intel-rapl:0/name",
+                entry_type: File("package-0"),
+            },
+            Entry {
+                path: "intel-rapl:0/max_energy_range_uj",
+                entry_type: File("262143328850"),
+            },
+            Entry {
+                path: "intel-rapl:0/energy_uj",
+                entry_type: File("124599532281"),
+            },
+            Entry {
+                path: "intel-rapl:0/intel-rapl:0:0",
+                entry_type: Dir,
+            },
+            Entry {
+                path: "intel-rapl:0/intel-rapl:0:0/name",
+                entry_type: File("core"),
+            },
+            Entry {
+                path: "intel-rapl:0/intel-rapl:0:0/max_energy_range_uj",
+                entry_type: File("262143328850"),
+            },
+            Entry {
+                path: "intel-rapl:0/intel-rapl:0:0/energy_uj",
+                entry_type: File("23893449269"),
+            },
+            Entry {
+                path: "intel-rapl:0/intel-rapl:0:1",
+                entry_type: Dir,
+            },
+            Entry {
+                path: "intel-rapl:0/intel-rapl:0:1/name",
+                entry_type: File("uncore"),
+            },
+            Entry {
+                path: "intel-rapl:0/intel-rapl:0:1/max_energy_range_uj",
+                entry_type: File("262143328850"),
+            },
+            Entry {
+                path: "intel-rapl:0/intel-rapl:0:1/energy_uj",
+                entry_type: File("23992349269"),
+            },
+            Entry {
+                path: "intel-rapl:1",
+                entry_type: Dir,
+            },
+            Entry {
+                path: "intel-rapl:1/name",
+                entry_type: File("psys"),
+            },
+            Entry {
+                path: "intel-rapl:1/max_energy_range_uj",
+                entry_type: File("262143328850"),
+            },
+            Entry {
+                path: "intel-rapl:1/energy_uj",
+                entry_type: File("154571208422"),
+            },
+            Entry {
+                path: "intel-rapl:2",
+                entry_type: Dir,
+            },
+            Entry {
+                path: "intel-rapl:2/name",
+                entry_type: File("dram"),
+            },
+            Entry {
+                path: "intel-rapl:2/max_energy_range_uj",
+                entry_type: File("262143328850"),
+            },
+            Entry {
+                path: "intel-rapl:2/energy_uj",
+                entry_type: File("212143328850"),
+            },
+        ];
+
+        create_mock_layout(base_path.clone(), &entries)?;
+        let power_zones = all_power_zones_from_path(base_path.as_path())?.flat;
+
+        let mut zone_reading_buf = Vec::with_capacity(16);
+
+        let mut psys_zone = power_zones[3].open()?;
+        let mut dram_zone = power_zones[4].open()?;
+        let mut core_zone = power_zones[1].open()?;
+        let mut uncore_zone = power_zones[2].open()?;
+        let mut package_0_zone = power_zones[0].open()?;
+        assert_eq!(psys_zone.read_counter_diff_in_joules(&mut zone_reading_buf)?, None);
+        zone_reading_buf.clear();
+        assert_eq!(dram_zone.read_counter_diff_in_joules(&mut zone_reading_buf)?, None);
+        zone_reading_buf.clear();
+        assert_eq!(core_zone.read_counter_diff_in_joules(&mut zone_reading_buf)?, None);
+        zone_reading_buf.clear();
+        assert_eq!(uncore_zone.read_counter_diff_in_joules(&mut zone_reading_buf)?, None);
+        zone_reading_buf.clear();
+        assert_eq!(package_0_zone.read_counter_diff_in_joules(&mut zone_reading_buf)?, None);
+
+        let entries = [
+            Entry {
+                path: "enabled",
+                entry_type: File("1"),
+            },
+            Entry {
+                path: "intel-rapl:0",
+                entry_type: Dir,
+            },
+            Entry {
+                path: "intel-rapl:0/name",
+                entry_type: File("package-0"),
+            },
+            Entry {
+                path: "intel-rapl:0/max_energy_range_uj",
+                entry_type: File("262143328850"),
+            },
+            Entry {
+                path: "intel-rapl:0/energy_uj",
+                entry_type: File("129999532281"),
+            },
+            Entry {
+                path: "intel-rapl:0/intel-rapl:0:0",
+                entry_type: Dir,
+            },
+            Entry {
+                path: "intel-rapl:0/intel-rapl:0:0/name",
+                entry_type: File("core"),
+            },
+            Entry {
+                path: "intel-rapl:0/intel-rapl:0:0/max_energy_range_uj",
+                entry_type: File("262143328850"),
+            },
+            Entry {
+                path: "intel-rapl:0/intel-rapl:0:0/energy_uj",
+                entry_type: File("24293449269"),
+            },
+            Entry {
+                path: "intel-rapl:0/intel-rapl:0:1",
+                entry_type: Dir,
+            },
+            Entry {
+                path: "intel-rapl:0/intel-rapl:0:1/name",
+                entry_type: File("uncore"),
+            },
+            Entry {
+                path: "intel-rapl:0/intel-rapl:0:1/max_energy_range_uj",
+                entry_type: File("262143328850"),
+            },
+            Entry {
+                path: "intel-rapl:0/intel-rapl:0:1/energy_uj",
+                entry_type: File("23992349269"),
+            },
+            Entry {
+                path: "intel-rapl:1",
+                entry_type: Dir,
+            },
+            Entry {
+                path: "intel-rapl:1/name",
+                entry_type: File("psys"),
+            },
+            Entry {
+                path: "intel-rapl:1/max_energy_range_uj",
+                entry_type: File("262143328850"),
+            },
+            Entry {
+                path: "intel-rapl:1/energy_uj",
+                entry_type: File("154581208422"),
+            },
+            Entry {
+                path: "intel-rapl:2",
+                entry_type: Dir,
+            },
+            Entry {
+                path: "intel-rapl:2/name",
+                entry_type: File("dram"),
+            },
+            Entry {
+                path: "intel-rapl:2/max_energy_range_uj",
+                entry_type: File("262143328850"),
+            },
+            Entry {
+                path: "intel-rapl:2/energy_uj",
+                entry_type: File("908522"),
+            },
+        ];
+
+        create_mock_layout(base_path.clone(), &entries)?;
+
+        zone_reading_buf.clear();
+        assert_eq!(
+            psys_zone.read_counter_diff_in_joules(&mut zone_reading_buf)?,
+            Some(10.0)
+        );
+        zone_reading_buf.clear();
+        assert_eq!(
+            dram_zone.read_counter_diff_in_joules(&mut zone_reading_buf)?,
+            Some(50000.908523)
+        ); // overflow / corrected difference case
+        zone_reading_buf.clear();
+        assert_eq!(
+            core_zone.read_counter_diff_in_joules(&mut zone_reading_buf)?,
+            Some(400.0)
+        );
+        zone_reading_buf.clear();
+        assert_eq!(
+            uncore_zone.read_counter_diff_in_joules(&mut zone_reading_buf)?,
+            Some(0.0)
+        );
+        zone_reading_buf.clear();
+        assert_eq!(
+            package_0_zone.read_counter_diff_in_joules(&mut zone_reading_buf)?,
+            Some(5400.0)
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_opened_zone_energy_uj_read() -> anyhow::Result<()> {
+        let base_path = create_valid_powercap_mock()?;
+        let power_zones = all_power_zones_from_path(base_path.as_path())?.flat;
+        let mut zone_reading_buf = Vec::with_capacity(16);
+        let mut psys_zone = power_zones[3].open()?;
+        let mut dram_zone = power_zones[4].open()?;
+        let mut core_zone = power_zones[1].open()?;
+        let mut uncore_zone = power_zones[2].open()?;
+        let mut package_0_zone = power_zones[0].open()?;
+        assert_eq!(package_0_zone.read_counter_value(&mut zone_reading_buf)?, 124599532281);
+        zone_reading_buf.clear();
+        assert_eq!(core_zone.read_counter_value(&mut zone_reading_buf)?, 23893449269);
+        zone_reading_buf.clear();
+        assert_eq!(uncore_zone.read_counter_value(&mut zone_reading_buf)?, 23992349269);
+        zone_reading_buf.clear();
+        assert_eq!(psys_zone.read_counter_value(&mut zone_reading_buf)?, 154571208422);
+        zone_reading_buf.clear();
+        assert_eq!(dram_zone.read_counter_value(&mut zone_reading_buf)?, 182178908522);
+        Ok(())
+    }
+
+    #[cfg(test)]
+    #[test]
+    fn test_all_power_zones_from_path() -> anyhow::Result<()> {
+        let base_path = create_valid_powercap_mock()?;
+        let base_str = base_path.to_str().expect("cannot convert base_path to str");
+
+        let actual_zones = all_power_zones_from_path(base_path.as_path())?.flat;
+
+        let expected_zones = vec![
+            PowerZone {
+                name: "package-0".to_string(),
+                domain: RaplDomainType::Package,
+                path: PathBuf::from(format!("{}/intel-rapl:0", base_str)),
+                socket_id: Some(0),
+                children: vec![
+                    PowerZone {
+                        name: "core".to_string(),
+                        domain: RaplDomainType::PP0,
+                        path: PathBuf::from(format!("{}/intel-rapl:0/intel-rapl:0:0", base_str)),
+                        socket_id: Some(0),
+                        children: Vec::new(),
+                    },
+                    PowerZone {
+                        name: "uncore".to_string(),
+                        domain: RaplDomainType::PP1,
+                        path: PathBuf::from(format!("{}/intel-rapl:0/intel-rapl:0:1", base_str)),
+                        socket_id: Some(0),
+                        children: Vec::new(),
+                    },
+                ],
+            },
+            PowerZone {
+                name: "core".to_string(),
+                domain: RaplDomainType::PP0,
+                path: PathBuf::from(format!("{}/intel-rapl:0/intel-rapl:0:0", base_str)),
+                socket_id: Some(0),
+                children: Vec::new(),
+            },
+            PowerZone {
+                name: "uncore".to_string(),
+                domain: RaplDomainType::PP1,
+                path: PathBuf::from(format!("{}/intel-rapl:0/intel-rapl:0:1", base_str)),
+                socket_id: Some(0),
+                children: Vec::new(),
+            },
+            PowerZone {
+                name: "psys".to_string(),
+                domain: RaplDomainType::Platform,
+                path: PathBuf::from(format!("{}/intel-rapl:1", base_str)),
+                socket_id: None,
+                children: Vec::new(),
+            },
+            PowerZone {
+                name: "dram".to_string(),
+                domain: RaplDomainType::Dram,
+                path: PathBuf::from(format!("{}/intel-rapl:2", base_str)),
+                socket_id: None,
+                children: Vec::new(),
+            },
+        ];
+
+        assert_eq!(actual_zones, expected_zones);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_custom_format() {
+        let zone = PowerZone {
+            name: "package-0".to_string(),
+            domain: RaplDomainType::Package,
+            path: PathBuf::from(format!("/sys/devices/virtual/powercap/intel-rapl/intel-rapl:0")),
+            socket_id: Some(0),
+            children: Vec::new(),
+        };
+        let actual_zone_fmt = format!("{zone}");
+        let expected_zone_fmt = "- package-0 (Package) \t\t: /sys/devices/virtual/powercap/intel-rapl/intel-rapl:0";
+        assert_eq!(actual_zone_fmt, expected_zone_fmt);
+    }
+
+    #[test]
+    fn test_open_with_wrong_path() {
+        let zone = PowerZone {
+            name: "package-0".to_string(),
+            domain: RaplDomainType::Package,
+            path: PathBuf::from(format!("/i/do/not/exists")),
+            socket_id: Some(0),
+            children: Vec::new(),
+        };
+        let result = zone.open();
+        assert!(
+            result.is_err(),
+            "expected an error when opening a power zone with a wrong path parameter"
+        );
+    }
+
+    #[test]
+    fn test_all_with_wrong_path() {
+        let result = all_power_zones_from_path(Path::new("/i/do/not/exists"));
+        assert!(
+            result.is_err(),
+            "expected an error when getting all power zones with a wrong input path"
+        );
+    }
+
+    #[test]
+    fn test_open_with_no_max_energy_range_uj() -> anyhow::Result<()> {
+        let tmp = tempdir()?;
+        let base_path = tmp.keep();
+
+        use EntryType::*;
+
+        let entries = [
+            Entry {
+                path: "enabled",
+                entry_type: File("wrongcontent"),
+            },
+            Entry {
+                path: "intel-rapl:0",
+                entry_type: Dir,
+            },
+            Entry {
+                path: "intel-rapl:0/name",
+                entry_type: File("package-0"),
+            },
+            Entry {
+                path: "intel-rapl:0/energy_uj",
+                entry_type: File("wrongcontent"),
+            },
+        ];
+
+        create_mock_layout(base_path.clone(), &entries)?;
+
+        let power_zones = all_power_zones_from_path(base_path.as_path())?.flat;
+
+        let result = power_zones[0].open();
+        assert!(
+            result.is_err(),
+            "expected an error while opening the power zone because of wrong layout content"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_open_with_wrong_layout_content() -> anyhow::Result<()> {
+        let tmp = tempdir()?;
+        let base_path = tmp.keep();
+
+        use EntryType::*;
+
+        let entries = [
+            Entry {
+                path: "enabled",
+                entry_type: File("wrongcontent"),
+            },
+            Entry {
+                path: "intel-rapl:0",
+                entry_type: Dir,
+            },
+            Entry {
+                path: "intel-rapl:0/name",
+                entry_type: File("package-0"),
+            },
+            Entry {
+                path: "intel-rapl:0/max_energy_range_uj",
+                entry_type: File("wrongcontent"),
+            },
+            Entry {
+                path: "intel-rapl:0/energy_uj",
+                entry_type: File("wrongcontent"),
+            },
+        ];
+
+        create_mock_layout(base_path.clone(), &entries)?;
+
+        let power_zones = all_power_zones_from_path(base_path.as_path())?.flat;
+
+        let result = power_zones[0].open();
+        assert!(
+            result.is_err(),
+            "expected an error while opening the power zone because of wrong layout content"
+        );
+        Ok(())
     }
 }

--- a/plugin-rapl/src/tests_mock.rs
+++ b/plugin-rapl/src/tests_mock.rs
@@ -1,0 +1,132 @@
+#[cfg(test)]
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::PathBuf;
+use tempfile::tempdir;
+
+/// Entry to be created in the mock filesystem
+pub enum EntryType<'a> {
+    File(&'a str), // File with content
+    Dir,           // Directory
+}
+
+/// Single entry specification
+pub struct Entry<'a> {
+    pub path: &'a str,
+    pub entry_type: EntryType<'a>,
+}
+
+/// Create all specified entries under the given base path
+pub fn create_mock_layout(base_path: PathBuf, entries: &[Entry]) -> std::io::Result<()> {
+    for entry in entries {
+        let full_path = base_path.join(entry.path);
+        match &entry.entry_type {
+            EntryType::Dir => fs::create_dir_all(&full_path)?,
+            EntryType::File(content) => {
+                if let Some(parent) = full_path.parent() {
+                    fs::create_dir_all(parent)?;
+                }
+                let mut file = File::create(full_path)?;
+                file.write_all(content.as_bytes())?;
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn create_valid_powercap_mock() -> anyhow::Result<PathBuf> {
+    let tmp = tempdir()?;
+    let base_path = tmp.keep();
+
+    use EntryType::*;
+
+    let entries = [
+        Entry {
+            path: "enabled",
+            entry_type: File("1"),
+        },
+        Entry {
+            path: "intel-rapl:0",
+            entry_type: Dir,
+        },
+        Entry {
+            path: "intel-rapl:0/name",
+            entry_type: File("package-0"),
+        },
+        Entry {
+            path: "intel-rapl:0/max_energy_range_uj",
+            entry_type: File("262143328850"),
+        },
+        Entry {
+            path: "intel-rapl:0/energy_uj",
+            entry_type: File("124599532281"),
+        },
+        Entry {
+            path: "intel-rapl:0/intel-rapl:0:0",
+            entry_type: Dir,
+        },
+        Entry {
+            path: "intel-rapl:0/intel-rapl:0:0/name",
+            entry_type: File("core"),
+        },
+        Entry {
+            path: "intel-rapl:0/intel-rapl:0:0/max_energy_range_uj",
+            entry_type: File("262143328850"),
+        },
+        Entry {
+            path: "intel-rapl:0/intel-rapl:0:0/energy_uj",
+            entry_type: File("23893449269"),
+        },
+        Entry {
+            path: "intel-rapl:0/intel-rapl:0:1",
+            entry_type: Dir,
+        },
+        Entry {
+            path: "intel-rapl:0/intel-rapl:0:1/name",
+            entry_type: File("uncore"),
+        },
+        Entry {
+            path: "intel-rapl:0/intel-rapl:0:1/max_energy_range_uj",
+            entry_type: File("262143328850"),
+        },
+        Entry {
+            path: "intel-rapl:0/intel-rapl:0:1/energy_uj",
+            entry_type: File("23992349269"),
+        },
+        Entry {
+            path: "intel-rapl:1",
+            entry_type: Dir,
+        },
+        Entry {
+            path: "intel-rapl:1/name",
+            entry_type: File("psys"),
+        },
+        Entry {
+            path: "intel-rapl:1/max_energy_range_uj",
+            entry_type: File("262143328850"),
+        },
+        Entry {
+            path: "intel-rapl:1/energy_uj",
+            entry_type: File("154571208422"),
+        },
+        Entry {
+            path: "intel-rapl:2",
+            entry_type: Dir,
+        },
+        Entry {
+            path: "intel-rapl:2/name",
+            entry_type: File("dram"),
+        },
+        Entry {
+            path: "intel-rapl:2/max_energy_range_uj",
+            entry_type: File("262143328850"),
+        },
+        Entry {
+            path: "intel-rapl:2/energy_uj",
+            entry_type: File("182178908522"),
+        },
+    ];
+
+    create_mock_layout(base_path.clone(), &entries)?;
+    Ok(base_path)
+}


### PR DESCRIPTION
Added new unit tests to increase the tested code coverage (up to 70% now).
In order to do so I've done some refactoring, in particular:

- get a global consistency on how powercap and perf_event are initialized and the kind of objects they return
- removed old `PowerZoneHierarchy` that was actually not used in the plugin: now we just use the "flat" version, "top" was removed. This makes it consistent with powercap objects.
- simulate perf_event_open syscall using `nix` library in order to make unit testing of perf_event
- added new configs only available in tests to be able to pass path containing mocked data
- rewrite some functions that was not test-ready because of hardcoded constant paths.

Note that `perf_events` is only partially tested yet, we still miss integration tests for it. Biggest issue is about finding a way to mock syscall+file descriptor behavior while running it with alumet (unit testing part have been done yet).