### PR TITLE
ci: multi arch support for deb packages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,8 +89,12 @@ jobs:
   build-deb:
     needs: gather-informations
     uses: alumet-dev/packaging/.github/workflows/build_deb.yaml@main
+    strategy:
+      fail-fast: false
+      matrix: 
+        arch: [x86_64, aarch64]
     with:
-      arch: "amd64"
+      arch: ${{ matrix.arch }}
       version: ${{ needs.gather-informations.outputs.version }}
       revision: ${{ needs.gather-informations.outputs.release }}
       tag: ${{ needs.gather-informations.outputs.tag }}


### PR DESCRIPTION
Once https://github.com/alumet-dev/packaging/pull/20 is merged, we will be able to release all artifacts in multi-arch: RPM, deb, docker