### PR TITLE
fix(plugin-jetson): refactor the Jetson plugin and make it more robust to errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
  "tokio-stream",
  "tokio-timerfd",
  "tokio-util",
- "toml",
+ "toml 0.8.22",
 ]
 
 [[package]]
@@ -102,7 +102,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.12",
  "tokio",
- "toml",
+ "toml 0.8.22",
  "vergen",
  "vergen-gitcl",
 ]
@@ -117,7 +117,7 @@ dependencies = [
  "libc",
  "libloading",
  "log",
- "toml",
+ "toml 0.8.22",
 ]
 
 [[package]]
@@ -436,7 +436,7 @@ dependencies = [
  "serde_json",
  "syn 2.0.100",
  "tempfile",
- "toml",
+ "toml 0.8.22",
 ]
 
 [[package]]
@@ -2544,7 +2544,7 @@ dependencies = [
  "serde",
  "serde_json",
  "time",
- "toml",
+ "toml 0.8.22",
 ]
 
 [[package]]
@@ -2579,7 +2579,7 @@ dependencies = [
  "log",
  "serde",
  "tempfile",
- "toml",
+ "toml 0.8.22",
 ]
 
 [[package]]
@@ -2593,7 +2593,7 @@ dependencies = [
  "reqwest",
  "serde",
  "tokio",
- "toml",
+ "toml 0.8.22",
 ]
 
 [[package]]
@@ -2611,7 +2611,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "toml",
+ "toml 0.8.22",
 ]
 
 [[package]]
@@ -2640,6 +2640,7 @@ dependencies = [
  "serde",
  "tempfile",
  "thiserror 2.0.12",
+ "toml 0.9.5",
  "walkdir",
 ]
 
@@ -2699,7 +2700,7 @@ dependencies = [
  "rlimit",
  "serde",
  "tokio",
- "toml",
+ "toml 0.8.22",
 ]
 
 [[package]]
@@ -2732,7 +2733,7 @@ dependencies = [
  "regex",
  "serde",
  "tempfile",
- "toml",
+ "toml 0.8.22",
 ]
 
 [[package]]
@@ -3498,6 +3499,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3759,7 +3769,7 @@ dependencies = [
  "log",
  "pretty_assertions",
  "regex",
- "toml",
+ "toml 0.8.22",
 ]
 
 [[package]]
@@ -3984,9 +3994,24 @@ checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
 dependencies = [
  "indexmap 2.8.0",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.8",
+ "toml_datetime 0.6.9",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+dependencies = [
+ "indexmap 2.8.0",
+ "serde",
+ "serde_spanned 1.0.0",
+ "toml_datetime 0.7.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -3999,6 +4024,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4006,9 +4040,18 @@ checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap 2.8.0",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.8",
+ "toml_datetime 0.6.9",
  "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+dependencies = [
  "winnow",
 ]
 
@@ -4017,6 +4060,12 @@ name = "toml_write"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tonic"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "plugin-nvidia-jetson"
-version = "0.4.0"
+version = "1.0.0"
 dependencies = [
  "alumet",
  "anyhow",
@@ -2636,9 +2636,11 @@ dependencies = [
  "log",
  "pretty_assertions",
  "regex",
+ "rustc-hash",
  "serde",
  "tempfile",
  "thiserror 2.0.12",
+ "walkdir",
 ]
 
 [[package]]

--- a/plugin-nvidia-jetson/Cargo.toml
+++ b/plugin-nvidia-jetson/Cargo.toml
@@ -18,5 +18,7 @@ walkdir = "2.5.0"
 workspace = true
 
 [dev-dependencies]
+alumet = { path = "../alumet", features = ["test"] }
 pretty_assertions = "1.4.1"
 tempfile = "3.19.1"
+toml = "0.9.5"

--- a/plugin-nvidia-jetson/Cargo.toml
+++ b/plugin-nvidia-jetson/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plugin-nvidia-jetson"
-version = "0.4.0"
+version = "1.0.0"
 edition = "2021"
 
 [dependencies]
@@ -9,8 +9,10 @@ anyhow = "1.0.97"
 humantime-serde = "1.1.1"
 log = "0.4.27"
 regex = "1.11.1"
+rustc-hash = "2.1.1"
 serde = { version = "1.0.219", features = ["derive"] }
 thiserror = "2.0.12"
+walkdir = "2.5.0"
 
 [lints]
 workspace = true

--- a/plugin-nvidia-jetson/README.md
+++ b/plugin-nvidia-jetson/README.md
@@ -1,3 +1,72 @@
-# Jetson plugin for NVIDIA Jetson devices
+# Jetson plugin
 
-The `nvidia-jetson` plugin allows to measure the utilization and power consumption of Jetson edge devices.
+The `jetson` plugin allows to measure the power consumption of Jetson edge devices by querying their internal INA-3221 sensor(s).
+
+## Requirements
+
+This plugin only works on NVIDIA Jetson™ devices.
+It supports Jetson Linux versions 32 to 36 (JetPack 4.6 to 6.x), and will probably work fine with future versions.
+
+The plugin needs to read files from the sysfs, so it needs to have the permission to read the I2C hierarchy of the INA-3221 sensor(s).
+Depending on your system, the root of this hierarchy is located at:
+- `/sys/bus/i2c/drivers/ina3221` on modern systems,
+- `/sys/bus/i2c/drivers/ina3221x` on older systems
+
+## Metrics
+
+The plugin source can collect the following metrics.
+Depending on the hardware, some metrics may or may not be collected.
+
+|Name|Type|Unit|Description|Attributes|
+|----|----|----|-----------|----------|
+|`input_current`| u64 | mA (milli-Ampere) | current intensity on the channel's line | see below |
+|`input_voltage`| u64 | mV (milli-Volt)| current voltage on the channel's line    | see below |
+|`input_power`  | u64 | mW (milli-Watt)| instantaneous electrical power on the channel's line    | see below |
+
+### Attributes
+
+The sensor provides measurements for several **channels**, which are connected to different parts of the hardware (this depends on the exact model of the device). This is reflected in the attributes attached to the measurement points.
+
+Each measurement point produced by the plugin has the following attributes:
+- `ina_device_number` (u64): the sensor's device number
+- `ina_i2c_address` (u64): the I2C address of the sensor
+- `ina_channel_id` (u64): the identifier of the channel
+- `ina_channel_label` (str): the label of the channel
+
+Refer to the documentation of your Jetson to learn more about the channels that are available on your device.
+
+### Example
+
+On the Jetson Xavier NX Developer Kit, one sensor is connected to the I2C sysfs, at `/sys/bus/i2c/drivers/ina3221/7-0040/hwmon/hwmon6`. It features 4 channels:
+- Channel 1: `VDD_IN`
+  - Files `in1_label`, `curr1_input`, etc.
+- Channel 2: `VDD_CPU_GPU_CV`
+  - Files `in2_label`, `in2_input`, etc.
+- Channel 3: `VDD_SOC`
+  - Files `in2_label`, `in2_input`, etc.
+- Channel 7: `sum of shunt voltages`
+  - Files `in7_label`, `in7_input`, etc.
+
+When measuring the data from _channel 1_, the plugin will produce measurements with the following attributes:
+- `ina_device_number: 6`
+- `ina_i2c_address: 0x40` (64 in decimal)
+- `ina_channel_id: 1`
+- `ina_channel_label: "VDD_IN"`
+
+## Configuration
+
+Here is a configuration example of the plugin. It's part of the Alumet configuration file (eg: `alumet-config.toml`).
+
+```toml
+[plugins.jetson]
+poll_interval = "1s"
+flush_interval = "5s"
+```
+
+## More information
+
+To find the model of your Jetson, run:
+
+```sh
+cat /sys/firmware/devicetree/base/model
+```

--- a/plugin-nvidia-jetson/src/ina.rs
+++ b/plugin-nvidia-jetson/src/ina.rs
@@ -1,21 +1,24 @@
 use std::{
-    collections::HashMap,
-    io::ErrorKind,
+    fs::ReadDir,
     path::{Path, PathBuf},
 };
 
-use alumet::units::{PrefixedUnit, Unit};
-use anyhow::{anyhow, Context};
-use regex::{Match, Regex};
-use thiserror::Error;
+use alumet::units::PrefixedUnit;
+use anyhow::Context;
+use rustc_hash::FxHashMap;
+
+use modern::{ModernInaExplorer, SYSFS_INA_MODERN};
+use old::{OldInaExplorer, SYSFS_INA_OLD};
+
+mod common;
+mod modern;
+mod old;
 
 /// Detected INA sensor.
 #[derive(Debug, PartialEq)]
 pub struct InaSensor {
-    /// Path to the sysfs directory of the sensor.
-    pub path: PathBuf,
-    /// I2C id of the sensor.
-    pub i2c_id: String,
+    /// Information about the device in the I2C sysfs.
+    pub metadata: InaDeviceMetadata,
     /// Channels available on this sensor.
     /// Each INA3221 has at least one channel.
     pub channels: Vec<InaChannel>,
@@ -39,325 +42,172 @@ pub struct InaRailMetric {
     pub name: String,
 }
 
-/// Returns a list of all the INA sensors available on the machine.
-///
-/// This function supports multiple version of the NVIDIA Jetpack SDK.
-pub fn detect_ina_sensors() -> anyhow::Result<Vec<InaSensor>> {
-    match detect_hierarchy_modern(SYSFS_INA) {
-        Ok(res) => Ok(res),
-        Err(DetectionError::SysfsAccess(err)) => {
-            log::debug!("modern hierarchy detection failed, trying the old version: {err}");
-            match detect_hierarchy_old_v4(SYSFS_INA_OLD) {
-                Ok(res) => Ok(res),
-                Err(DetectionError::SysfsAccess(err)) => {
-                    log::error!("old hierarchy detection failed: {err}");
-                    Ok(vec![])
-                }
-                Err(err) => Err(err.into()),
-            }
-        }
-        Err(DetectionError::Internal(err)) => Err(err),
-    }
+#[derive(Debug, Clone, PartialEq)]
+pub struct InaDeviceMetadata {
+    pub path: PathBuf,
+    pub i2c_address: u32,
+    pub number: u32,
+}
+
+/// Explores the sysfs to find the INA-3221 channels that are relevant for our measurement purposes.
+pub trait InaExplorer {
+    fn sysfs_root(&self) -> &Path;
+    fn devices(&self) -> anyhow::Result<Vec<InaDeviceMetadata>>;
+    fn analyze_entry(&self, channel_entry_path: &Path) -> anyhow::Result<EntryAnalysis>;
+}
+
+pub enum EntryAnalysis {
+    /// This entry must be ignored.
+    Ignore,
+    /// This entry contains the label of the current channel.
+    Label { channel_id: u32, label: String },
+    /// This entry is sysfs node that provides measurements.
+    MeasurementNode {
+        channel_id: u32,
+        unit: PrefixedUnit,
+        metric_name: String,
+        // TODO description
+    },
 }
 
 /// Sorts a list of sensors and sorts each element in the sensors, recursively.
 pub fn sort_sensors_recursively(sensors: &mut Vec<InaSensor>) {
     for s in sensors.iter_mut() {
-        s.sort_channels();
-    }
-    sensors.sort_by_key(|s| s.i2c_id.clone());
-}
-
-impl InaSensor {
-    pub fn sort_channels(&mut self) {
-        for chan in &mut self.channels {
+        for chan in &mut s.channels {
             chan.metrics.sort_by_key(|m| m.name.clone());
         }
-        self.channels.sort_by_key(|chan| chan.id);
+        s.channels.sort_by_key(|chan| chan.id);
+    }
+    sensors.sort_by_key(|s| s.metadata.i2c_address.clone());
+}
+
+impl std::fmt::Display for InaDeviceMetadata {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "device {} (i2c {}) at {}",
+            self.number,
+            self.i2c_address,
+            self.path.display()
+        )
     }
 }
 
-#[derive(Debug, Error)]
-enum DetectionError {
-    /// Failed to access the root path that should point to INA sensors.
-    ///
-    /// If this error occurs, it probably means that the version of the hierarchy
-    /// is not the expected one.
-    #[error("could not access the sysfs: {0}")]
-    SysfsAccess(anyhow::Error),
-    /// Internal detection error.
-    #[error("internal detection error: {0}")]
-    Internal(#[from] anyhow::Error),
-}
-
-impl From<std::io::Error> for DetectionError {
-    fn from(value: std::io::Error) -> Self {
-        DetectionError::Internal(value.into())
+impl InaChannel {
+    pub fn new(id: u32) -> Self {
+        Self {
+            id,
+            label: None,
+            metrics: Vec::new(),
+            description: None,
+        }
     }
 }
 
-const SYSFS_INA_OLD: &str = "/sys/bus/i2c/drivers/ina3221x";
-const SYSFS_INA: &str = "/sys/bus/i2c/drivers/ina3221";
-
-/// Detect the available INA sensors, assuming that Nvidia Jetpack version >= 5.0 is installed.
+/// Returns a list of all the INA sensors available on the machine.
 ///
-/// The standard `sys_ina` looks like `/sys/bus/i2c/drivers/ina3221`.
-fn detect_hierarchy_modern<P: AsRef<Path>>(sys_ina: P) -> Result<Vec<InaSensor>, DetectionError> {
-    /// Look for a path of the form <sensor_path>/hwmon/hwmon<id>
-    fn sensor_channels_dir(sensor_path: &Path) -> anyhow::Result<PathBuf> {
-        let hwmon = sensor_path.join("hwmon");
-        for child in std::fs::read_dir(&hwmon)
-            .with_context(|| format!("failed to list content of directory {}", hwmon.display()))?
-        {
-            let child = child?;
-            let path = child.path();
-            if path.file_name().unwrap().to_string_lossy().starts_with("hwmon") {
-                log::trace!("Found sensor channel dir: {path:?}");
-                return Ok(path);
-            }
-        }
-        Err(anyhow!("no sensor found in {}", sensor_path.display()))
+/// This function supports multiple version of the NVIDIA Jetpack SDK.
+pub fn detect_ina_sensors() -> anyhow::Result<(Vec<InaSensor>, Vec<anyhow::Error>)> {
+    if let Ok(true) = std::fs::exists(modern::SYSFS_INA_MODERN) {
+        explore_ina_devices(ModernInaExplorer::new(modern::SYSFS_INA_MODERN))
+    } else if let Ok(true) = std::fs::exists(old::SYSFS_INA_OLD) {
+        explore_ina_devices(OldInaExplorer::new(old::SYSFS_INA_OLD))
+    } else {
+        Err(anyhow::Error::msg(format!(
+            "no INA-3221 sensor detected: neither {} nor {} exist",
+            SYSFS_INA_MODERN, SYSFS_INA_OLD
+        )))
     }
-
-    /// Tries to guess the measurement unit that corresponds to the given channel prefix.
-    /// Returns `None` if the unit cannot be found.
-    fn guess_channel_unit(prefix: &Option<Match>, suffix: &Option<Match>) -> Option<PrefixedUnit> {
-        if prefix.is_none() {
-            return None;
-        }
-        if suffix.is_some_and(|suffix| suffix.as_str() == "enable") {
-            // this is not a channel measurement but a simple flag
-            return None;
-        }
-
-        let prefix = prefix.unwrap().as_str();
-        match prefix {
-            "curr" => Some(PrefixedUnit::milli(Unit::Ampere)),
-            "in" => Some(PrefixedUnit::milli(Unit::Volt)),
-            "crit" => Some(PrefixedUnit::milli(Unit::Ampere)),
-            "shunt" => Some(PrefixedUnit::milli(Unit::Custom {
-                unique_name: "Ohm".to_string(),
-                display_name: "Ω".to_string(),
-            })),
-            _ => None,
-        }
-    }
-
-    fn is_label_file(prefix: &Option<Match>, suffix: &Option<Match>) -> anyhow::Result<bool> {
-        let prefix = prefix.context("parsing failed: missing prefix")?.as_str();
-        let suffix = suffix.context("parsing failed: missing suffix")?.as_str();
-        Ok(prefix == "in" && suffix == "label")
-    }
-
-    fn format_metric_name(prefix: &Option<Match>, suffix: &Option<Match>) -> String {
-        format!("{}_{}", prefix.unwrap().as_str(), suffix.unwrap().as_str())
-    }
-
-    let metric_filename_pattern =
-        Regex::new(r"(?<prefix>[a-zA-Z]+)(?<id>\d+)_(?<suffix>[a-zA-Z_-]+)").expect("regex should be valid");
-
-    detect_hierarchy(
-        sys_ina,
-        metric_filename_pattern,
-        sensor_channels_dir,
-        guess_channel_unit,
-        is_label_file,
-        format_metric_name,
-    )
 }
 
-/// Detect the available INA sensors, assuming that Nvidia Jetpack version 4.x is installed.
-/// The hierarchy is subtly different in that case, and the metric and label files have different names than in v5+.
-///
-/// The standard `sys_ina` looks like `/sys/bus/i2c/drivers/ina3221x`
-fn detect_hierarchy_old_v4<P: AsRef<Path>>(sys_ina: P) -> Result<Vec<InaSensor>, DetectionError> {
-    /// Look for a path of the form <sensor_path>/iio:device<id>
-    fn sensor_channels_dir(sensor_path: &Path) -> anyhow::Result<PathBuf> {
-        for child in std::fs::read_dir(sensor_path)? {
-            let child = child?;
-            let path = child.path();
-            if path.file_name().unwrap().to_string_lossy().starts_with("iio:device") {
-                log::trace!("Found sensor channel dir: {path:?}");
-                return Ok(path);
+pub fn explore_ina_devices(explorer: impl InaExplorer) -> anyhow::Result<(Vec<InaSensor>, Vec<anyhow::Error>)> {
+    let mut sensors = Vec::new();
+    let mut errors = Vec::new();
+
+    for device in explorer.devices()? {
+        // resolve symlinks now
+        let canonical_path = device
+            .path
+            .canonicalize()
+            .with_context(|| format!("failed to canonicalize {:?}", device.path))?;
+
+        match std::fs::read_dir(&canonical_path) {
+            Ok(ls) => {
+                let channels = detect_device_channels(&explorer, ls, &mut errors);
+                let sensor = InaSensor {
+                    metadata: device,
+                    channels,
+                };
+                sensors.push(sensor);
             }
-        }
-        Err(anyhow!("no sensor found in {}", sensor_path.display()))
-    }
-
-    /// Tries to guess the measurement unit that corresponds to the given channel prefix.
-    /// Returns `None` if the unit cannot be found.
-    fn guess_channel_unit(prefix: &Option<Match>, _suffix: &Option<Match>) -> Option<PrefixedUnit> {
-        if prefix.is_none() {
-            return None;
-        }
-        let prefix = prefix.unwrap().as_str();
-        match prefix {
-            _ if prefix.contains("volt") => Some(PrefixedUnit::milli(Unit::Volt)),
-            _ if prefix.contains("current") => Some(PrefixedUnit::milli(Unit::Ampere)),
-            _ if prefix.contains("power") => Some(PrefixedUnit::milli(Unit::Watt)),
-            _ => None,
+            Err(e) => errors
+                .push(anyhow::Error::from(e).context(format!("could not list the content of {:?}", &canonical_path))),
         }
     }
-
-    fn is_label_file(prefix: &Option<Match>, suffix: &Option<Match>) -> anyhow::Result<bool> {
-        let prefix = prefix.context("parsing failed: missing prefix")?.as_str();
-        Ok(prefix == "rail_name" && suffix.is_none())
-    }
-
-    fn format_metric_name(prefix: &Option<Match>, suffix: &Option<Match>) -> String {
-        let prefix = prefix.unwrap().as_str();
-        match suffix {
-            Some(suffix_match) => format!("{prefix}{}", suffix_match.as_str()),
-            None => prefix.to_string(),
-        }
-    }
-
-    let metric_filename_pattern =
-        Regex::new(r"(?<prefix>[a-zA-Z_]+?)_?(?<id>\d+)(?<suffix>_([a-zA-Z]+))?").expect("regex should be valid");
-
-    detect_hierarchy(
-        sys_ina,
-        metric_filename_pattern,
-        sensor_channels_dir,
-        guess_channel_unit,
-        is_label_file,
-        format_metric_name,
-    )
+    Ok((sensors, errors))
 }
 
-/// Detection function, common to all Jetpack versions.
-fn detect_hierarchy<P: AsRef<Path>>(
-    sys_ina: P,
-    metric_filename_pattern: Regex,
-    sensor_channels_dir: fn(sensor_path: &Path) -> anyhow::Result<PathBuf>,
-    guess_channel_unit: fn(prefix: &Option<Match>, suffix: &Option<Match>) -> Option<PrefixedUnit>,
-    is_label_file: fn(prefix: &Option<Match>, suffix: &Option<Match>) -> anyhow::Result<bool>,
-    format_metric_name: fn(prefix: &Option<Match>, suffix: &Option<Match>) -> String,
-) -> Result<Vec<InaSensor>, DetectionError> {
-    // Look for channels and metrics.
-    // - `channels_dir`: path of the form <sensor_path>/hwmon/hwmon<id>
-    let sensor_channels = |channels_dir: &Path| -> anyhow::Result<Vec<InaChannel>> {
-        let mut channel_metrics = HashMap::with_capacity(2);
-        let mut channel_labels = HashMap::with_capacity(2);
-        let entries =
-            std::fs::read_dir(channels_dir).with_context(|| format!("failed to list content of {channels_dir:?}"))?;
-        for entry in entries {
-            let entry = entry.with_context(|| format!("failed to get dir entry in {channels_dir:?}"))?;
-            let path = entry.path();
-            let filename = path.file_name().unwrap().to_str().unwrap().to_owned();
-            let captures = metric_filename_pattern.captures(&filename);
-            log::trace!("regex match for {filename}: {captures:?}");
-            if let Some(groups) = captures {
-                // Extract the prefix, suffix and channel id.
-                let (prefix, suffix) = (&groups.name("prefix"), &groups.name("suffix"));
-                let channel_id: u32 = groups["id"]
-                    .parse()
-                    .with_context(|| format!("invalid channel id: {}", &groups["id"]))?;
+/// Detects the channels of an INA I2C device.
+fn detect_device_channels(
+    explorer: &impl InaExplorer,
+    ls: ReadDir,
+    errors: &mut Vec<anyhow::Error>,
+) -> Vec<InaChannel> {
+    // The label of the channel is provided by a dedicated file, but we are not
+    // guaranteed to read it first (the order of the files in ReadDir is unspecified). Therefore, we fill the fields little by little.
+    let mut channels_by_id = FxHashMap::default();
 
-                // Determine whether the file contains the label of the channel, or a metric.
-                let is_label = is_label_file(prefix, suffix)
-                    .with_context(|| format!("failed to parse filename of INA metric: {}", filename))?;
-
-                if is_label {
-                    // This file contains the label of the channel.
-                    let label = std::fs::read_to_string(&path)
-                        .with_context(|| format!("failed to read channel label from {path:?}"))?;
-                    let label = label.trim_end().to_owned();
-                    channel_labels.insert(channel_id, label);
-                } else {
-                    // This file contains the (automatically updated) value of a metric.
-                    match guess_channel_unit(prefix, suffix) {
-                        Some(unit) => channel_metrics
-                            .entry(channel_id)
-                            .or_insert_with(|| Vec::with_capacity(5))
-                            .push(InaRailMetric {
-                                path,
-                                unit,
-                                name: format_metric_name(prefix, suffix),
-                            }),
-                        None => log::warn!(
-                            "Could not determine the unit of this INA3221 channel: {}",
-                            path.display()
-                        ),
-                    }
-                }
+    for entry in ls.into_iter().filter_map(|e| e.ok()) {
+        let entry_path = entry.path();
+        match explorer.analyze_entry(&entry_path) {
+            Err(err) => {
+                errors.push(err.context(format!("failed to analyze I2C entry {entry_path:?}")));
+            }
+            Ok(EntryAnalysis::Ignore) => (),
+            Ok(EntryAnalysis::Label { channel_id, label }) => {
+                channels_by_id
+                    .entry(channel_id)
+                    .or_insert_with_key(|id| InaChannel::new(*id))
+                    .label = Some(label);
+            }
+            Ok(EntryAnalysis::MeasurementNode {
+                channel_id,
+                unit,
+                metric_name: name,
+            }) => {
+                let metric = InaRailMetric {
+                    path: entry_path,
+                    unit,
+                    name,
+                };
+                channels_by_id
+                    .entry(channel_id)
+                    .or_insert_with_key(|id| InaChannel::new(*id))
+                    .metrics
+                    .push(metric);
             }
         }
-
-        let res = channel_metrics
-            .into_iter()
-            .map(|(id, metrics)| InaChannel {
-                id,
-                label: channel_labels.get(&id).map(|v| v.to_owned()),
-                metrics,
-                description: None, // added later
-            })
-            .collect();
-        Ok(res)
-    };
-
-    let dir_path: &Path = sys_ina.as_ref();
-    log::trace!("Exploring {dir_path:?}");
-    match std::fs::read_dir(dir_path) {
-        Ok(dir) => {
-            let mut sensors = Vec::new();
-            for entry in dir {
-                let entry = entry.map_err(|e| DetectionError::SysfsAccess(e.into()))?;
-                // Resolve symbolic links.
-                let resolved = entry
-                    .path()
-                    .canonicalize()
-                    .with_context(|| format!("failed to canonicalize {:?}", entry.path()))?;
-                let metadata = resolved
-                    .metadata()
-                    .with_context(|| format!("failed to get metadata of {:?}", resolved))?;
-                if metadata.is_dir() && entry.file_name() != "module" {
-                    log::trace!("Collecting sensors from dir {:?}", entry.path());
-                    // Each subdirectory corresponds to one INA 3221 sensor.
-                    let path = &resolved;
-                    // The name of the directory corresponds to the i2c id.
-                    let i2c_id = path.file_name().unwrap().to_str().unwrap().to_owned();
-                    // Discover all the sensor channels (with their metrics).
-                    match sensor_channels_dir(path).and_then(|dir| sensor_channels(&dir)) {
-                        Ok(channels) => {
-                            sensors.push(InaSensor {
-                                path: path.clone(),
-                                channels,
-                                i2c_id,
-                            });
-                        }
-                        Err(err) => {
-                            log::error!("Sensor discovery failed for directory {}: {err:?}", resolved.display());
-                        }
-                    }
-                }
-            }
-            log::debug!("Found sensors: {sensors:?}");
-            Ok(sensors)
-        }
-        Err(e) if e.kind() == ErrorKind::NotFound => {
-            // The directory does not exist, simply return an empty list of sensors.
-            Err(DetectionError::SysfsAccess(
-                anyhow!(e).context(format!("{} does not exist", dir_path.display())),
-            ))
-        }
-        Err(e) => Err(DetectionError::SysfsAccess(
-            anyhow!(e).context(format!("failed to list the content of {}", dir_path.display())),
-        )),
     }
+
+    channels_by_id.into_values().collect()
 }
 
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
 
-    use super::{
-        detect_hierarchy_modern, detect_hierarchy_old_v4, sort_sensors_recursively, DetectionError, InaChannel,
-        InaRailMetric, InaSensor,
-    };
     use alumet::units::{PrefixedUnit, Unit};
     use pretty_assertions::assert_eq;
     use tempfile::tempdir;
+
+    use crate::ina::{
+        common::{METRIC_CURRENT, METRIC_POWER, METRIC_VOLTAGE},
+        modern::ModernInaExplorer,
+        old::OldInaExplorer,
+        InaDeviceMetadata,
+    };
+
+    use super::{explore_ina_devices, sort_sensors_recursively, InaChannel, InaRailMetric, InaSensor};
 
     #[test]
     fn ina_modern() {
@@ -390,16 +240,17 @@ mod tests {
         std::fs::write(hwmon1.join("crit0_max"), "103").unwrap();
 
         // Test the detection
-        let sensors = detect_hierarchy_modern(root).expect("detection failed");
-        let mut sensor_ids: Vec<&str> = sensors.iter().map(|s| s.i2c_id.as_ref()).collect();
-        sensor_ids.sort();
-        assert_eq!(sensor_ids, vec!["1-0040", "1-0041"]);
+        let (sensors, errs) = explore_ina_devices(ModernInaExplorer::new(root)).expect("detection failed");
+        assert!(errs.is_empty(), "detection failed");
+        let mut sensor_addrs: Vec<u32> = sensors.iter().map(|s| s.metadata.i2c_address).collect();
+        sensor_addrs.sort();
+        assert_eq!(sensor_addrs, vec![0x40, 0x41]);
 
-        let expected_channel_labels: HashMap<&str, Vec<&str>> = HashMap::from_iter(vec![
-            ("1-0040", vec!["Sensor 0, channel 0", "Sensor 0, channel 1"]),
-            ("1-0041", vec!["Sensor 1, channel 0"]),
+        let expected_channel_labels: HashMap<u32, Vec<&str>> = HashMap::from_iter(vec![
+            (0x40, vec!["Sensor 0, channel 0", "Sensor 0, channel 1"]),
+            (0x41, vec!["Sensor 1, channel 0"]),
         ]);
-        let mut expected_metrics = vec!["in_input", "curr_input", "curr_crit", "crit_max"];
+        let mut expected_metrics = vec![METRIC_CURRENT, METRIC_VOLTAGE];
         expected_metrics.sort();
 
         for sensor in sensors.into_iter() {
@@ -410,13 +261,86 @@ mod tests {
                 .collect();
             channel_labels.sort();
 
-            let expected_labels = &expected_channel_labels[sensor.i2c_id.as_str()];
+            let expected_labels = &expected_channel_labels[&sensor.metadata.i2c_address];
             assert_eq!(expected_labels, &channel_labels);
 
             for channel in sensor.channels {
                 let mut metrics: Vec<&String> = channel.metrics.iter().map(|m| &m.name).collect();
                 metrics.sort();
                 assert_eq!(metrics, expected_metrics);
+            }
+        }
+    }
+
+    #[test]
+    fn ina_modern_some_errors() {
+        let tmp = tempdir().unwrap();
+
+        // Create the fake sensor directories
+        let root = tmp.path().join("test-alumet-plugin-nvidia/ina-modern");
+        let hwmon0 = root.join("1-0040/hwmon/hwmon0");
+        let hwmon1 = root.join("1-0041/hwmon/hwmon1");
+        std::fs::create_dir_all(&hwmon0).unwrap();
+        std::fs::create_dir_all(&hwmon1).unwrap();
+
+        // Create the files that contains the label and metrics
+        std::fs::write(hwmon0.join("in0_label"), "Sensor 0, channel 0").unwrap();
+        std::fs::write(hwmon0.join("curr0_input"), "").unwrap(); // INVALID
+        std::fs::write(hwmon0.join("in0_input"), "1").unwrap();
+
+        std::fs::write(hwmon0.join("in1_label"), "Sensor 0, channel 1").unwrap();
+        std::fs::write(hwmon0.join("curr1_input"), "10").unwrap();
+        std::fs::write(hwmon0.join("in1_input"), "11").unwrap();
+
+        // no "in0_label"
+        std::fs::write(hwmon1.join("curr0_input"), "100").unwrap();
+        std::fs::write(hwmon1.join("in0_input"), "101").unwrap();
+        std::fs::write(hwmon1.join("badname"), "101").unwrap();
+
+        // Test the detection
+        let (sensors, errs) = explore_ina_devices(ModernInaExplorer::new(root)).expect("detection failed");
+        assert!(!errs.is_empty(), "detection should report some errors");
+        for err in errs {
+            println!("{err:#}");
+        }
+
+        let mut sensor_addrs: Vec<u32> = sensors.iter().map(|s| s.metadata.i2c_address).collect();
+        sensor_addrs.sort();
+        assert_eq!(sensor_addrs, vec![0x40, 0x41]);
+
+        let expected_channel_labels: HashMap<u32, Vec<Option<String>>> = HashMap::from_iter(vec![
+            (
+                0x40,
+                vec![
+                    Some("Sensor 0, channel 0".to_string()),
+                    Some("Sensor 0, channel 1".to_string()),
+                ],
+            ),
+            (0x41, vec![None]),
+        ]);
+
+        let expected_metrics_0_0 = vec![METRIC_VOLTAGE];
+        let mut expected_metrics_nominal = vec![METRIC_CURRENT, METRIC_VOLTAGE];
+        expected_metrics_nominal.sort();
+
+        for sensor in sensors.into_iter() {
+            let mut channel_labels: Vec<Option<String>> =
+                sensor.channels.iter().map(|chan| chan.label.clone()).collect();
+            channel_labels.sort();
+
+            let expected_labels = &expected_channel_labels[&sensor.metadata.i2c_address];
+            assert_eq!(expected_labels, &channel_labels);
+
+            for channel in sensor.channels {
+                let mut metrics: Vec<&String> = channel.metrics.iter().map(|m| &m.name).collect();
+                metrics.sort();
+
+                if sensor.metadata.i2c_address == 0x40 && channel.id == 0 {
+                    // Because of the error, `curr0_input` is not included in the list of available metrics.
+                    assert_eq!(metrics, expected_metrics_0_0);
+                } else {
+                    assert_eq!(metrics, expected_metrics_nominal);
+                }
             }
         }
     }
@@ -431,12 +355,16 @@ mod tests {
         println!("actual root: {actual_root:?}");
         println!("linked root: {root:?}");
 
-        let sensor_0040_link = root.join("1-0041");
-        let sensor_0041_link = root.join("1-0040");
+        let sensor_0040_link = root.join("1-0040");
+        let sensor_0041_link = root.join("1-0041");
         let sensor_0040 = actual_root.join("1-0040");
         let sensor_0041 = actual_root.join("1-0041");
+
+        let hwmon0_link = root.join("1-0040/hwmon/hwmon0");
+        let hwmon1_link = root.join("1-0041/hwmon/hwmon1");
         let hwmon0 = actual_root.join("1-0040/hwmon/hwmon0");
         let hwmon1 = actual_root.join("1-0041/hwmon/hwmon1");
+
         std::fs::create_dir_all(&hwmon0).unwrap();
         std::fs::create_dir_all(&hwmon1).unwrap();
         std::fs::create_dir_all(&root).unwrap();
@@ -456,12 +384,12 @@ mod tests {
                 InaRailMetric {
                     path: hwmon0.join("curr0_input"),
                     unit: PrefixedUnit::milli(Unit::Ampere),
-                    name: String::from("curr_input"),
+                    name: String::from(METRIC_CURRENT),
                 },
                 InaRailMetric {
                     path: hwmon0.join("in0_input"),
                     unit: PrefixedUnit::milli(Unit::Volt),
-                    name: String::from("in_input"),
+                    name: String::from(METRIC_VOLTAGE),
                 },
             ],
             description: None,
@@ -479,22 +407,12 @@ mod tests {
                 InaRailMetric {
                     path: hwmon0.join("curr1_input"),
                     unit: PrefixedUnit::milli(Unit::Ampere),
-                    name: String::from("curr_input"),
+                    name: String::from(METRIC_CURRENT),
                 },
                 InaRailMetric {
                     path: hwmon0.join("in1_input"),
                     unit: PrefixedUnit::milli(Unit::Volt),
-                    name: String::from("in_input"),
-                },
-                InaRailMetric {
-                    path: hwmon0.join("curr1_crit"),
-                    unit: PrefixedUnit::milli(Unit::Ampere),
-                    name: String::from("curr_crit"),
-                },
-                InaRailMetric {
-                    path: hwmon0.join("crit1_max"),
-                    unit: PrefixedUnit::milli(Unit::Ampere),
-                    name: String::from("crit_max"),
+                    name: String::from(METRIC_VOLTAGE),
                 },
             ],
             description: None,
@@ -512,22 +430,12 @@ mod tests {
                 InaRailMetric {
                     path: hwmon1.join("curr0_input"),
                     unit: PrefixedUnit::milli(Unit::Ampere),
-                    name: String::from("curr_input"),
-                },
-                InaRailMetric {
-                    path: hwmon1.join("curr0_crit"),
-                    unit: PrefixedUnit::milli(Unit::Ampere),
-                    name: String::from("curr_crit"),
-                },
-                InaRailMetric {
-                    path: hwmon1.join("curr0_max"),
-                    unit: PrefixedUnit::milli(Unit::Ampere),
-                    name: String::from("curr_max"),
+                    name: String::from(METRIC_CURRENT),
                 },
                 InaRailMetric {
                     path: hwmon1.join("in0_input"),
                     unit: PrefixedUnit::milli(Unit::Volt),
-                    name: String::from("in_input"),
+                    name: String::from(METRIC_VOLTAGE),
                 },
             ],
             description: None,
@@ -553,40 +461,12 @@ mod tests {
                 InaRailMetric {
                     path: hwmon1.join("curr5_input"),
                     unit: PrefixedUnit::milli(Unit::Ampere),
-                    name: String::from("curr_input"),
-                },
-                InaRailMetric {
-                    path: hwmon1.join("curr5_crit"),
-                    unit: PrefixedUnit::milli(Unit::Ampere),
-                    name: String::from("curr_crit"),
-                },
-                InaRailMetric {
-                    path: hwmon1.join("curr5_crit_alarm"),
-                    unit: PrefixedUnit::milli(Unit::Ampere),
-                    name: String::from("curr_crit_alarm"),
-                },
-                InaRailMetric {
-                    path: hwmon1.join("curr5_max"),
-                    unit: PrefixedUnit::milli(Unit::Ampere),
-                    name: String::from("curr_max"),
-                },
-                InaRailMetric {
-                    path: hwmon1.join("curr5_max_alarm"),
-                    unit: PrefixedUnit::milli(Unit::Ampere),
-                    name: String::from("curr_max_alarm"),
+                    name: String::from(METRIC_CURRENT),
                 },
                 InaRailMetric {
                     path: hwmon1.join("in5_input"),
                     unit: PrefixedUnit::milli(Unit::Volt),
-                    name: String::from("in_input"),
-                },
-                InaRailMetric {
-                    path: hwmon1.join("shunt5_resistor"),
-                    unit: PrefixedUnit::milli(Unit::Custom {
-                        unique_name: String::from("Ohm"),
-                        display_name: String::from("Ω"),
-                    }),
-                    name: String::from("shunt_resistor"),
+                    name: String::from(METRIC_VOLTAGE),
                 },
             ],
             description: None,
@@ -595,19 +475,26 @@ mod tests {
         // Build what we expect
         let mut expected_sensors = vec![
             InaSensor {
-                path: sensor_0040,
-                i2c_id: String::from("1-0040"),
+                metadata: InaDeviceMetadata {
+                    path: hwmon0_link,
+                    i2c_address: 0x40,
+                    number: 0,
+                },
                 channels: vec![expected_s0_chan0, expected_s0_chan1],
             },
             InaSensor {
-                path: sensor_0041,
-                i2c_id: String::from("1-0041"),
+                metadata: InaDeviceMetadata {
+                    path: hwmon1_link,
+                    i2c_address: 0x41,
+                    number: 1,
+                },
                 channels: vec![expected_s1_chan0, expected_s1_chan5],
             },
         ];
 
         // Test the detection
-        let mut sensors = detect_hierarchy_modern(root).expect("detection failed");
+        let (mut sensors, errs) = explore_ina_devices(ModernInaExplorer::new(root)).expect("detection failed");
+        assert!(errs.is_empty(), "detection failed");
         sort_sensors_recursively(&mut expected_sensors);
         sort_sensors_recursively(&mut sensors);
         assert_eq!(expected_sensors, sensors);
@@ -647,22 +534,17 @@ mod tests {
         std::fs::write(device1.join("warn_current_limit_0"), "104").unwrap();
 
         // Test the detection
-        let sensors = detect_hierarchy_old_v4(root).expect("detection failed");
-        let mut sensor_ids: Vec<&str> = sensors.iter().map(|s| s.i2c_id.as_ref()).collect();
+        let (sensors, errs) = explore_ina_devices(OldInaExplorer::new(root)).expect("detection failed");
+        assert!(errs.is_empty(), "detection failed");
+        let mut sensor_ids: Vec<u32> = sensors.iter().map(|s| s.metadata.i2c_address).collect();
         sensor_ids.sort();
-        assert_eq!(sensor_ids, vec!["1-0040", "1-0041"]);
+        assert_eq!(sensor_ids, vec![0x40, 0x41]);
 
-        let expected_channel_labels: HashMap<&str, Vec<&str>> = HashMap::from_iter(vec![
-            ("1-0040", vec!["Sensor 0, channel 0", "Sensor 0, channel 1"]),
-            ("1-0041", vec!["Sensor 1, channel 0"]),
+        let expected_channel_labels: HashMap<u32, Vec<&str>> = HashMap::from_iter(vec![
+            (0x40, vec!["Sensor 0, channel 0", "Sensor 0, channel 1"]),
+            (0x41, vec!["Sensor 1, channel 0"]),
         ]);
-        let mut expected_metrics = vec![
-            "in_current_input",
-            "in_voltage_input",
-            "in_power_input",
-            "crit_current_limit",
-            "warn_current_limit",
-        ];
+        let mut expected_metrics = vec![METRIC_CURRENT, METRIC_VOLTAGE, METRIC_POWER];
         expected_metrics.sort();
 
         for sensor in sensors.into_iter() {
@@ -673,7 +555,7 @@ mod tests {
                 .collect();
             channel_labels.sort();
 
-            let expected_labels = &expected_channel_labels[sensor.i2c_id.as_str()];
+            let expected_labels = &expected_channel_labels[&sensor.metadata.i2c_address];
             assert_eq!(expected_labels, &channel_labels);
 
             for channel in sensor.channels {
@@ -689,9 +571,7 @@ mod tests {
     fn no_ina() {
         let tmp = tempdir().unwrap();
         let root = tmp.path().join(".i-do-not-exist");
-        let res_modern = detect_hierarchy_modern(&root);
-        let res_old = detect_hierarchy_old_v4(&root);
-        assert!(matches!(res_modern, Err(DetectionError::SysfsAccess(_))));
-        assert!(matches!(res_old, Err(DetectionError::SysfsAccess(_))));
+        explore_ina_devices(ModernInaExplorer::new(&root)).expect_err("should fail");
+        explore_ina_devices(OldInaExplorer::new(&root)).expect_err("should fail");
     }
 }

--- a/plugin-nvidia-jetson/src/ina/common.rs
+++ b/plugin-nvidia-jetson/src/ina/common.rs
@@ -47,15 +47,15 @@ impl ChannelEntryAnalyzer {
 
                 // test the file, if it doesn't work, don't measure it in the future
                 let content = std::fs::read_to_string(channel_entry_path)?;
-                if content.is_empty() {
-                    return Err(anyhow::Error::msg("empty file"));
+                return if content.is_empty() {
+                    Err(anyhow::Error::msg("empty file"))
                 } else {
-                    return Ok(EntryAnalysis::MeasurementNode {
+                    Ok(EntryAnalysis::MeasurementNode {
                         channel_id,
                         unit: unit.clone(),
                         metric_name: metric_name.to_string(),
-                    });
-                }
+                    })
+                };
             }
         }
 

--- a/plugin-nvidia-jetson/src/ina/common.rs
+++ b/plugin-nvidia-jetson/src/ina/common.rs
@@ -1,0 +1,65 @@
+use std::path::Path;
+
+use alumet::units::PrefixedUnit;
+use regex::Regex;
+
+use super::EntryAnalysis;
+
+pub const METRIC_CURRENT: &str = "input_current";
+pub const METRIC_VOLTAGE: &str = "input_voltage";
+pub const METRIC_POWER: &str = "input_power";
+
+/// Regex-based analyzer of I2C sysfs channel entries.
+pub struct ChannelEntryAnalyzer {
+    /// Matches the file that contains the label of the channel.
+    pub label_matcher: Regex,
+    /// One matcher for each metric we are interested in.
+    pub metrics_matchers: Vec<MetricMatcher>,
+}
+
+/// Matches a file that we want to read to obtain measurements.
+pub struct MetricMatcher {
+    /// Pattern on the filename.
+    pub pat: Regex,
+    /// Measurement unit.
+    pub unit: PrefixedUnit,
+    /// Name of the metric.
+    pub metric_name: &'static str,
+}
+
+impl ChannelEntryAnalyzer {
+    pub fn analyze_entry(&self, channel_entry_path: &Path) -> anyhow::Result<EntryAnalysis> {
+        let filename = channel_entry_path.file_name().unwrap().to_str().unwrap();
+
+        if let Some(c) = self.label_matcher.captures(filename) {
+            // this file contains the label of the I2C channel
+            let channel_id_match = c.name("N").unwrap();
+            let channel_id: u32 = channel_id_match.as_str().parse()?;
+            let label = std::fs::read_to_string(channel_entry_path)?;
+            return Ok(EntryAnalysis::Label { channel_id, label });
+        }
+
+        for MetricMatcher { pat, unit, metric_name } in &self.metrics_matchers {
+            if let Some(c) = pat.captures(filename) {
+                // this file contains a value that we want to measure
+                let channel_id_match = c.name("N").unwrap();
+                let channel_id: u32 = channel_id_match.as_str().parse()?;
+
+                // test the file, if it doesn't work, don't measure it in the future
+                let content = std::fs::read_to_string(channel_entry_path)?;
+                if content.is_empty() {
+                    return Err(anyhow::Error::msg("empty file"));
+                } else {
+                    return Ok(EntryAnalysis::MeasurementNode {
+                        channel_id,
+                        unit: unit.clone(),
+                        metric_name: metric_name.to_string(),
+                    });
+                }
+            }
+        }
+
+        // nothing matches, ignore this file
+        Ok(EntryAnalysis::Ignore)
+    }
+}

--- a/plugin-nvidia-jetson/src/ina/common.rs
+++ b/plugin-nvidia-jetson/src/ina/common.rs
@@ -35,7 +35,7 @@ impl ChannelEntryAnalyzer {
             // this file contains the label of the I2C channel
             let channel_id_match = c.name("N").unwrap();
             let channel_id: u32 = channel_id_match.as_str().parse()?;
-            let label = std::fs::read_to_string(channel_entry_path)?;
+            let label = std::fs::read_to_string(channel_entry_path)?.trim_ascii().to_owned();
             return Ok(EntryAnalysis::Label { channel_id, label });
         }
 

--- a/plugin-nvidia-jetson/src/ina/modern.rs
+++ b/plugin-nvidia-jetson/src/ina/modern.rs
@@ -1,0 +1,117 @@
+use std::path::{Path, PathBuf};
+
+use alumet::units::{PrefixedUnit, Unit};
+use regex::Regex;
+use walkdir::WalkDir;
+
+use super::common::{ChannelEntryAnalyzer, MetricMatcher, METRIC_CURRENT, METRIC_VOLTAGE};
+use super::{EntryAnalysis, InaDeviceMetadata, InaExplorer};
+
+pub const SYSFS_INA_MODERN: &str = "/sys/bus/i2c/drivers/ina3221";
+
+/// Detect the available INA sensors, assuming that Nvidia Jetpack version >= 5.0 is installed.
+pub struct ModernInaExplorer {
+    sysfs_root: PathBuf,
+    entry_analyzer: ChannelEntryAnalyzer,
+}
+
+impl ModernInaExplorer {
+    pub fn new(sysfs_root: impl Into<PathBuf>) -> Self {
+        Self {
+            sysfs_root: sysfs_root.into(),
+            entry_analyzer: Self::init_analyzer().expect("regexps should be valid"),
+        }
+    }
+
+    fn init_analyzer() -> Result<ChannelEntryAnalyzer, regex::Error> {
+        Ok(ChannelEntryAnalyzer {
+            label_matcher: Regex::new("in(?<N>[0-9]+)_label")?,
+            metrics_matchers: vec![
+                MetricMatcher {
+                    pat: Regex::new("curr(?<N>[0-9]+)_input")?,
+                    unit: PrefixedUnit::milli(Unit::Ampere),
+                    metric_name: METRIC_CURRENT,
+                },
+                MetricMatcher {
+                    pat: Regex::new("in(?<N>[0-9]+)_input")?,
+                    unit: PrefixedUnit::milli(Unit::Volt),
+                    metric_name: METRIC_VOLTAGE,
+                },
+            ],
+        })
+    }
+}
+
+impl InaExplorer for ModernInaExplorer {
+    fn sysfs_root(&self) -> &Path {
+        self.sysfs_root.as_path()
+    }
+
+    fn devices(&self) -> anyhow::Result<Vec<InaDeviceMetadata>> {
+        let mut res = Vec::new();
+
+        for entry in WalkDir::new(self.sysfs_root())
+            .min_depth(3)
+            .max_depth(3)
+            .follow_links(true)
+        {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(err) => {
+                    if err.io_error().is_some() {
+                        return Err(err.into());
+                    } else {
+                        // a loop has been detected, just ignore it
+                        continue;
+                    }
+                }
+            };
+            if let Some(device) = parse_device_entry(entry.path()) {
+                res.push(device);
+            }
+        }
+        Ok(res)
+    }
+
+    fn analyze_entry(&self, channel_entry_path: &Path) -> anyhow::Result<EntryAnalysis> {
+        self.entry_analyzer.analyze_entry(channel_entry_path)
+    }
+}
+
+/// Parses `/sys/bus/i2c/drivers/ina3221/1-0040/hwmon/hwmon2`.
+/// Extracts `40` (hexadecimal i2c address) and `2` (device id).
+fn parse_device_entry(entry_path: &Path) -> Option<InaDeviceMetadata> {
+    // get i2c address
+    let i2c_identifier = entry_path.parent()?.parent()?.file_name()?.to_str()?;
+    let (_, addr) = i2c_identifier.split_once('-')?;
+    let i2c_address = u32::from_str_radix(addr, 16).ok()?;
+
+    // get device id
+    let device_identifier = entry_path.file_name()?.to_str()?;
+    let number = device_identifier.strip_prefix("hwmon")?.parse().ok()?;
+
+    Some(InaDeviceMetadata {
+        path: entry_path.to_owned(),
+        i2c_address,
+        number,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_device_entry() {
+        assert_eq!(
+            parse_device_entry(Path::new("/sys/bus/i2c/drivers/ina3221/1-0040/hwmon/hwmon2")),
+            Some(InaDeviceMetadata {
+                path: PathBuf::from("/sys/bus/i2c/drivers/ina3221/1-0040/hwmon/hwmon2"),
+                i2c_address: 64,
+                number: 2
+            })
+        );
+
+        assert_eq!(parse_device_entry(Path::new("/sys/bus/i2c/drivers/ina3221/bad")), None)
+    }
+}

--- a/plugin-nvidia-jetson/src/ina/old.rs
+++ b/plugin-nvidia-jetson/src/ina/old.rs
@@ -1,0 +1,123 @@
+use std::path::{Path, PathBuf};
+
+use alumet::units::{PrefixedUnit, Unit};
+use regex::Regex;
+use walkdir::WalkDir;
+
+use super::common::{ChannelEntryAnalyzer, MetricMatcher, METRIC_CURRENT, METRIC_POWER, METRIC_VOLTAGE};
+use super::{EntryAnalysis, InaDeviceMetadata, InaExplorer};
+
+pub const SYSFS_INA_OLD: &str = "/sys/bus/i2c/drivers/ina3221x";
+
+/// Detects the available INA sensors, assuming that Nvidia Jetpack version 4.x is installed.
+/// The hierarchy is subtly different in that case, and the metric and label files have different names than in v5+.
+pub struct OldInaExplorer {
+    sysfs_root: PathBuf,
+    entry_analyzer: ChannelEntryAnalyzer,
+}
+
+impl OldInaExplorer {
+    pub fn new(sysfs_root: impl Into<PathBuf>) -> Self {
+        Self {
+            sysfs_root: sysfs_root.into(),
+            entry_analyzer: Self::init_analyzer().expect("regexps should be valid"),
+        }
+    }
+
+    fn init_analyzer() -> Result<ChannelEntryAnalyzer, regex::Error> {
+        Ok(ChannelEntryAnalyzer {
+            label_matcher: Regex::new("rail_name(_)?(?<N>[0-9]+)")?,
+            metrics_matchers: vec![
+                MetricMatcher {
+                    pat: Regex::new("in_current(?<N>[0-9]+)_input")?,
+                    unit: PrefixedUnit::milli(Unit::Ampere),
+                    metric_name: METRIC_CURRENT,
+                },
+                MetricMatcher {
+                    pat: Regex::new("in_voltage(?<N>[0-9]+)_input")?,
+                    unit: PrefixedUnit::milli(Unit::Volt),
+                    metric_name: METRIC_VOLTAGE,
+                },
+                MetricMatcher {
+                    pat: Regex::new("in_power(?<N>[0-9]+)_input")?,
+                    unit: PrefixedUnit::milli(Unit::Watt),
+                    metric_name: METRIC_POWER,
+                },
+            ],
+        })
+    }
+}
+
+impl InaExplorer for OldInaExplorer {
+    fn sysfs_root(&self) -> &Path {
+        self.sysfs_root.as_path()
+    }
+
+    fn devices(&self) -> anyhow::Result<Vec<InaDeviceMetadata>> {
+        let mut res = Vec::new();
+
+        for entry in WalkDir::new(self.sysfs_root())
+            .min_depth(2)
+            .max_depth(2)
+            .follow_links(true)
+        {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(err) => {
+                    if err.io_error().is_some() {
+                        return Err(err.into());
+                    } else {
+                        // a loop has been detected, just ignore it
+                        continue;
+                    }
+                }
+            };
+            if let Some(device) = parse_device_entry(entry.path()) {
+                res.push(device);
+            }
+        }
+        Ok(res)
+    }
+
+    fn analyze_entry(&self, channel_entry_path: &Path) -> anyhow::Result<EntryAnalysis> {
+        self.entry_analyzer.analyze_entry(channel_entry_path)
+    }
+}
+
+/// Parses `/sys/bus/i2c/drivers/ina3221x/7-0040/iio:device1`.
+/// Extracts `40` (hexadecimal i2c address) and `1` (device id).
+fn parse_device_entry(entry_path: &Path) -> Option<InaDeviceMetadata> {
+    // get i2c address
+    let i2c_identifier = entry_path.parent()?.file_name()?.to_str()?;
+    let (_, addr) = i2c_identifier.split_once('-')?;
+    let i2c_address = u32::from_str_radix(addr, 16).ok()?;
+
+    // get device id
+    let device_identifier = entry_path.file_name()?.to_str()?;
+    let number = device_identifier.strip_prefix("iio:device")?.parse().ok()?;
+
+    Some(InaDeviceMetadata {
+        path: entry_path.to_owned(),
+        i2c_address,
+        number,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_device_entry() {
+        assert_eq!(
+            parse_device_entry(Path::new("/sys/bus/i2c/drivers/ina3221x/7-0040/iio:device1")),
+            Some(InaDeviceMetadata {
+                path: PathBuf::from("/sys/bus/i2c/drivers/ina3221x/7-0040/iio:device1"),
+                i2c_address: 64,
+                number: 1
+            })
+        );
+
+        assert_eq!(parse_device_entry(Path::new("/sys/bus/i2c/drivers/ina3221x/bad")), None)
+    }
+}

--- a/plugin-nvidia-jetson/src/lib.rs
+++ b/plugin-nvidia-jetson/src/lib.rs
@@ -17,6 +17,21 @@ pub struct JetsonPlugin {
     config: Config,
 }
 
+impl JetsonPlugin {
+    #[cfg(test)]
+    fn sysfs_paths(&self) -> ina::InaSysfsPath<'_> {
+        ina::InaSysfsPath {
+            sysfs_ina_modern: &self.config.sysfs_ina_modern,
+            sysfs_ina_old: &self.config.sysfs_ina_old,
+        }
+    }
+
+    #[cfg(not(test))]
+    fn sysfs_paths(&self) -> ina::InaSysfsPath<'_> {
+        ina::InaSysfsPath::default()
+    }
+}
+
 impl AlumetPlugin for JetsonPlugin {
     fn name() -> &'static str {
         "jetson"
@@ -37,8 +52,8 @@ impl AlumetPlugin for JetsonPlugin {
     }
 
     fn start(&mut self, alumet: &mut alumet::plugin::AlumetPluginStart) -> anyhow::Result<()> {
-        let (mut sensors, errs) =
-            ina::detect_ina_sensors().context("no INA-3221 sensor found, are you running on a Jetson device?")?;
+        let (mut sensors, errs) = ina::detect_ina_sensors(self.sysfs_paths())
+            .context("no INA-3221 sensor found, are you running on a Jetson device?")?;
         ina::sort_sensors_recursively(&mut sensors);
 
         // print errors to help the admin
@@ -68,7 +83,7 @@ impl AlumetPlugin for JetsonPlugin {
         let trigger = TriggerSpec::builder(self.config.poll_interval)
             .flush_interval(self.config.flush_interval)
             .build()?;
-        alumet.add_source("builtin_ina", Box::new(source), trigger)?;
+        alumet.add_source("builtin_ina_sensor", Box::new(source), trigger)?;
         Ok(())
     }
 
@@ -80,13 +95,19 @@ impl AlumetPlugin for JetsonPlugin {
 #[derive(Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 struct Config {
-    /// Initial interval between two Nvidia measurements.
+    /// Initial interval between two measurements.
     #[serde(with = "humantime_serde")]
     poll_interval: Duration,
 
-    /// Initial interval between two flushing of Nvidia measurements.
+    /// Initial interval between two measurement flushes.
     #[serde(with = "humantime_serde")]
     flush_interval: Duration,
+
+    #[cfg(test)]
+    sysfs_ina_modern: String,
+
+    #[cfg(test)]
+    sysfs_ina_old: String,
 }
 
 impl Default for Config {
@@ -94,6 +115,134 @@ impl Default for Config {
         Self {
             poll_interval: Duration::from_secs(1), // 1Hz
             flush_interval: Duration::from_secs(5),
+            #[cfg(test)]
+            sysfs_ina_modern: ina::modern::SYSFS_INA_MODERN.to_string(),
+            #[cfg(test)]
+            sysfs_ina_old: ina::old::SYSFS_INA_OLD.to_string(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+
+    use alumet::{
+        agent::plugin::{PluginInfo, PluginSet},
+        measurement::{AttributeValue, MeasurementPoint},
+        metrics::RawMetricId,
+        pipeline::naming::SourceName,
+        plugin::PluginMetadata,
+        test::{RuntimeExpectations, StartupExpectations},
+        units::{PrefixedUnit, Unit},
+    };
+    use tempfile::tempdir;
+
+    use super::*;
+
+    const TIMEOUT: Duration = Duration::from_secs(1);
+
+    #[test]
+    fn test_plugin_with_modern_sysfs() {
+        let tmp = tempdir().unwrap();
+
+        // Create the fake sensor directories
+        let root = tmp.path().join("test-alumet-plugin-nvidia/ina-modern");
+        let hwmon0 = root.join("1-0040/hwmon/hwmon0");
+        let hwmon1 = root.join("1-0041/hwmon/hwmon1");
+        std::fs::create_dir_all(&hwmon0).unwrap();
+        std::fs::create_dir_all(&hwmon1).unwrap();
+
+        // Create the files that contains the label and metrics
+        std::fs::write(hwmon0.join("in0_label"), "Sensor 0, channel 0").unwrap();
+        std::fs::write(hwmon0.join("curr0_input"), "0").unwrap();
+        std::fs::write(hwmon0.join("in0_input"), "1").unwrap();
+
+        std::fs::write(hwmon0.join("in1_label"), "Sensor 0, channel 1").unwrap();
+        std::fs::write(hwmon0.join("curr1_input"), "10").unwrap();
+        std::fs::write(hwmon0.join("in1_input"), "11").unwrap();
+
+        std::fs::write(hwmon1.join("in0_label"), "Sensor 1, channel 0").unwrap();
+        std::fs::write(hwmon1.join("curr0_input"), "100").unwrap();
+        std::fs::write(hwmon1.join("in0_input"), "101").unwrap();
+
+        // Create the config
+        let sysfs_root = root.to_str().unwrap();
+        let config = toml::from_str(&format!(
+            r#"
+                poll_interval = "1s"
+                flush_interval = "1s"
+                sysfs_ina_modern = "{sysfs_root}"
+                sysfs_ina_old = ""
+            "#
+        ))
+        .unwrap();
+
+        // Start Alumet with the plugin.
+        let mut plugins = PluginSet::new();
+        plugins.add_plugin(PluginInfo {
+            metadata: PluginMetadata::from_static::<JetsonPlugin>(),
+            enabled: true,
+            config: Some(config),
+        });
+
+        let startup = StartupExpectations::new()
+            .expect_metric::<u64>("input_current", PrefixedUnit::milli(Unit::Ampere))
+            .expect_metric::<u64>("input_voltage", PrefixedUnit::milli(Unit::Volt))
+            .expect_source("jetson", "builtin_ina_sensor");
+
+        let runtime = RuntimeExpectations::new().test_source(
+            SourceName::from_str("jetson", "builtin_ina_sensor"),
+            || {},
+            |out| {
+                println!("{out:?}");
+
+                // group measurements by (i2c address, channel, metric) to check them later (the order in the buffer is not guaranteed)
+                let mut measurements: HashMap<(u64, u64, RawMetricId), MeasurementPoint> = HashMap::new();
+                for m in out {
+                    let channel_id = m
+                        .attributes()
+                        .find(|attr| attr.0 == "ina_channel_id")
+                        .expect("missing attribute ina_channel_id")
+                        .1;
+                    let channel_id = match channel_id {
+                        AttributeValue::U64(id) => *id,
+                        _ => panic!("channel_id should be a U64"),
+                    };
+                    let i2c_address = m
+                        .attributes()
+                        .find(|attr| attr.0 == "ina_i2c_address")
+                        .expect("missing attribute ina_i2c_address")
+                        .1;
+                    let i2c_address = match i2c_address {
+                        AttributeValue::U64(id) => *id,
+                        _ => panic!("ina_i2c_address should be a U64"),
+                    };
+
+                    if measurements
+                        .insert((i2c_address, channel_id, m.metric), m.to_owned())
+                        .is_some()
+                    {
+                        panic!("only one measurement should be produced for each triple (sensor, channel, metric)")
+                    }
+                }
+
+                // check the measurements
+                // TODO check the values by using the metric id… but there isn't an easy way to access the metric registry from here.
+                let sensors_and_channels: HashSet<(u64, u64)> =
+                    measurements.into_keys().map(|(s, c, _)| (s, c)).collect();
+                assert_eq!(
+                    sensors_and_channels,
+                    HashSet::from_iter([(0x40, 0), (0x40, 1), (0x41, 0)])
+                );
+            },
+        );
+
+        let agent = alumet::agent::Builder::new(plugins)
+            .with_expectations(startup)
+            .with_expectations(runtime)
+            .build_and_start()
+            .expect("agent should start");
+        agent.wait_for_shutdown(TIMEOUT).expect("pipeline should run fine");
     }
 }

--- a/plugin-nvidia-jetson/src/lib.rs
+++ b/plugin-nvidia-jetson/src/lib.rs
@@ -13,6 +13,9 @@ use alumet::{
     },
 };
 
+#[cfg(not(target_os = "linux"))]
+compile_error!("This plugin only works on Linux.");
+
 pub struct JetsonPlugin {
     config: Config,
 }
@@ -178,7 +181,7 @@ mod tests {
         // Create the config
         let sysfs_root = root.to_str().unwrap();
         let config = toml::from_str(&format!(
-            r#"
+            r#" 
                 poll_interval = "1s"
                 flush_interval = "1s"
                 sysfs_ina_modern = "{sysfs_root}"

--- a/plugin-nvidia-jetson/src/source.rs
+++ b/plugin-nvidia-jetson/src/source.rs
@@ -54,10 +54,7 @@ impl JetsonInaSource {
         for sensor in sensors {
             let mut sensor_opened_channels = Vec::with_capacity(sensor.channels.len());
             for channel in sensor.channels {
-                let channel_label = channel
-                    .label
-                    .clone()
-                    .map_or_else(|| channel.id.to_string(), |v| v.replace(' ', "_").to_ascii_uppercase());
+                let channel_label = channel.label.unwrap_or_else(|| format!("channel_{}", channel.id));
                 let metrics: anyhow::Result<Vec<OpenedInaMetric>> = channel
                     .metrics
                     .into_iter()
@@ -69,7 +66,7 @@ impl JetsonInaSource {
                         // Create a metric in Alumet. Duplicates are ok (Alumet will only create each metric once).
                         let metric_id = alumet
                             .create_metric(&m.name, m.unit, format!("{} (see attributes for channel info)", m.name))
-                            .with_context(|| format!("could not create metric for channel {channel_label}"))?;
+                            .with_context(|| format!("could not create metric for channel '{channel_label}'"))?;
 
                         Ok(OpenedInaMetric {
                             metric_id,

--- a/plugin-nvidia-jetson/src/source.rs
+++ b/plugin-nvidia-jetson/src/source.rs
@@ -28,8 +28,8 @@ pub struct OpenedInaSensor {
 
 /// A channel that has been "opened" for reading.
 pub struct OpenedInaChannel {
+    id: u32,
     label: String,
-    description: String,
     metrics: Vec<OpenedInaMetric>,
 }
 
@@ -54,23 +54,23 @@ impl JetsonInaSource {
         for sensor in sensors {
             let mut sensor_opened_channels = Vec::with_capacity(sensor.channels.len());
             for channel in sensor.channels {
-                let channel_string_id = channel.label.clone().map_or_else(
-                    || format!("channel_{}", channel.id),
-                    |v| v.replace(' ', "_").to_ascii_lowercase(),
-                );
+                let channel_label = channel
+                    .label
+                    .clone()
+                    .map_or_else(|| channel.id.to_string(), |v| v.replace(' ', "_").to_ascii_uppercase());
                 let metrics: anyhow::Result<Vec<OpenedInaMetric>> = channel
                     .metrics
                     .into_iter()
                     .map(|m| {
-                        let metric_description = match &channel.description {
-                            Some(desc) => format!("channel {} ({}); {}", channel.id, desc, m.name),
-                            None => format!("channel {}; {}", channel.id, m.name),
-                        };
-                        let metric_id = alumet
-                            .create_metric(format!("{}::{}", channel_string_id, m.name), m.unit, metric_description)
-                            .with_context(|| format!("could not create metric for channel {channel_string_id}"))?;
+                        // Open the file for the measurement operation.
                         let file = File::open(&m.path)
                             .with_context(|| format!("could not open virtual file {}", m.path.display()))?;
+
+                        // Create a metric in Alumet. Duplicates are ok (Alumet will only create each metric once).
+                        let metric_id = alumet
+                            .create_metric(&m.name, m.unit, format!("{} (see attributes for channel info)", m.name))
+                            .with_context(|| format!("could not create metric for channel {channel_label}"))?;
+
                         Ok(OpenedInaMetric {
                             metric_id,
                             resource_id: Resource::LocalMachine,
@@ -79,8 +79,8 @@ impl JetsonInaSource {
                     })
                     .collect();
                 let opened_chan = OpenedInaChannel {
-                    label: channel_string_id,
-                    description: channel.description.unwrap_or(String::from("")),
+                    id: channel.id,
+                    label: channel_label,
                     metrics: metrics?,
                 };
                 sensor_opened_channels.push(opened_chan);
@@ -120,11 +120,8 @@ impl alumet::pipeline::Source for JetsonInaSource {
                         MeasurementPoint::new(timestamp, m.metric_id, m.resource_id.clone(), consumer, value)
                             .with_attr("ina_device_number", AttributeValue::U64(sensor.device_number.into()))
                             .with_attr("ina_i2c_address", AttributeValue::U64(sensor.i2c_address.into()))
-                            .with_attr("ina_channel_label", AttributeValue::String(chan.label.clone()))
-                            .with_attr(
-                                "ina_channel_description",
-                                AttributeValue::String(chan.description.clone()),
-                            ),
+                            .with_attr("ina_channel_id", AttributeValue::U64(chan.id.into()))
+                            .with_attr("ina_channel_label", AttributeValue::String(chan.label.clone())),
                     );
                 }
             }


### PR DESCRIPTION
Resolves #212 

Summary:
- cleaner code with new modules: common, modern, old
- unification of the metrics across system versions
- more robust sensor exploration: don't stop at the first error
- detection of invalid entries (on startup): if a sysfs file that should provide measurement doesn't work, skip it (in the previous versions, the entries were not tested and crashed the Alumet source)