### PR TITLE
feat(slurm): Is it a job or a step

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,6 @@ redundant_field_names = "deny"
 single_char_pattern = "deny"
 unused_enumerate_index = "deny"
 useless_format = "deny"
+
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin)'] }

--- a/plugins/cgroups/slurm/src/attr.rs
+++ b/plugins/cgroups/slurm/src/attr.rs
@@ -2,7 +2,7 @@ use alumet::measurement::AttributeValue;
 
 pub const JOB_REGEX_SLURM1: &str = "/slurm/uid_(?<user_id__u64>[0-9]+)/job_(?<job_id__u64>[0-9]+)";
 pub const JOB_REGEX_SLURM2: &str = "/slurmstepd.scope/job_(?<job_id__u64>[0-9]+)";
-pub const JOB_STEP: &str = "step_((?<job_step>[0-9a-zA-Z]+)).*";
+pub const JOB_STEP_REGEX: &str = "step_((?<job_step>[0-9a-zA-Z]+)).*";
 
 pub fn find_jobid_in_attrs(attrs: &Vec<(String, AttributeValue)>) -> Option<u64> {
     attrs.iter().find(|(k, _)| k == "job_id").map(|(_, v)| match v {

--- a/plugins/cgroups/slurm/src/attr.rs
+++ b/plugins/cgroups/slurm/src/attr.rs
@@ -2,6 +2,7 @@ use alumet::measurement::AttributeValue;
 
 pub const JOB_REGEX_SLURM1: &str = "/slurm/uid_(?<user_id__u64>[0-9]+)/job_(?<job_id__u64>[0-9]+)";
 pub const JOB_REGEX_SLURM2: &str = "/slurmstepd.scope/job_(?<job_id__u64>[0-9]+)";
+pub const JOB_STEP: &str = "step_((?<job_step>[0-9a-zA-Z]+)).*";
 
 pub fn find_jobid_in_attrs(attrs: &Vec<(String, AttributeValue)>) -> Option<u64> {
     attrs.iter().find(|(k, _)| k == "job_id").map(|(_, v)| match v {
@@ -12,7 +13,7 @@ pub fn find_jobid_in_attrs(attrs: &Vec<(String, AttributeValue)>) -> Option<u64>
 
 #[cfg(test)]
 mod tests {
-    use crate::attr::find_jobid_in_attrs;
+    use crate::attr::*;
     use alumet::measurement::AttributeValue;
 
     #[test]

--- a/plugins/cgroups/slurm/src/source.rs
+++ b/plugins/cgroups/slurm/src/source.rs
@@ -1,7 +1,7 @@
-use alumet::pipeline::elements::source::trigger::TriggerSpec;
+use alumet::{measurement::AttributeValue, pipeline::elements::source::trigger::TriggerSpec};
 use util_cgroups::Cgroup;
 
-use crate::attr::{JOB_REGEX_SLURM1, JOB_REGEX_SLURM2, find_jobid_in_attrs};
+use crate::attr::{JOB_REGEX_SLURM1, JOB_REGEX_SLURM2, JOB_STEP, find_jobid_in_attrs};
 use util_cgroups_plugins::{
     cgroup_events::{CgroupSetupCallback, ProbeSetup, SourceSettings},
     metrics::{AugmentedMetrics, Metrics},
@@ -12,6 +12,7 @@ use util_cgroups_plugins::{
 pub struct JobSourceSetup {
     extractor_v1: RegexAttributesExtrator,
     extractor_v2: RegexAttributesExtrator,
+    step_extractor: RegexAttributesExtrator,
     trigger: TriggerSpec,
     jobs_only: bool,
 }
@@ -23,6 +24,7 @@ impl JobSourceSetup {
         Ok(Self {
             extractor_v1: RegexAttributesExtrator::new(JOB_REGEX_SLURM1)?,
             extractor_v2: RegexAttributesExtrator::new(JOB_REGEX_SLURM2)?,
+            step_extractor: RegexAttributesExtrator::new(JOB_STEP)?,
             trigger,
             jobs_only: config.jobs_only,
         })
@@ -38,17 +40,24 @@ impl CgroupSetupCallback for JobSourceSetup {
             util_cgroups::CgroupVersion::V2 => &mut self.extractor_v2,
         };
 
-        let attrs = extractor
+        let mut attrs = extractor
             .extract(cgroup.canonical_path())
             .expect("bad regex: it should only match if the input can be parsed into the specified types");
 
         let is_job = !attrs.is_empty();
         let name: String;
 
+        // Use regex to check the step name if there is one
+        let steps_attrs = self
+            .step_extractor
+            .extract(cgroup.canonical_path())
+            .expect("bad regex: it should only match if the input can be parsed into the specified types");
+
         if is_job {
             let job_id = find_jobid_in_attrs(&attrs).expect("job_id should be set");
             // give a nice name
             name = format!("slurm-job-{}", job_id);
+            attrs.extend(steps_attrs);
         } else {
             // not a job, just a cgroup (for ex. a systemd service)
             if self.jobs_only {


### PR DESCRIPTION
add the specification if it's a job or a step in slurm plugin.
It returns in attribute: 

- `job` if it's the main job
- `step` if it's a step of the job

Fix #266 