### PR TITLE
ci: multi-arch docker images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,8 +76,12 @@ jobs:
   build-rpm:
     needs: gather-informations
     uses: alumet-dev/packaging/.github/workflows/build_rpm.yaml@main
+    strategy:
+      fail-fast: false
+      matrix: 
+        arch: [x86_64, aarch64]
     with:
-      arch: x86_64
+      arch: ${{ matrix.arch }}
       version: ${{ needs.gather-informations.outputs.version }}
       release-version: ${{ needs.gather-informations.outputs.release }}
       tag: ${{ needs.gather-informations.outputs.tag }}
@@ -97,8 +101,12 @@ jobs:
       - build-rpm
       - build-deb
     uses: alumet-dev/packaging/.github/workflows/build_docker.yaml@main
+    strategy:
+      fail-fast: false
+      matrix: 
+        arch: [x86_64, aarch64]
     with:
-      arch: x86_64
+      arch: ${{ matrix.arch }}
       version: ${{ needs.gather-informations.outputs.version }}
       release-version: ${{ needs.gather-informations.outputs.release }}
 
@@ -200,15 +208,36 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push images
+      - name: Push images with multi-arch support
         run: |
           tars=$(find ./docker-artifacts -type f)
+          declare -A base_to_arch_map
           for tar in $tars
             do
               image_tags=$(docker load -q -i $tar | sed 's/Loaded image: //g')
               for image_tag in $image_tags
                 do
                   docker push $image_tag
+                  # Prepare to create the multi-arch manifest
+                  base_tag="${image_tag%_aarch64}"
+                  base_tag="${base_tag%_x86_64}"
+                  arch="${image_tag##*_}"
+                  base_to_arch_map["$base_tag"]+="${arch} "
                 done
             done
+          for base in "${!base_to_arch_map[@]}"; do
+            archs=(${base_to_arch_map[$base]})
+            echo "Creating multi-arch manifest for: $base"
+            
+            cmd="docker manifest create $base"
+            for arch in "${archs[@]}"
+              do
+                cmd+=" ${base}_${arch}"
+              done
+
+            eval "$cmd"
+            docker manifest push "$base"
+
+          done
+
 


### PR DESCRIPTION
Depends on https://github.com/alumet-dev/packaging/pull/19 to enable automatic multi-arch docker images. 
Working with RPM-based images, pending to implement deb

Example in my fork using the artifacts from https://github.com/guigomcha/alumet-packaging/actions/runs/16568037066/job/46853651107:
```bash
docker manifest inspect ghcr.io/guigomcha/alumet-agent:0.0.0-1_ubi9.5
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1993,
         "digest": "sha256:9e1574c655cb1f2bf8c9bb83e65d6fbfdb5bc2eb35dc8687d163eca484b6ae18",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1993,
         "digest": "sha256:7a5f08c18cc42fa68b53e6c1a4fe380bc362ebfcd800ff5b57ec3e488836520b",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      }
   ]
```