### PR TITLE
feat(core): add event to trigger measurement at experiment end

### DIFF
--- a/alumet/src/agent/exec.rs
+++ b/alumet/src/agent/exec.rs
@@ -58,7 +58,7 @@ pub fn watch_process(
 
     // Publish an event to perform a measurement at the end of the experiment
     log::info!("Publishing EndConsumerMeasurement event");
-    crate::plugin::event::end_consumer_measurement().publish(EndConsumerMeasurement());
+    crate::plugin::event::end_consumer_measurement().publish(EndConsumerMeasurement);
 
     // Stop the pipeline
     agent.pipeline.control_handle().shutdown();

--- a/alumet/src/plugin/event.rs
+++ b/alumet/src/plugin/event.rs
@@ -165,7 +165,7 @@ pub struct StartResourceMeasurement(pub Vec<Resource>);
 
 /// Event occurring when measurements should be performed at the end of the consumer experiment.
 #[derive(Clone)]
-pub struct EndConsumerMeasurement();
+pub struct EndConsumerMeasurement;
 
 impl Event for StartConsumerMeasurement {}
 impl Event for StartResourceMeasurement {}


### PR DESCRIPTION
Adding a dedicated EventBus to perform a measurement at the end of the experiment because Plugin::stop is not suited for this, as it is called after the pipeline elements (sources, transforms, outputs) are stopped and dropped.
