### PR TITLE
feat(plugin-grace-hopper): Energy instead of power

### DIFF
--- a/alumet/src/measurement.rs
+++ b/alumet/src/measurement.rs
@@ -184,6 +184,19 @@ impl Timestamp {
     pub fn duration_since(&self, earlier: Timestamp) -> Result<Duration, SystemTimeError> {
         self.0.duration_since(earlier.0)
     }
+
+    pub fn from_unix_timestamp(secs: u64, nanos: u32) -> Self {
+        let duration = Duration::new(secs, nanos);
+        Self(SystemTime::UNIX_EPOCH + duration)
+    }
+
+    pub fn add_duration(&self, duration: Duration) -> Self {
+        Self(self.0 + duration)
+    }
+
+    pub fn sub_duration(&self, duration: Duration) -> Self {
+        Self(self.0 - duration)
+    }
 }
 
 impl From<SystemTime> for Timestamp {

--- a/plugin-grace-hopper/src/lib.rs
+++ b/plugin-grace-hopper/src/lib.rs
@@ -118,7 +118,7 @@ fn get_sensor_from_dir(entry: DirEntry) -> Result<Option<Sensor>, anyhow::Error>
         return Ok(None);
     }
     let file = File::open(&device_file).context("failed to open the file")?;
-    let (kind, socket) = get_sensor_information_from_file(file)?;
+    let (kind, socket) = get_sensor_information_from_file(&file)?;
     Ok(Some(Sensor {
         kind,
         socket,
@@ -135,8 +135,8 @@ fn get_sensor_from_dir(entry: DirEntry) -> Result<Option<Sensor>, anyhow::Error>
 /// Returns a [Result] containing a tuple `(String, u32)` on success
 /// - The first element of the tuple (`String`) represents the sensor type (e.g., "grace", "cpu").
 /// - The second element (`u32`) represents the associated socket number.
-fn get_sensor_information_from_file(file: File) -> Result<(String, u32), anyhow::Error> {
-    let reader = io::BufReader::new(&file);
+fn get_sensor_information_from_file(file: &File) -> Result<(String, u32), anyhow::Error> {
+    let reader = io::BufReader::new(file);
     let mut lines = reader.lines();
     let kind: String;
     let socket: u32;
@@ -187,8 +187,8 @@ mod tests {
     use super::*;
     use crate::GraceHopperPlugin;
     use anyhow::Result;
-    use std::fs::File;
-    use std::io::Write;
+    use std::fs::{File, OpenOptions};
+    use std::io::{Seek, Write};
     use std::time::Duration;
     use tempfile::tempdir;
 
@@ -221,7 +221,7 @@ mod tests {
             let file = File::open(&file_path)
                 .context("Failed to open the file")
                 .expect("Can't open the file when testing");
-            let result = get_sensor_information_from_file(file);
+            let result = get_sensor_information_from_file(&file);
             assert!(result.is_ok(), "Expected Ok for input '{}'", line);
             let sensor_struct = result.unwrap();
             // Check content
@@ -275,5 +275,125 @@ mod tests {
         let mut plugin = fake_grace_hopper_plugin();
         let result = plugin.stop();
         assert!(result.is_ok(), "Stop should complete without errors.");
+    }
+
+    #[test]
+    fn test_get_sensor_from_dir_not_dir() {
+        let root = tempdir().unwrap();
+        let root_path = root.path();
+        let file_path = root.path().join("Clara_Oswald");
+        let mut _file = File::create(&file_path).unwrap();
+        // std::thread::sleep(Duration::from_secs(30));
+
+        let entries = fs::read_dir(root_path.clone()).unwrap();
+        for entry in entries {
+            let result = get_sensor_from_dir(entry.unwrap());
+            match result {
+                Ok(_) => assert!(false),
+                Err(e) => {
+                    assert_eq!(e.to_string(), "path is not a directory");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_get_sensor_from_dir_missing_file_interval() {
+        let root = tempdir().unwrap();
+        let root_path = root.path();
+        let file_path_info = root_path.clone().join("mySensor/device/power1_oem_info");
+        let file_path_average = root_path.clone().join("mySensor/device/power1_average");
+        std::fs::create_dir_all(file_path_info.parent().unwrap()).unwrap();
+        let mut file = File::create(&file_path_info).unwrap();
+        let mut file_avg = File::create(&file_path_average).unwrap();
+        writeln!(file, "Module Power Socket 0").unwrap();
+        writeln!(file_avg, "123456789").unwrap();
+
+        let entries = fs::read_dir(root_path).unwrap();
+        for entry in entries {
+            let Ok(entry) = entry else { continue };
+            let result = get_sensor_from_dir(entry);
+            match result {
+                Ok(sensor) => {
+                    assert_eq!(50, sensor.unwrap().average_interval.as_millis());
+                }
+                Err(_) => assert!(false),
+            }
+        }
+    }
+
+    #[test]
+    fn test_get_sensor_from_dir_missing_file_device() {
+        let root = tempdir().unwrap();
+        let root_path = root.path();
+        let file_path_average = root_path.clone().join("mySensor/device/power1_average");
+        std::fs::create_dir_all(file_path_average.parent().unwrap()).unwrap();
+        let mut file_avg = File::create(&file_path_average).unwrap();
+        writeln!(file_avg, "11558822").unwrap();
+
+        let entries = fs::read_dir(root_path).unwrap();
+        for entry in entries {
+            let Ok(entry) = entry else { continue };
+            let result = get_sensor_from_dir(entry);
+            match result {
+                Ok(sensor) => {
+                    assert!(sensor.is_none());
+                }
+                Err(_) => assert!(false),
+            }
+        }
+    }
+
+    #[test]
+    fn test_get_sensor_information_from_file() {
+        let root = tempdir().unwrap();
+        let root_path = root.path();
+        let file_average = root_path.clone().join("myFile");
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&file_average)
+            .unwrap();
+
+        // Check for correct parsing
+        writeln!(file, "Grace Power Socket 3").unwrap();
+        file.rewind().expect("Can't rewind to the beginning of a stream");
+        let (kind, socket) = get_sensor_information_from_file(&file).unwrap();
+        assert_eq!("Grace", kind);
+        assert_eq!(3, socket);
+
+        // Check error when trying to parse line with missing informations
+        file.set_len(0).expect("Can't set the file size to 0");
+        writeln!(file, "Grace Power 3").unwrap();
+        file.rewind().expect("Can't rewind to the beginning of a stream");
+        let res = get_sensor_information_from_file(&file);
+        match res {
+            Ok(_) => assert!(false),
+            Err(e) => {
+                assert!(e.to_string().contains("can't parse the content of the file: "));
+            }
+        }
+
+        // Check error when trying to parse empty file
+        file.set_len(0).expect("Can't set the file size to 0");
+        let res = get_sensor_information_from_file(&file);
+        match res {
+            Ok(_) => assert!(false),
+            Err(e) => {
+                assert_eq!(e.to_string(), "failed to read the line from file");
+            }
+        }
+
+        // Check error when trying to parse file with more than one line
+        writeln!(file, "Grace Power Socket 3\n another line").unwrap();
+        file.rewind().expect("Can't rewind to the beginning of a stream");
+        let res = get_sensor_information_from_file(&file);
+        match res {
+            Ok(_) => assert!(false),
+            Err(e) => {
+                assert!(e.to_string().contains(", there is at least one line too many"));
+            }
+        }
     }
 }

--- a/plugin-grace-hopper/tests/tests.rs
+++ b/plugin-grace-hopper/tests/tests.rs
@@ -70,7 +70,7 @@ fn test_correct_plugin_init_with_one_source_empty_value() {
     });
 
     let startup_expectation = StartupExpectations::new()
-        .expect_metric::<u64>("consumption", PrefixedUnit::micro(alumet::units::Unit::Watt))
+        .expect_metric::<f64>("consumption", PrefixedUnit::micro(alumet::units::Unit::Watt))
         .expect_source("grace-hopper", "Module_0");
 
     let runtime_expectation = RuntimeExpectations::new().test_source(
@@ -79,7 +79,7 @@ fn test_correct_plugin_init_with_one_source_empty_value() {
         |m| {
             assert_eq!(m.len(), 1);
             for elm in m {
-                assert!(elm.value == WrappedMeasurementValue::U64(0));
+                assert!(elm.value == WrappedMeasurementValue::F64(0.0));
             }
         },
     );
@@ -105,9 +105,10 @@ fn test_correct_plugin_init_with_several_sources() {
     std::fs::create_dir_all(file_path_info.parent().unwrap()).unwrap();
     let mut file = File::create(&file_path_info).unwrap();
     let mut file_avg = File::create(&file_path_average).unwrap();
-    let mut _file_int = File::create(&file_path_interval).unwrap();
+    let mut file_int = File::create(&file_path_interval).unwrap();
     writeln!(file, "Module Power Socket 0").unwrap();
     writeln!(file_avg, "123456789").unwrap();
+    writeln!(file_int, "50").unwrap();
 
     let file_path_info = root.path().join("hwmon2/device/power1_oem_info");
     let file_path_average = root.path().join("hwmon2/device/power1_average");
@@ -135,9 +136,10 @@ fn test_correct_plugin_init_with_several_sources() {
     std::fs::create_dir_all(file_path_info.parent().unwrap()).unwrap();
     let mut file = File::create(&file_path_info).unwrap();
     let mut file_avg = File::create(&file_path_average).unwrap();
-    let mut _file_int = File::create(&file_path_interval).unwrap();
+    let mut file_int = File::create(&file_path_interval).unwrap();
     writeln!(file, "SysIO Power Socket 2").unwrap();
     writeln!(file_avg, "678954321").unwrap();
+    writeln!(file_int, "50").unwrap();
 
     let mut plugins = PluginSet::new();
     let config = Config {
@@ -152,7 +154,7 @@ fn test_correct_plugin_init_with_several_sources() {
     });
 
     let startup_expectation = StartupExpectations::new()
-        .expect_metric::<u64>("consumption", PrefixedUnit::micro(alumet::units::Unit::Watt))
+        .expect_metric::<f64>("consumption", PrefixedUnit::micro(alumet::units::Unit::Watt))
         .expect_source("grace-hopper", "Module_0")
         .expect_source("grace-hopper", "Grace_0")
         .expect_source("grace-hopper", "CPU_2")
@@ -165,7 +167,7 @@ fn test_correct_plugin_init_with_several_sources() {
             |m| {
                 assert_eq!(m.len(), 1);
                 for elm in m {
-                    assert!(elm.value == WrappedMeasurementValue::U64(123456789));
+                    assert!(elm.value == WrappedMeasurementValue::F64(123456789.0));
                 }
             },
         )
@@ -175,7 +177,7 @@ fn test_correct_plugin_init_with_several_sources() {
             |m| {
                 assert_eq!(m.len(), 1);
                 for elm in m {
-                    assert!(elm.value == WrappedMeasurementValue::U64(987654321));
+                    assert!(elm.value == WrappedMeasurementValue::F64(987654321.0));
                 }
             },
         )
@@ -185,7 +187,7 @@ fn test_correct_plugin_init_with_several_sources() {
             |m| {
                 assert_eq!(m.len(), 1);
                 for elm in m {
-                    assert!(elm.value == WrappedMeasurementValue::U64(1234598761));
+                    assert!(elm.value == WrappedMeasurementValue::F64(1234598761.0));
                 }
             },
         )
@@ -195,7 +197,7 @@ fn test_correct_plugin_init_with_several_sources() {
             |m| {
                 assert_eq!(m.len(), 1);
                 for elm in m {
-                    assert!(elm.value == WrappedMeasurementValue::U64(678954321));
+                    assert!(elm.value == WrappedMeasurementValue::F64(678954321.0));
                 }
             },
         );


### PR DESCRIPTION
- Add the energy instead of power in the return of plugin and also improve code test coverage
- Add some little functions in the `Timestamp` wrapper for easier use.

Tarpaulin output:
![image](https://github.com/user-attachments/assets/e9a423b0-97d9-438b-b454-477e74889123)
