### PR TITLE
feat(core): start a source in pause mode

### DIFF
--- a/alumet/src/pipeline/control/request.rs
+++ b/alumet/src/pipeline/control/request.rs
@@ -22,7 +22,7 @@ pub mod any;
 mod create;
 pub(super) mod introspect;
 mod output;
-mod source;
+pub mod source;
 mod transform;
 
 pub use create::{create_many, create_one, CreationRequest, MultiCreationRequestBuilder, SingleCreationRequestBuilder};

--- a/alumet/src/pipeline/elements/source.rs
+++ b/alumet/src/pipeline/elements/source.rs
@@ -1,7 +1,7 @@
 //! Implementation and control of source tasks.
 
 pub mod builder;
-pub(crate) mod control;
+pub mod control;
 pub mod error;
 pub mod interface;
 pub mod run;

--- a/alumet/src/pipeline/elements/source/builder.rs
+++ b/alumet/src/pipeline/elements/source/builder.rs
@@ -10,6 +10,7 @@ use crate::{
     },
 };
 
+use super::control::TaskState;
 use super::interface::{AutonomousSource, Source};
 use super::trigger::TriggerSpec;
 
@@ -26,6 +27,7 @@ use super::trigger::TriggerSpec;
 /// use std::time::Duration;
 /// use alumet::pipeline::elements::source::builder::{ManagedSource, ManagedSourceBuilder, ManagedSourceBuildContext};
 /// use alumet::pipeline::elements::source::trigger;
+/// use alumet::pipeline::elements::source::control::TaskState;
 /// use alumet::pipeline::Source;
 ///
 /// fn build_my_source() -> anyhow::Result<Box<dyn Source>> {
@@ -35,6 +37,7 @@ use super::trigger::TriggerSpec;
 /// let builder: &dyn ManagedSourceBuilder = &|ctx: &mut dyn ManagedSourceBuildContext| {
 ///     let source = build_my_source()?;
 ///     Ok(ManagedSource {
+///         initial_state: TaskState::Run,
 ///         trigger_spec: trigger::TriggerSpec::at_interval(Duration::from_secs(1)),
 ///         source,
 ///     })
@@ -139,6 +142,7 @@ impl std::fmt::Debug for SendSourceBuilder {
 
 /// Information required to register a new managed source to the measurement pipeline.
 pub struct ManagedSource {
+    pub initial_state: TaskState,
     pub trigger_spec: TriggerSpec,
     pub source: Box<dyn Source>,
 }

--- a/alumet/src/pipeline/elements/source/control.rs
+++ b/alumet/src/pipeline/elements/source/control.rs
@@ -80,7 +80,7 @@ pub(super) enum Reconfiguration {
 /// State of a (managed) source task.
 #[derive(Clone, Debug, PartialEq, Eq, Copy, IntoPrimitive, FromPrimitive)]
 #[repr(u8)]
-pub(super) enum TaskState {
+pub enum TaskState {
     Run,
     Pause,
     #[num_enum(default)]
@@ -274,7 +274,12 @@ impl TaskManager {
                 let mut source = build(ctx).context("managed source creation failed")?;
 
                 // Apply constraints on the source trigger
-                log::trace!("New managed source: {} with spec {:?}", name, source.trigger_spec);
+                log::trace!(
+                    "New managed source: {} with spec {:?} and initial state {:?}",
+                    name,
+                    source.trigger_spec,
+                    source.initial_state
+                );
                 source.trigger_spec.constrain(&self.trigger_constraints);
                 log::trace!("spec after constraints: {:?}", source.trigger_spec);
 
@@ -296,7 +301,7 @@ impl TaskManager {
                 log::trace!("new trigger created from the spec");
 
                 // Create a controller to control the async task.
-                let (controller, config) = super::task_controller::new_managed(trigger);
+                let (controller, config) = super::task_controller::new_managed(trigger, source.initial_state);
                 self.controllers.push((name.clone(), controller));
                 log::trace!("new controller initialized");
 

--- a/alumet/src/pipeline/elements/source/task_controller.rs
+++ b/alumet/src/pipeline/elements/source/task_controller.rs
@@ -32,11 +32,14 @@ pub struct SharedSourceConfig {
     pub manual_trigger: Option<ManualTrigger>,
 }
 
-pub fn new_managed(initial_trigger: Trigger) -> (SingleSourceController, Arc<SharedSourceConfig>) {
+pub fn new_managed(
+    initial_trigger: Trigger,
+    initial_state: TaskState,
+) -> (SingleSourceController, Arc<SharedSourceConfig>) {
     let manual_trigger = initial_trigger.manual_trigger();
     let config = Arc::new(SharedSourceConfig {
         change_notifier: Notify::new(),
-        atomic_state: AtomicU8::new(TaskState::Run as u8),
+        atomic_state: AtomicU8::new(initial_state as u8),
         new_trigger: Mutex::new(Some(initial_trigger)),
         manual_trigger,
     });

--- a/alumet/src/plugin/phases.rs
+++ b/alumet/src/plugin/phases.rs
@@ -11,6 +11,7 @@ use crate::metrics::online::{MetricReader, MetricSender};
 use crate::metrics::registry::MetricRegistry;
 use crate::pipeline::control::key::{OutputKey, SourceKey, TransformKey};
 use crate::pipeline::elements::source::builder::{ManagedSource, SourceBuilder};
+use crate::pipeline::elements::source::control::TaskState;
 use crate::pipeline::elements::source::trigger::TriggerSpec;
 use crate::pipeline::elements::{output, source, transform};
 use crate::pipeline::naming::{namespace::DuplicateNameError, PluginName};
@@ -112,7 +113,23 @@ impl<'a> AlumetPluginStart<'a> {
         source: Box<dyn Source>,
         trigger_spec: TriggerSpec,
     ) -> Result<SourceKey, DuplicateNameError> {
-        self.add_source_builder(name, |_| Ok(ManagedSource { trigger_spec, source }))
+        self.add_source_with_state(name, source, TaskState::Run, trigger_spec)
+    }
+
+    pub fn add_source_with_state(
+        &mut self,
+        name: &str,
+        source: Box<dyn Source>,
+        initial_state: TaskState,
+        trigger_spec: TriggerSpec,
+    ) -> Result<SourceKey, DuplicateNameError> {
+        self.add_source_builder(name, move |_| {
+            Ok(ManagedSource {
+                trigger_spec,
+                initial_state,
+                source,
+            })
+        })
     }
 
     /// Adds the builder of a _managed_ measurement source to the Alumet pipeline.

--- a/alumet/tests/errors/plugin.rs
+++ b/alumet/tests/errors/plugin.rs
@@ -8,6 +8,7 @@ use super::points::{error_point, panic_point};
 use alumet::measurement::{MeasurementAccumulator, MeasurementBuffer, Timestamp};
 use alumet::pipeline::elements::error::PollError;
 use alumet::pipeline::elements::output::{OutputContext, WriteError};
+use alumet::pipeline::elements::source::control::TaskState;
 use alumet::pipeline::elements::source::{builder::ManagedSource, trigger::TriggerSpec};
 use alumet::pipeline::elements::transform::{TransformContext, TransformError};
 use alumet::pipeline::{Output, Source, Transform};
@@ -51,6 +52,7 @@ impl AlumetPlugin for BadPlugin {
             .add_source_builder("source1", |_| {
                 error_point!(source1_build);
                 Ok(ManagedSource {
+                    initial_state: TaskState::Run,
                     trigger_spec: TriggerSpec::at_interval(Duration::from_millis(100)),
                     source: Box::new(BadSource1),
                 })
@@ -82,6 +84,7 @@ impl AlumetPlugin for BadPlugin {
         let create_source2 = request::create_one().add_source_builder("source2", |_| {
             error_point!(source2_build);
             Ok(ManagedSource {
+                initial_state: TaskState::Run,
                 trigger_spec: TriggerSpec::at_interval(Duration::from_millis(100)),
                 source: Box::new(BadSource2),
             })
@@ -89,6 +92,7 @@ impl AlumetPlugin for BadPlugin {
         let create_source3 = request::create_one().add_source_builder("source3", |_| {
             error_point!(source3_build);
             Ok(ManagedSource {
+                initial_state: TaskState::Run,
                 trigger_spec: TriggerSpec::at_interval(Duration::from_millis(100)),
                 source: Box::new(BadSource3),
             })


### PR DESCRIPTION
This PR make possible to add a new source in pause mode.

A plugin can use new method `add_source_with_state` and set the initial_state parameter to pause.

This is useful to ask Alumet monitor sources only if you explicitely ask it (by resuming paused source afterwards).

Note: 
- In current implementation, sources started in pause mode can be resumed for 1 minute
- Tests for this behavior are missing. RuntimeExpectations don't allow to test such behavior cause it automatically resume the sources.