### PR TITLE
Feature/add watch command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
  "indoc",
  "libc",
  "log",
- "nix",
+ "nc",
  "num_enum",
  "ordered-float",
  "rustc-hash",
@@ -2085,6 +2085,15 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nc"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c6d92d33b290df8a962fbf778711d529b11c92dc060cd675f1ce45a9a50977"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,7 @@ dependencies = [
  "indoc",
  "libc",
  "log",
+ "nix",
  "num_enum",
  "ordered-float",
  "rustc-hash",
@@ -146,9 +147,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -176,22 +177,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -504,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.5.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -514,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.5.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -526,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.41"
+version = "4.5.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -1209,9 +1210,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "heapless"
@@ -1664,7 +1665,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "serde",
 ]
 
@@ -1794,9 +1795,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libloading"
@@ -1805,7 +1806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -2977,9 +2978,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
 dependencies = [
  "unicode-ident",
 ]
@@ -3222,9 +3223,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -3232,9 +3233,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -3242,9 +3243,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.16"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7251471db004e509f4e75a62cca9435365b5ec7bcdff530d612ac7c87c44a792"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -3300,9 +3301,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.22"
+version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3496,9 +3497,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -3642,9 +3643,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.141"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "indexmap 2.10.0",
  "itoa",
@@ -3770,9 +3771,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
@@ -3785,9 +3786,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -4159,9 +4160,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4811,7 +4812,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -4847,10 +4848,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/agent/src/bin/main.rs
+++ b/agent/src/bin/main.rs
@@ -166,8 +166,8 @@ fn main() -> anyhow::Result<()> {
             }
         }
         cli::Command::Watch(process) => {
-            let timeout = Duration::from_secs(5);
-            let res = watch::watch_process(agent, process.pid, timeout);
+            let shutdown_timeout = Duration::from_secs(5);
+            let res = watch::watch_process(agent, process.pid, shutdown_timeout);
             if let Err(err @ watch::WatchError::ProcessWait(pid, e)) = &res {
                 match e.kind() {
                     std::io::ErrorKind::NotFound => {
@@ -410,7 +410,7 @@ mod cli {
     #[derive(Args)]
     pub struct Process {
         /// The PID to watch.
-        pub pid: String,
+        pub pid: u32,
     }
 
     #[derive(Args)]

--- a/core/alumet/Cargo.toml
+++ b/core/alumet/Cargo.toml
@@ -31,6 +31,7 @@ thiserror.workspace = true
 futures = "0.3.30"
 ordered-float = "4.6.0"
 num_enum = "0.7.3"
+nix = "0.30.1"
 
 # Dependencies for Linux builds only.
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/core/alumet/Cargo.toml
+++ b/core/alumet/Cargo.toml
@@ -31,7 +31,7 @@ thiserror.workspace = true
 futures = "0.3.30"
 ordered-float = "4.6.0"
 num_enum = "0.7.3"
-nix = "0.30.1"
+nc = "0.9"
 
 # Dependencies for Linux builds only.
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/core/alumet/src/agent/mod.rs
+++ b/core/alumet/src/agent/mod.rs
@@ -70,5 +70,6 @@ pub mod builder;
 pub mod config;
 pub mod exec;
 pub mod plugin;
+pub mod watch;
 
 pub use builder::{Builder, RunningAgent};

--- a/core/alumet/src/agent/watch.rs
+++ b/core/alumet/src/agent/watch.rs
@@ -1,0 +1,179 @@
+//! Watch processes through it's pid
+//! 
+use mio::{unix::SourceFd, Events, Interest, Poll, Token, Waker};
+use std::{fs::File, io::{ErrorKind, Read}, num::ParseIntError, os::fd::AsRawFd, process::ExitStatus, time::Duration};
+use thiserror::Error;
+
+use anyhow::Context;
+
+use crate::pipeline::{control::request, matching::SourceNamePattern, MeasurementPipeline};
+
+use super::{builder::ShutdownError, RunningAgent};
+
+/// Error that can occur in [`watch_process`].
+#[derive(Error, Debug)]
+pub enum WatchError {
+    /// The process could not be spawned.
+    #[error("failed to check process with pid {0}")]
+    PidCheck(String, #[source] std::num::ParseIntError),
+    /// The process's files could not be reached.
+    #[error("failed to check reach file: {1} for pid {0}")]
+    PidFilesCheck(String, String, #[source] std::io::Error),
+    /// The process has spawned but waiting for it has failed.
+    #[error("failed to wait for pid {0}")]
+    ProcessWait(u32, #[source] std::io::Error),
+    /// An error occurred while waiting for the agent to shut down.
+    #[error("error in shutdown")]
+    Shutdown(#[source] ShutdownError),
+     // #[error("read error")]
+    // MountRead(#[from] ReadError),
+    #[error("failed to initialize epoll")]
+    PollInit(#[source] std::io::Error),
+    #[error("poll.poll() returned an error")]
+    PollPoll(#[source] std::io::Error),
+    #[error("failed to register a timer to epoll")]
+    PollTimer(#[source] std::io::Error),
+    #[error("could not set up a timer with delay {0:?} for event coalescing")]
+    Timerfd(Duration, #[source] std::io::Error),
+    #[error("failed to stop epoll from another thread")]
+    Stop(#[source] std::io::Error),
+}
+
+const MOUNT_TOKEN: Token = Token(0);
+const TIMER_TOKEN: Token = Token(1);
+const STOP_TOKEN: Token = Token(2);
+const POLL_TIMEOUT: Duration = Duration::from_secs(5);
+const PROC_MOUNTS_PATH: &str = "/proc/mounts";
+const TRIGGER_TIMEOUT: Duration = Duration::from_secs(1);
+
+
+/// Watch process that runs identified by it's pid until it's end.
+///
+/// The measurement sources are triggered before the process spawns and after it exits.
+///
+/// After the process exits, the pipeline must stop within `shutdown_timeout`, or an error is returned.
+pub fn watch_process(
+    agent: RunningAgent,
+    pid: String,
+    shutdown_timeout: Duration,
+) -> Result<(), WatchError> {
+    println!("THIS IS WATCH COMMAND");
+    log::error!("THIS IS WATCH COMMAND - {pid}");
+
+    // Check if we can convert the pid to u332
+    let pid_u32 = pid
+        .parse::<u32>()
+        .map_err(|e| WatchError::PidCheck(pid.to_string(), e))?;
+
+    if let Err(e) = trigger_measurement_now(&agent.pipeline) {
+        log::error!("Could not trigger a first measurement before the child spawn: {e}");
+    }
+
+    // Spawn the process and wait for it to exit.
+    let exit_status = wait_child(pid)?;
+    log::info!("Child process exited with status {exit_status}, Alumet will now stop.");
+
+    // One last measurement.
+    if let Err(e) = trigger_measurement_now(&agent.pipeline) {
+        log::error!("Could not trigger one last measurement after the child exit: {e}");
+    }
+
+    // Stop the pipeline
+    agent.pipeline.control_handle().shutdown();
+    agent.wait_for_shutdown(shutdown_timeout).map_err(WatchError::Shutdown)
+}
+
+/// Spawns a child process and waits for it to exit.
+fn wait_child(pid: String) -> Result<ExitStatus, WatchError> {
+    // According to `man proc_mounts`, a filesystem mount or unmount causes
+    // `poll` and `epoll_wait` to mark the file as having a PRIORITY event.
+    let path = format!("/proc/{pid}/mounts");
+    let fd = File::open(&path).map_err( |e | WatchError::PidFilesCheck(pid.clone(), path, e))?;
+    let binding = fd.as_raw_fd();
+    let mut fd = SourceFd(&binding);
+    
+    // Prepare epoll.
+    let mut poll = Poll::new().map_err(WatchError::PollInit)?;
+    let stop_waker = Waker::new(poll.registry(), STOP_TOKEN).map_err(WatchError::PollInit)?;
+
+    poll.registry()
+        .register(&mut fd, MOUNT_TOKEN, Interest::READABLE | Interest::PRIORITY)
+        .map_err(WatchError::PollInit)?;
+
+    let mut events = Events::with_capacity(8); // we don't expect many events
+    // let mut state = State::new(callback);
+
+    loop {
+        let poll_res = poll.poll(&mut events, Some(POLL_TIMEOUT));
+        println!("^^^^^^^^^^^^^^^^^ poll res: {:?}\n", poll_res);
+        if let Err(e) = poll_res {
+            if e.kind() == ErrorKind::Interrupted {
+                log::error!("Interrupted: continue");
+                break; // retry
+            } else {
+                log::error!("propagate error");
+                return Err(WatchError::PollPoll(e)); // propagate error
+            }
+        }
+
+        // Call next() because we are not interested in each individual event.
+        // If the timeout elapses, the event list is empty.
+        // println!("Event is: {:?}", events);
+        // if let Some(event) = events.iter().next() {
+        //     log::debug!("event on /proc/{pid}/mounts: {event:?}");
+
+        //     // the stop_waker has been triggered, which means that we must stop now
+        //     if event.token() == STOP_TOKEN {
+        //         log::error!("BREAK: Stop");
+        //         break; // stop
+        //     }
+        // }
+        for event in events.iter() {
+            if event.token() == STOP_TOKEN {
+                // Handle stop condition
+                break; // stop
+            }
+
+            if event.token() == MOUNT_TOKEN {
+                if event.is_readable() || event.is_priority() {
+                    // Read the contents of the mounts file
+                    println!("!!!!!!!!!!!!! Current mounts:\n");
+                }
+            }
+        }
+    }
+
+    //Await, attendre... ?
+
+    log::error!("WAITING");
+    let status = 1;
+
+    // // Spawn the process.
+    // let mut p = Command::new(external_command.clone())
+    //     .args(args)
+    //     .spawn()
+    //     .map_err(|e| WatchError::ProcessSpawn(external_command.clone(), e))?;
+
+    // // Notify the plugins that there is a process to observe.
+    // let pid = p.id();
+    // log::info!("Child process '{external_command}' spawned with pid {pid}.");
+    // crate::plugin::event::start_consumer_measurement()
+    //     .publish(StartConsumerMeasurement(vec![ResourceConsumer::Process { pid }]));
+
+    // // Wait for the process to terminate.
+    // let status = p.wait().map_err(|e| WatchError::ProcessWait(pid, e))?;
+    Ok(ExitStatus::default())
+}
+
+// Triggers one measurement (on all sources that support manual trigger).
+fn trigger_measurement_now(pipeline: &MeasurementPipeline) -> anyhow::Result<()> {
+    let control_handle = pipeline.control_handle();
+    let send_task = control_handle.send_wait(
+        request::source(SourceNamePattern::wildcard()).trigger_now(),
+        TRIGGER_TIMEOUT,
+    );
+    pipeline
+        .async_runtime()
+        .block_on(send_task)
+        .context("failed to send TriggerMessage")
+}


### PR DESCRIPTION
Added a watch command to the alumet agent. Both option to watch a process trough it's PID. 

- Use of `pidfd_open` system call available on Kernel version >= 5.3
- Look for the existence of file `/proc/$pid`

Also some refactorization due to `exec` command with use `watch` terms

Close #120 