### PR TITLE
fix(plugin-nvidia-nvml): change the way to collect process related measurements

### DIFF
--- a/alumet/src/units.rs
+++ b/alumet/src/units.rs
@@ -53,6 +53,9 @@ pub enum Unit {
     /// Amount of information (1 byte = 8 bits).
     Byte,
 
+    /// Percent, between 0% and 100%. (note: actual value is between 0 and 100 - eg: 5% would be 5, not 0.05)
+    Percent,
+
     /// A custom unit
     Custom {
         /// The unique name (case sensitive) of the unit, as specified by the UCUM.
@@ -105,6 +108,7 @@ impl Unit {
             Unit::DegreeFahrenheit => "[degF]",
             Unit::WattHour => "W.h",
             Unit::Byte => "By",
+            Unit::Percent => "%",
             Unit::Custom {
                 unique_name,
                 display_name: _,
@@ -128,6 +132,7 @@ impl Unit {
             Unit::DegreeFahrenheit => "°F",
             Unit::WattHour => "Wh",
             Unit::Byte => "B",
+            Unit::Percent => "%",
             Unit::Custom {
                 unique_name: _,
                 display_name,
@@ -166,6 +171,7 @@ impl FromStr for Unit {
             "[degF]" => Unit::DegreeFahrenheit,
             "W.h" => Unit::WattHour,
             "By" => Unit::Byte,
+            "%" => Unit::Percent,
             _ => return Err(anyhow!("Unknown or non standard Unit {s}")),
         };
         Ok(res)
@@ -311,6 +317,7 @@ mod tests {
         assert_eq!(parse_self(Unit::DegreeFahrenheit), Unit::DegreeFahrenheit);
         assert_eq!(parse_self(Unit::WattHour), Unit::WattHour);
         assert_eq!(parse_self(Unit::Byte), Unit::Byte);
+        assert_eq!(parse_self(Unit::Percent), Unit::Percent);
     }
 
     #[test]

--- a/plugin-nvidia-nvml/src/nvml/features.rs
+++ b/plugin-nvidia-nvml/src/nvml/features.rs
@@ -24,6 +24,8 @@ pub struct OptionalFeatures {
     pub decoder_utilization: bool,
     /// GPU video encoding property.
     pub encoder_utilization: bool,
+    /// Utilization stats for relevant currently running processes.
+    pub process_utilization_stats: bool,
     /// Relevant currently running computing processes data.
     pub running_compute_processes: AvailableVersion,
     /// Relevant currently running graphical processes data.
@@ -40,6 +42,7 @@ impl OptionalFeatures {
             major_utilization: is_supported(device.utilization_rates())?,
             decoder_utilization: is_supported(device.decoder_utilization())?,
             encoder_utilization: is_supported(device.encoder_utilization())?,
+            process_utilization_stats: is_supported(device.process_utilization_stats(0))?,
             running_compute_processes: check_running_compute_processes(device)?,
             running_graphics_processes: check_running_graphics_processes(device)?,
         })
@@ -78,6 +81,9 @@ impl Display for OptionalFeatures {
         }
         if self.encoder_utilization {
             available.push("encoder_utilization");
+        }
+        if self.process_utilization_stats {
+            available.push("process_utilization_stats");
         }
         if self.temperature_gpu {
             available.push("temperature_gpu");
@@ -150,13 +156,14 @@ mod tests {
             major_utilization: true,
             decoder_utilization: true,
             encoder_utilization: true,
+            process_utilization_stats: true,
             temperature_gpu: true,
             running_compute_processes: AvailableVersion::Latest,
             running_graphics_processes: AvailableVersion::Latest,
         };
         assert_eq!(
             format!("{}", features),
-            "total_energy_consumption, instant_power, major_utilization, decoder_utilization, encoder_utilization, temperature_gpu, running_compute_processes(latest), running_graphics_processes(latest)"
+            "total_energy_consumption, instant_power, major_utilization, decoder_utilization, encoder_utilization, process_utilization_stats, temperature_gpu, running_compute_processes(latest), running_graphics_processes(latest)"
         );
     }
 
@@ -170,6 +177,7 @@ mod tests {
             major_utilization: false,
             decoder_utilization: true,
             encoder_utilization: true,
+            process_utilization_stats: false,
             temperature_gpu: true,
             running_compute_processes: AvailableVersion::None,
             running_graphics_processes: AvailableVersion::None,
@@ -190,6 +198,7 @@ mod tests {
             major_utilization: false,
             decoder_utilization: false,
             encoder_utilization: false,
+            process_utilization_stats: false,
             temperature_gpu: false,
             running_compute_processes: AvailableVersion::V2,
             running_graphics_processes: AvailableVersion::V2,
@@ -220,6 +229,7 @@ mod tests {
             major_utilization: false,
             decoder_utilization: false,
             encoder_utilization: false,
+            process_utilization_stats: false,
             temperature_gpu: false,
             running_compute_processes: AvailableVersion::None,
             running_graphics_processes: AvailableVersion::None,

--- a/plugin-nvidia-nvml/src/nvml/metrics.rs
+++ b/plugin-nvidia-nvml/src/nvml/metrics.rs
@@ -52,21 +52,10 @@ impl Metrics {
                 Unit::DegreeCelsius,
                 "Instantaneous temperature of the GPU at the time of the measurement",
             )?,
-            major_utilization_gpu: alumet.create_metric("nvml_gpu_utilization", Unit::Unity, "GPU rate utilization")?,
-            major_utilization_memory: alumet.create_metric(
-                "nvml_memory_utilization",
-                Unit::Unity,
-                "GPU memory utilization",
-            )?,
-            decoder_utilization: alumet.create_metric(
-                "nvml_decoder_utilization",
-                Unit::Unity,
-                "GPU video decoding property",
-            )?,
-            encoder_utilization: alumet.create_metric(
-                "nvml_encoder_utilization",
-                Unit::Unity,
-                "GPU video encoding property",
+            major_utilization_gpu: alumet.create_metric(
+                "nvml_gpu_utilization",
+                Unit::Percent,
+                "GPU rate utilization",
             )?,
             decoder_sampling_period_us: alumet.create_metric(
                 "nvml_decoder_sampling_period",
@@ -78,11 +67,6 @@ impl Metrics {
                 PrefixedUnit::micro(Unit::Second),
                 "Get the current utilization and sampling size for the encoder",
             )?,
-            sm_utilization: alumet.create_metric(
-                "nvml_sm_utilization",
-                Unit::Unity,
-                "Percentage of time that the Streaming Multiprocessors of a GPU",
-            )?,
             running_compute_processes: alumet.create_metric(
                 "nvml_n_compute_processes",
                 Unit::Unity,
@@ -92,6 +76,28 @@ impl Metrics {
                 "nvml_n_graphic_processes",
                 Unit::Unity,
                 "Number of graphic processes running on the device",
+            )?,
+
+            // device process-related measurements
+            major_utilization_memory: alumet.create_metric(
+                "nvml_memory_utilization",
+                Unit::Percent,
+                "Utilization of the GPU memory by the process",
+            )?,
+            decoder_utilization: alumet.create_metric(
+                "nvml_decoder_utilization",
+                Unit::Percent,
+                "Utilization of the GPU video decoder by the process",
+            )?,
+            encoder_utilization: alumet.create_metric(
+                "nvml_encoder_utilization",
+                Unit::Percent,
+                "Utilization of the GPU video encoder by the process",
+            )?,
+            sm_utilization: alumet.create_metric(
+                "nvml_sm_utilization",
+                Unit::Percent,
+                "Utilization of the GPU streaming multiprocessors by the process",
             )?,
         })
     }


### PR DESCRIPTION
Old way to collect process related measurements was buggy, cause it was using pid instead of a unix timestamp in `process_utilization_stats` method. This lead to unexpected values.

Now the source/probe will keep an Option<Timestamp> in memory that contains the timestamp of the last poll. This is helpful to ask `process_utilization_stats` the values since this timestamp.

Also added a new Unit called `Percent`.