### PR TITLE
feat(plugin-process-to-cgroup-bridge): create new plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,7 @@ dependencies = [
  "plugin-nvidia-nvml",
  "plugin-opentelemetry",
  "plugin-perf",
+ "plugin-process-to-cgroup-bridge",
  "plugin-procfs",
  "plugin-prometheus-exporter",
  "plugin-rapl",
@@ -2681,6 +2682,19 @@ dependencies = [
  "log",
  "perf-event2",
  "serde",
+]
+
+[[package]]
+name = "plugin-process-to-cgroup-bridge"
+version = "0.1.0"
+dependencies = [
+ "alumet",
+ "anyhow",
+ "lazy_static",
+ "log",
+ "serde",
+ "tempfile",
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ members = [
     "plugin-nvidia-nvml",
     "plugin-nvidia-jetson",
     "plugin-perf",
+    "plugin-process-to-cgroup-bridge",
     "plugin-procfs",
     "plugin-prometheus-exporter",
     "plugin-rapl",
     "plugin-relay",
     "plugin-socket-control",
-    "plugin-mongodb",
     "test-dynamic-plugins", 
 ]
 

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -39,6 +39,7 @@ plugin-cgroupv2 = { path = "../plugin-cgroupv2" }
 plugin-grace-hopper = { path = "../plugin-grace-hopper" }
 plugin-nvidia-jetson = { path = "../plugin-nvidia-jetson" }
 plugin-nvidia-nvml = { path = "../plugin-nvidia-nvml" }
+plugin-process-to-cgroup-bridge = { path = "../plugin-process-to-cgroup-bridge" }
 plugin-perf = { path = "../plugin-perf" }
 plugin-procfs = { path = "../plugin-procfs" }
 plugin-rapl = { path = "../plugin-rapl" }

--- a/agent/src/bin/main.rs
+++ b/agent/src/bin/main.rs
@@ -50,6 +50,7 @@ fn load_plugins_metadata() -> Vec<PluginMetadata> {
             plugin_perf::PerfPlugin,
             plugin_procfs::ProcfsPlugin,
             plugin_nvidia_nvml::NvmlPlugin,
+            plugin_process_to_cgroup_bridge::ProcessToCgroupBridgePlugin,
             plugin_nvidia_jetson::JetsonPlugin,
         ]);
     }

--- a/plugin-process-to-cgroup-bridge/Cargo.toml
+++ b/plugin-process-to-cgroup-bridge/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "plugin-process-to-cgroup-bridge"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+alumet = { path = "../alumet" }
+anyhow = "1.0.79"
+log = "*"
+serde = { version = "1.0.198", features = ["derive"] }
+
+[dev-dependencies]
+alumet = {path = "../alumet", features = ["test"]}
+toml = "0.8.19"
+tempfile = "3.20.0"
+lazy_static = "1.5.0"

--- a/plugin-process-to-cgroup-bridge/README.md
+++ b/plugin-process-to-cgroup-bridge/README.md
@@ -1,0 +1,33 @@
+# Process to Cgroup Bridge Plugin
+
+The Process to Cgroup Bridge plugin creates an Alumet **transform** that will take as input measurements with a ResourceConsumer::Process and transform it to ResourceConsumer::ControlGroup using procfs to bridge the process id to the related cgroup.
+
+It's designed to be coupled with another Alumet source that produce process measurements (eg: `plugin-nvidia-nvml`).
+The [Configuration](#configuration) allows to make the transformation step only on some selected metrics.
+
+## Requirements
+
+- A **source** plugin that produces measurements with ResourceConsumer::Process
+
+## Configuration
+
+Here is a configuration example of the Process to Cgroup Bridge Plugin. It's part of the Alumet configuration file (eg: `alumet-config.toml`).
+
+```toml
+[plugins.process-to-cgroup-bridge]
+# The metrics names we want to find the cgroup for
+processes_metrics = [
+    "some_metric_to_bridge",
+    "another_metric_to_bridge",
+]
+# Will aggregate measurements in case multiple processes share the same cgroup and have the same timestamp. This leads to one measurement per metric per cgroup per timestamp.
+merge_similar_cgroups = true
+# Will keep all the measurements that have been processed by the transformer. In case it's false only the measurements with a cgroup resource consumer will be kept.
+keep_processed_measurements = true
+```
+
+## More informations
+
+### Cgroup not found
+
+In case the transform plugin doesn't find a cgroup for a process measurement, it will silently skip the transformation step for this measurement.

--- a/plugin-process-to-cgroup-bridge/src/lib.rs
+++ b/plugin-process-to-cgroup-bridge/src/lib.rs
@@ -1,0 +1,107 @@
+use alumet::{
+    metrics::RawMetricId,
+    plugin::{
+        rust::{deserialize_config, serialize_config, AlumetPlugin},
+        ConfigTable,
+    },
+};
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+use transform::ProcessToCgroupBridgeTransform;
+
+#[cfg(test)]
+use std::path::PathBuf;
+
+#[cfg(test)]
+mod tests;
+
+mod transform;
+
+pub struct ProcessToCgroupBridgePlugin {
+    config: Config,
+}
+
+impl AlumetPlugin for ProcessToCgroupBridgePlugin {
+    fn name() -> &'static str {
+        "process-to-cgroup-bridge"
+    }
+
+    fn version() -> &'static str {
+        env!("CARGO_PKG_VERSION")
+    }
+
+    fn default_config() -> anyhow::Result<Option<ConfigTable>> {
+        Ok(Some(serialize_config(Config::default())?))
+    }
+
+    fn init(config: alumet::plugin::ConfigTable) -> anyhow::Result<Box<Self>> {
+        let config = deserialize_config(config)?;
+        Ok(Box::new(ProcessToCgroupBridgePlugin { config }))
+    }
+
+    fn start(&mut self, alumet: &mut alumet::plugin::AlumetPluginStart) -> anyhow::Result<()> {
+        let processes_metrics = self.config.processes_metrics.clone();
+        let merge_similar_cgroups = self.config.merge_similar_cgroups;
+        let keep_processed_measurements = self.config.keep_processed_measurements;
+
+        #[cfg(test)]
+        let proc_path = self.config.proc_path.clone();
+
+        alumet.add_transform_builder("transform", move |ctx| {
+            let mut processes_metrics_ids: Vec<RawMetricId> = Vec::new();
+            for metric_name in &processes_metrics {
+                processes_metrics_ids.push(
+                    ctx.metric_by_name(metric_name)
+                        .with_context(|| format!("Metric not found : {}", metric_name))?
+                        .0,
+                );
+            }
+            if processes_metrics.is_empty() {
+                return Err(anyhow::anyhow!("no processes metrics was found either because `processes_metrics` config is empty or because no Alumet metric have matched the names"))
+            }
+            let transform = Box::new(ProcessToCgroupBridgeTransform::new(
+                processes_metrics_ids,
+                merge_similar_cgroups,
+                keep_processed_measurements,
+
+                #[cfg(test)]
+                proc_path,
+            ));
+            Ok(transform)
+        })?;
+        Ok(())
+    }
+
+    fn stop(&mut self) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct Config {
+    /// The metrics names we want to find the cgroup for
+    pub processes_metrics: Vec<String>,
+    /// Will aggregate measurements in case multiple processes share the same cgroup and have the same timestamp. This leads to one measurement per metric per cgroup per timestamp.
+    pub merge_similar_cgroups: bool,
+    /// Will keep all the measurements that have been processed by the transformer. In case it's false only the measurements with a cgroup resource consumer will be kept.
+    pub keep_processed_measurements: bool,
+
+    #[cfg(test)]
+    pub proc_path: PathBuf,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            processes_metrics: vec![
+                String::from("some_metric_to_bridge"),
+                String::from("another_metric_to_bridge"),
+            ],
+            merge_similar_cgroups: true,
+            keep_processed_measurements: true,
+
+            #[cfg(test)]
+            proc_path: PathBuf::from("/proc"),
+        }
+    }
+}

--- a/plugin-process-to-cgroup-bridge/src/tests.rs
+++ b/plugin-process-to-cgroup-bridge/src/tests.rs
@@ -1,0 +1,451 @@
+// This file contains integration tests. Not having them in tests/ subdir is expected here.
+// This is to bypass a rust behavior while cfg(test) annotations are not visible for integration tests under tests/ subdir
+// In our context we want use these annotations to change how code is compiled under tests (most of time to mock constants)
+#[cfg(test)]
+use std::{
+    fs::{self, File},
+    io::Write,
+    path::PathBuf,
+    time::{Duration, UNIX_EPOCH},
+};
+
+use tempfile::{tempdir, TempDir};
+
+use crate::{Config, ProcessToCgroupBridgePlugin};
+
+use alumet::{
+    agent::{
+        self,
+        plugin::{PluginInfo, PluginSet},
+    },
+    measurement::{MeasurementAccumulator, MeasurementBuffer, MeasurementPoint, Timestamp, WrappedMeasurementValue},
+    metrics::TypedMetricId,
+    pipeline::naming::TransformName,
+    pipeline::{elements::error::PollError, elements::source::trigger::TriggerSpec, Source},
+    plugin::rust::AlumetPlugin,
+    plugin::PluginMetadata,
+    resources::{Resource, ResourceConsumer},
+    test::{runtime::TransformCheckInputContext, RuntimeExpectations},
+    units::Unit,
+};
+use lazy_static::lazy_static;
+
+lazy_static! {
+    static ref T: Timestamp = Timestamp::from(UNIX_EPOCH);
+    static ref T2: Timestamp = Timestamp::from(UNIX_EPOCH + Duration::from_secs(1));
+}
+
+#[derive(Debug, Clone)]
+struct ExpectedCounts {
+    t_initial: usize,
+    t2_initial: usize,
+    t_shared: usize,
+    t_single: usize,
+    t2_shared: usize,
+    t2_single: usize,
+}
+
+fn count_measurements_by_consumer_and_time(
+    measurements: &MeasurementBuffer,
+    consumer_filter: impl Fn(&ResourceConsumer) -> bool,
+    timestamp: Timestamp,
+) -> usize {
+    measurements
+        .iter()
+        .filter(|p| consumer_filter(&p.consumer) && p.timestamp == timestamp)
+        .count()
+}
+
+fn count_initial_measurements(measurements: &MeasurementBuffer, timestamp: Timestamp) -> usize {
+    count_measurements_by_consumer_and_time(
+        measurements,
+        |consumer| {
+            matches!(
+                consumer,
+                ResourceConsumer::Process { .. } | ResourceConsumer::LocalMachine
+            )
+        },
+        timestamp,
+    )
+}
+
+fn count_cgroup_measurements(measurements: &MeasurementBuffer, cgroup_path: &str, timestamp: Timestamp) -> usize {
+    count_measurements_by_consumer_and_time(
+        measurements,
+        |consumer| matches!(consumer, ResourceConsumer::ControlGroup { path } if path == cgroup_path),
+        timestamp,
+    )
+}
+
+fn assert_measurement_counts(measurements: &MeasurementBuffer, expected: ExpectedCounts) {
+    let t_initial_count = count_initial_measurements(measurements, *T);
+    assert_eq!(t_initial_count, expected.t_initial);
+
+    let t2_initial_count = count_initial_measurements(measurements, *T2);
+    assert_eq!(t2_initial_count, expected.t2_initial);
+
+    let t_shared_count = count_cgroup_measurements(measurements, "/system.slice/shared.slice", *T);
+    assert_eq!(t_shared_count, expected.t_shared);
+
+    let t_single_count = count_cgroup_measurements(measurements, "/system.slice/single.slice", *T);
+    assert_eq!(t_single_count, expected.t_single);
+
+    let t2_shared_count = count_cgroup_measurements(measurements, "/system.slice/shared.slice", *T2);
+    assert_eq!(t2_shared_count, expected.t2_shared);
+
+    let t2_single_count = count_cgroup_measurements(measurements, "/system.slice/single.slice", *T2);
+    assert_eq!(t2_single_count, expected.t2_single);
+}
+
+fn run_test_with_config(config: Config, expected_counts: ExpectedCounts) -> anyhow::Result<()> {
+    let _ = prepare_procfs_mock()?;
+    let mut plugins = PluginSet::new();
+
+    plugins.add_plugin(PluginInfo {
+        metadata: PluginMetadata::from_static::<DumbNvmlPlugin>(),
+        enabled: true,
+        config: None,
+    });
+    plugins.add_plugin(PluginInfo {
+        metadata: PluginMetadata::from_static::<ProcessToCgroupBridgePlugin>(),
+        enabled: true,
+        config: Some(config_to_toml_table(&config)),
+    });
+
+    let make_input = move |ctx: &mut TransformCheckInputContext| -> MeasurementBuffer {
+        prepare_mock_measurements(ctx).expect("failed to prepare mock points")
+    };
+
+    let check_output = move |measurements: &MeasurementBuffer| {
+        assert_measurement_counts(measurements, expected_counts.clone());
+    };
+
+    let runtime_expectations = RuntimeExpectations::new().test_transform(
+        TransformName::from_str("process-to-cgroup-bridge", "transform"),
+        make_input,
+        check_output,
+    );
+
+    let agent = agent::Builder::new(plugins)
+        .with_expectations(runtime_expectations)
+        .build_and_start()
+        .unwrap();
+
+    agent.wait_for_shutdown(Duration::from_secs(2)).unwrap();
+
+    Ok(())
+}
+
+#[test]
+fn test_default_setup() -> anyhow::Result<()> {
+    let tmp = prepare_procfs_mock()?;
+    let base_path = tmp.path().to_path_buf();
+    let config = Config {
+        processes_metrics: string_vec(&["metric_a", "metric_b"]),
+        proc_path: base_path,
+        ..Default::default()
+    };
+
+    let expected = ExpectedCounts {
+        t_initial: 6,
+        t2_initial: 1,
+        t_shared: 2,
+        t_single: 1,
+        t2_shared: 1,
+        t2_single: 0,
+    };
+
+    run_test_with_config(config, expected)
+}
+
+#[test]
+fn test_only_metric_a() -> anyhow::Result<()> {
+    let tmp = prepare_procfs_mock()?;
+    let base_path = tmp.path().to_path_buf();
+    let config = Config {
+        processes_metrics: string_vec(&["metric_a"]),
+        proc_path: base_path,
+        ..Default::default()
+    };
+
+    let expected = ExpectedCounts {
+        t_initial: 6,
+        t2_initial: 1,
+        t_shared: 1,
+        t_single: 1,
+        t2_shared: 1,
+        t2_single: 0,
+    };
+
+    run_test_with_config(config, expected)
+}
+
+#[test]
+fn test_merge_config_disable() -> anyhow::Result<()> {
+    let tmp = prepare_procfs_mock()?;
+    let base_path = tmp.path().to_path_buf();
+    let config = Config {
+        processes_metrics: string_vec(&["metric_a", "metric_b"]),
+        merge_similar_cgroups: false,
+        proc_path: base_path,
+        ..Default::default()
+    };
+
+    let expected = ExpectedCounts {
+        t_initial: 6,
+        t2_initial: 1,
+        t_shared: 4,
+        t_single: 1,
+        t2_shared: 1,
+        t2_single: 0,
+    };
+
+    run_test_with_config(config, expected)
+}
+
+#[test]
+fn test_keep_config_disable() -> anyhow::Result<()> {
+    let tmp = prepare_procfs_mock()?;
+    let base_path = tmp.path().to_path_buf();
+    let config = Config {
+        processes_metrics: string_vec(&["metric_a", "metric_b"]),
+        keep_processed_measurements: false,
+        proc_path: base_path,
+        ..Default::default()
+    };
+
+    let expected = ExpectedCounts {
+        t_initial: 1,
+        t2_initial: 0,
+        t_shared: 2,
+        t_single: 1,
+        t2_shared: 1,
+        t2_single: 0,
+    };
+
+    run_test_with_config(config, expected)
+}
+
+#[test]
+fn test_process_id_not_found_in_procfs() -> anyhow::Result<()> {
+    let tmp = prepare_procfs_mock()?;
+    let base_path = tmp.path().to_path_buf();
+
+    let mut plugins = PluginSet::new();
+
+    let source_config = Config {
+        processes_metrics: string_vec(&["metric_a", "metric_b"]),
+        proc_path: base_path,
+        ..Default::default()
+    };
+
+    plugins.add_plugin(PluginInfo {
+        metadata: PluginMetadata::from_static::<DumbNvmlPlugin>(),
+        enabled: true,
+        config: None,
+    });
+    plugins.add_plugin(PluginInfo {
+        metadata: PluginMetadata::from_static::<ProcessToCgroupBridgePlugin>(),
+        enabled: true,
+        config: Some(config_to_toml_table(&source_config)),
+    });
+
+    let make_input = move |ctx: &mut TransformCheckInputContext| -> MeasurementBuffer {
+        let metric = ctx
+            .metrics()
+            .by_name("metric_a")
+            .expect("metric_a metric should exist")
+            .0;
+        let mut m = MeasurementBuffer::new();
+        let point = MeasurementPoint::new_untyped(
+            *T,
+            metric,
+            Resource::LocalMachine,
+            ResourceConsumer::Process { pid: 42 },
+            WrappedMeasurementValue::U64(10),
+        );
+        m.push(point);
+        m
+    };
+
+    let check_output = move |measurements: &MeasurementBuffer| {
+        assert_eq!(measurements.len(), 1);
+        assert_eq!(
+            measurements.iter().next().unwrap().consumer,
+            ResourceConsumer::Process { pid: 42 }
+        );
+    };
+
+    let runtime_expectations = RuntimeExpectations::new().test_transform(
+        TransformName::from_str("process-to-cgroup-bridge", "transform"),
+        make_input,
+        check_output,
+    );
+
+    let agent = agent::Builder::new(plugins)
+        .with_expectations(runtime_expectations)
+        .build_and_start()
+        .unwrap();
+
+    agent.wait_for_shutdown(Duration::from_secs(2)).unwrap();
+
+    Ok(())
+}
+
+fn prepare_procfs_mock() -> anyhow::Result<TempDir> {
+    let tmp = tempdir()?;
+
+    let entries = [
+        Entry {
+            path: "1",
+            entry_type: EntryType::Dir,
+        },
+        Entry {
+            path: "2",
+            entry_type: EntryType::Dir,
+        },
+        Entry {
+            path: "3",
+            entry_type: EntryType::Dir,
+        },
+        Entry {
+            path: "1/cgroup",
+            entry_type: EntryType::File("0::/system.slice/shared.slice"),
+        },
+        Entry {
+            path: "2/cgroup",
+            entry_type: EntryType::File("0::/system.slice/shared.slice"),
+        },
+        Entry {
+            path: "3/cgroup",
+            entry_type: EntryType::File("0::/system.slice/single.slice"),
+        },
+    ];
+
+    let base_path = tmp.path().to_path_buf();
+
+    create_mock_layout(base_path, &entries)?;
+    Ok(tmp)
+}
+
+fn prepare_mock_measurements(ctx: &mut TransformCheckInputContext) -> anyhow::Result<MeasurementBuffer> {
+    let metric_a = ctx
+        .metrics()
+        .by_name("metric_a")
+        .expect("metric_a metric should exist")
+        .0;
+    let metric_b = ctx
+        .metrics()
+        .by_name("metric_b")
+        .expect("metric_b metric should exist")
+        .0;
+
+    let mut m = MeasurementBuffer::new();
+
+    let create_point = |timestamp, metric, consumer, value| {
+        MeasurementPoint::new_untyped(
+            timestamp,
+            metric,
+            Resource::LocalMachine,
+            consumer,
+            WrappedMeasurementValue::U64(value),
+        )
+    };
+
+    // metric_a points
+    m.push(create_point(*T, metric_a, ResourceConsumer::Process { pid: 1 }, 10));
+    m.push(create_point(*T2, metric_a, ResourceConsumer::Process { pid: 1 }, 10));
+    m.push(create_point(*T, metric_a, ResourceConsumer::Process { pid: 2 }, 10));
+    m.push(create_point(*T, metric_a, ResourceConsumer::Process { pid: 3 }, 10));
+    m.push(create_point(*T, metric_a, ResourceConsumer::LocalMachine, 10));
+
+    // metric_b points
+    m.push(create_point(*T, metric_b, ResourceConsumer::Process { pid: 1 }, 10));
+    m.push(create_point(*T, metric_b, ResourceConsumer::Process { pid: 2 }, 10));
+
+    Ok(m)
+}
+
+fn config_to_toml_table(config: &Config) -> toml::Table {
+    toml::Table::try_from(config).unwrap().clone()
+}
+
+// Mock filesystem utilities
+enum EntryType {
+    File(&'static str),
+    Dir,
+}
+
+struct Entry {
+    pub path: &'static str,
+    pub entry_type: EntryType,
+}
+
+fn create_mock_layout(base_path: PathBuf, entries: &[Entry]) -> std::io::Result<()> {
+    for entry in entries {
+        let full_path = base_path.join(entry.path);
+        match &entry.entry_type {
+            EntryType::Dir => fs::create_dir_all(&full_path)?,
+            EntryType::File(content) => {
+                if let Some(parent) = full_path.parent() {
+                    fs::create_dir_all(parent)?;
+                }
+                let mut file = File::create(full_path)?;
+                file.write_all(content.as_bytes())?;
+            }
+        }
+    }
+    Ok(())
+}
+
+// Mock plugin implementations
+struct DumbNvmlPlugin;
+
+impl AlumetPlugin for DumbNvmlPlugin {
+    fn name() -> &'static str {
+        "dumb"
+    }
+
+    fn version() -> &'static str {
+        "0.1.0"
+    }
+
+    fn default_config() -> anyhow::Result<Option<alumet::plugin::ConfigTable>> {
+        Ok(None)
+    }
+
+    fn init(_config: alumet::plugin::ConfigTable) -> anyhow::Result<Box<Self>> {
+        Ok(Box::new(Self))
+    }
+
+    fn start(&mut self, alumet: &mut alumet::plugin::AlumetPluginStart) -> anyhow::Result<()> {
+        let metric_a = alumet.create_metric("metric_a", Unit::Unity, "Some metric for tests purpose")?;
+        let metric_b = alumet.create_metric("metric_b", Unit::Unity, "Some metric for tests purpose")?;
+
+        let source = Box::new(DumbNvmlSource {
+            _metric_a: metric_a,
+            _metric_b: metric_b,
+        });
+        alumet.add_source("tests", source, TriggerSpec::at_interval(Duration::from_secs(1)))?;
+
+        Ok(())
+    }
+
+    fn stop(&mut self) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+struct DumbNvmlSource {
+    _metric_a: TypedMetricId<u64>,
+    _metric_b: TypedMetricId<u64>,
+}
+
+impl Source for DumbNvmlSource {
+    fn poll(&mut self, _measurements: &mut MeasurementAccumulator, _timestamp: Timestamp) -> Result<(), PollError> {
+        Ok(())
+    }
+}
+fn string_vec(values: &[&str]) -> Vec<String> {
+    values.into_iter().map(|s| s.to_string()).collect()
+}

--- a/plugin-process-to-cgroup-bridge/src/transform.rs
+++ b/plugin-process-to-cgroup-bridge/src/transform.rs
@@ -1,0 +1,179 @@
+use alumet::{
+    measurement::{MeasurementBuffer, MeasurementPoint, WrappedMeasurementValue},
+    metrics::RawMetricId,
+    pipeline::{
+        elements::{error::TransformError, transform::TransformContext},
+        Transform,
+    },
+    resources::ResourceConsumer,
+};
+use anyhow::{anyhow, Context};
+use std::{collections::HashMap, fs, path::PathBuf, time::UNIX_EPOCH};
+
+pub struct ProcessToCgroupBridgeTransform {
+    processes_metrics_ids: Vec<RawMetricId>,
+    merge_similar_cgroups: bool,
+    keep_processed_measurements: bool,
+
+    #[cfg(test)]
+    proc_path: PathBuf,
+}
+
+impl Transform for ProcessToCgroupBridgeTransform {
+    fn apply(&mut self, measurements: &mut MeasurementBuffer, _ctx: &TransformContext) -> Result<(), TransformError> {
+        let mut cgroup_measurements = MeasurementBuffer::new();
+        let mut kept_measurements = MeasurementBuffer::new();
+        for measurement in measurements.iter() {
+            match self.cgroup_measurement_from_measurement(measurement) {
+                Ok(Some(cgroup_measurement)) => {
+                    cgroup_measurements.push(cgroup_measurement);
+                    if self.keep_processed_measurements {
+                        kept_measurements.push(measurement.clone());
+                    }
+                }
+                Ok(None) => kept_measurements.push(measurement.clone()),
+                Err(e) => {
+                    kept_measurements.push(measurement.clone());
+                    log::error!(
+                        "error while transforming measurement to cgroup measurement: {e} - keeping old measurement"
+                    )
+                }
+            }
+        }
+
+        if self.merge_similar_cgroups {
+            let mut aggregated_cgroup_measurements = aggregate_cgroups_measurements(&mut cgroup_measurements);
+            cgroup_measurements.clear();
+            cgroup_measurements.merge(&mut aggregated_cgroup_measurements);
+        }
+
+        measurements.clear();
+        measurements.merge(&mut kept_measurements);
+        measurements.merge(&mut cgroup_measurements);
+
+        Ok(())
+    }
+}
+
+impl ProcessToCgroupBridgeTransform {
+    pub fn new(
+        processes_metrics_ids: Vec<RawMetricId>,
+        merge_similar_cgroups: bool,
+        keep_processed_measurements: bool,
+
+        #[cfg(test)] proc_path: PathBuf,
+    ) -> Self {
+        Self {
+            processes_metrics_ids,
+            merge_similar_cgroups,
+            keep_processed_measurements,
+
+            #[cfg(test)]
+            proc_path,
+        }
+    }
+
+    fn cgroup_measurement_from_measurement(
+        &self,
+        measurement: &MeasurementPoint,
+    ) -> anyhow::Result<Option<MeasurementPoint>> {
+        if !self.processes_metrics_ids.contains(&measurement.metric) {
+            return Ok(None);
+        }
+        let pid = match extract_process_id_from_measurement(measurement) {
+            Ok(pid) => pid,
+            Err(_) => return Ok(None),
+        };
+        let cgroup_path = self.find_cgroup_path_from_process_id(pid)?;
+        let cgroup_consumer = ResourceConsumer::ControlGroup {
+            path: cgroup_path.into(),
+        };
+        let mut cgroup_measurement = measurement.clone();
+        cgroup_measurement.consumer = cgroup_consumer;
+        Ok(Some(cgroup_measurement))
+    }
+
+    fn find_cgroup_path_from_process_id(&self, pid: u32) -> anyhow::Result<String> {
+        let procfs_cgroup_base_path = self.get_proc_path();
+        println!("PROC PATH: {procfs_cgroup_base_path:?}");
+
+        let procfs_cgroup_filepath = procfs_cgroup_base_path.join(pid.to_string()).join("cgroup");
+
+        let contents = fs::read_to_string(&procfs_cgroup_filepath)
+            .with_context(|| format!("failed to read {:?}", procfs_cgroup_filepath))?;
+
+        // a typical procfs cgroup file will contain only one line
+        // eg: 0::/system.slice/docker-7c7fc86f5f2a609c41c6edd65bd1b64135124a687fa6516f6b177b040d6e3b68.scope
+        for line in contents.lines() {
+            let parts: Vec<&str> = line.split(':').collect();
+            if parts.len() >= 3 {
+                let cgroup_path = parts[2];
+                if !cgroup_path.is_empty() {
+                    return Ok(cgroup_path.to_string());
+                }
+            }
+        }
+
+        Err(anyhow!(
+            "no cgroup path found for process id {pid} - searched on path {procfs_cgroup_filepath:?}"
+        ))
+    }
+
+    #[cfg(not(test))]
+    fn get_proc_path(&self) -> PathBuf {
+        PathBuf::from("/proc")
+    }
+
+    #[cfg(test)]
+    fn get_proc_path(&self) -> PathBuf {
+        self.proc_path.clone()
+    }
+}
+
+fn extract_process_id_from_measurement(measurement: &MeasurementPoint) -> anyhow::Result<u32> {
+    match measurement.consumer {
+        ResourceConsumer::Process { pid } => Ok(pid),
+        _ => Err(anyhow!(
+            "expected a process resource consumer, got something else: {:?}",
+            measurement.consumer
+        )),
+    }
+}
+
+/// Aggregates measurements with the same metric, consumer and timestamp by calculating their mean value.
+/// Groups are identified by (metric_id, consumer, timestamp) and all measurements in each
+/// group are averaged together.
+fn aggregate_cgroups_measurements(measurements: &mut MeasurementBuffer) -> MeasurementBuffer {
+    let mut grouped: HashMap<(RawMetricId, ResourceConsumer, u64), Vec<&MeasurementPoint>> = HashMap::new();
+
+    // Group by (metric_id, consumer, timestamp)
+    for point in measurements.iter() {
+        let ts = point.timestamp.duration_since(UNIX_EPOCH.into()).unwrap().as_secs();
+        let key = (point.metric, point.consumer.clone(), ts);
+        grouped.entry(key).or_default().push(point);
+    }
+
+    let mut aggregates = MeasurementBuffer::new();
+
+    // Calculate mean value for every group and create aggregated point
+    for ((_metric, _consumer, _timestamp), group) in grouped {
+        let (sum, count) = group
+            .iter()
+            .filter_map(|p| extract_numeric_value(p))
+            .fold((0.0, 0), |(sum, count), value| (sum + value, count + 1));
+
+        let mean = if count > 0 { sum / count as f64 } else { 0.0 };
+
+        let mut new_point = group[0].clone(); // cannot panic since group cannot be empty
+        new_point.value = WrappedMeasurementValue::F64(mean);
+        aggregates.push(new_point);
+    }
+    aggregates
+}
+
+fn extract_numeric_value(measurement: &MeasurementPoint) -> Option<f64> {
+    match measurement.value {
+        WrappedMeasurementValue::F64(v) => Some(v),
+        WrappedMeasurementValue::U64(v) => Some(v as f64),
+    }
+}


### PR DESCRIPTION
Add a new **Transform** plugin called `process-to-cgroup-bridge`.

This plugin aims to be enabled when `plugin-nvidia-nvml` (input) is enable.

It will find the cgroup related to the process measurement and will set it as the measurement consumer.
The plugin come with configuration:

- ability to filter the metrics impacted by this plugin
- ability to merge the measurements coming from different processes but with same cgroup at same timestamp
- ability to not keep measurements that have been transformed

The plugin also comes with integration tests that have been placed under `src` because needed some `#[cfg(test)]` tags that are not available in `tests` subdir.