### PR TITLE
refactor(plugin-kwollect-input): enhance metrics, timestamp, and timezone configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2641,7 +2641,7 @@ dependencies = [
 
 [[package]]
 name = "plugin-kwollect-input"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "alumet",
  "anyhow",

--- a/plugins/kwollect-input/Cargo.toml
+++ b/plugins/kwollect-input/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plugin-kwollect-input"
-version = "0.1.0"
+version = "1.0.0"
 edition.workspace = true
 repository.workspace = true
 

--- a/plugins/kwollect-input/Cargo.toml
+++ b/plugins/kwollect-input/Cargo.toml
@@ -14,15 +14,23 @@ log.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.20.0"
-time = { version ="0.3.41", features = ["formatting"]}
-tokio = "1.46.0"
+time = { version = "0.3.41", features = ["formatting"] }
+tokio.workspace = true
 
 # Use RusTLS instead of OpenSSL on musl
 [target.'cfg(not(target_env = "musl"))'.dependencies]
-reqwest = { version = "0.12.22", default-features = false, features = ["json", "blocking", "native-tls"] }
+reqwest = { version = "0.12.22", default-features = false, features = [
+    "json",
+    "blocking",
+    "native-tls",
+] }
 
 [target.'cfg(target_env = "musl")'.dependencies]
-reqwest = { version = "0.12.22", default-features = false, features = ["json", "blocking", "rustls-tls"] }
+reqwest = { version = "0.12.22", default-features = false, features = [
+    "json",
+    "blocking",
+    "rustls-tls",
+] }
 
 [lints]
 workspace = true

--- a/plugins/kwollect-input/README.md
+++ b/plugins/kwollect-input/README.md
@@ -34,8 +34,8 @@ Here is a configuration example of the plugin. It's part of the Alumet configura
 
 ```toml
 [plugins.kwollect-input]
-site = "lyon"                     # Grid'5000 site
-hostname = "taurus-7"             # Target node hostname
+site = "CLUSTER"                  # Grid'5000 site
+hostname = "NODE"                 # Target node hostname
 metrics = "wattmetre_power_watt"  # Metric to collect, DO NOT CHANGE IT
 login = "YOUR_G5K_LOGIN"          # Your Grid'5000 username
 password = "YOUR_G5K_PASSWORD"    # Your Grid'5000 password

--- a/plugins/kwollect-input/src/lib.rs
+++ b/plugins/kwollect-input/src/lib.rs
@@ -125,13 +125,11 @@ impl AlumetPlugin for KwollectPluginInput {
         let start_alumet: OffsetDateTime = SystemTime::now().into();
         let system_time: SystemTime = convert_to_system_time(start_alumet);
         let start_utc = convert_to_utc(system_time);
-        //let paris_offset = FixedOffset::east_opt(2 * 3600).unwrap();
         let paris_offset = if let Some(hours) = config_cloned.lock().unwrap().utc_offset {
             FixedOffset::east_opt(hours * 3600).unwrap()
         } else {
             FixedOffset::east_opt(0).unwrap() // fallback : UTC
         };
-        //let start_paris = start_utc.with_timezone(&paris_offset);
         let start_paris = start_utc.with_timezone(&paris_offset);
         event::end_consumer_measurement().subscribe(move |_evt| {
             log::debug!("End consumer measurement event received");
@@ -322,10 +320,10 @@ impl Default for Config {
         Config {
             site: "cluster".to_string(),
             hostname: "node".to_string(),
-            metrics: vec!["wattmetre_power_watt".to_string()],
+            metrics: vec!["metric".to_string()],
             login: "login".to_string(),
             password: "password".to_string(),
-            utc_offset: Some(2), // By default Summer Paris
+            utc_offset: Some(2), // UTC+2 (CEST, Central European Summer Time; note: UTC+1/CET applies in winter)
         }
     }
 }

--- a/plugins/kwollect-input/src/lib.rs
+++ b/plugins/kwollect-input/src/lib.rs
@@ -230,7 +230,7 @@ fn normalize_unit(unit_str: &str) -> &str {
         "rpm" => "rpm",          // Not UCUM standard
         "cfm" => "[cft_i]/min",  // UCUM standard (cubic foot per minute)
         "bytes" => "By",         // UCUM standard
-        "packets" => "tot.",     // UCUM standard for a count
+        "packets" => "1",        // UCUM standard for a count
         _ => unit_str,           // Return as-is if already UCUM or unknown
     }
 }

--- a/plugins/kwollect-input/src/lib.rs
+++ b/plugins/kwollect-input/src/lib.rs
@@ -74,9 +74,9 @@ impl AlumetPlugin for KwollectPluginInput {
 
         for metric_name in &config.metrics {
             let unit_str = extract_unit_from_metric_name(metric_name);
-            let prefixed_unit = if let Ok(unit) = PrefixedUnit::from_str(&unit_str) {
+            let prefixed_unit = if let Ok(unit) = PrefixedUnit::from_str(unit_str) {
                 unit
-            } else if let Ok(base_unit) = Unit::from_str(&unit_str) {
+            } else if let Ok(base_unit) = Unit::from_str(unit_str) {
                 PrefixedUnit {
                     base_unit,
                     prefix: UnitPrefix::Plain,
@@ -85,8 +85,8 @@ impl AlumetPlugin for KwollectPluginInput {
                 // fallback: create a custom unit if it doesn't exists
                 PrefixedUnit {
                     base_unit: Unit::Custom {
-                        unique_name: unit_str.clone(),
-                        display_name: unit_str.clone(),
+                        unique_name: unit_str.to_string(),
+                        display_name: unit_str.to_string(),
                     },
                     prefix: UnitPrefix::Plain,
                 }
@@ -211,34 +211,34 @@ impl AlumetPlugin for KwollectPluginInput {
 ///     `prom_all_metrics`, `prom_default_metrics`, `prom_nvgpu_all_metrics`,
 ///     `prom_nvgpu_default_metrics`.
 ///     Use the Prometheus exporter plugin instead for these metrics.
-fn normalize_unit(unit_str: &str) -> String {
+fn normalize_unit(unit_str: &str) -> &str {
     match unit_str {
-        "watt" => "W".to_string(),           // UCUM standard
-        "kilowatt" => "kW".to_string(),      // UCUM standard
-        "watthour" => "W.h".to_string(),     // UCUM standard
-        "celsius" => "Cel".to_string(),      // UCUM standard
-        "percent" | "%" => "%".to_string(),  // UCUM standard
-        "VA" => "V.A".to_string(),           // Not UCUM standard (Volt-Ampere)
-        "VAr" => "V.A_r".to_string(),        // Not UCUM standard (Reactive Volt-Ampere)
-        "amp" | "ampere" => "A".to_string(), // UCUM standard
-        "volt" => "V".to_string(),           // UCUM standard
-        "hertz" => "Hz".to_string(),         // UCUM standard
-        "lux" => "lx".to_string(),           // UCUM standard
-        "bar" => "bar".to_string(),          // UCUM standard
-        "deg" => "°".to_string(),            // UCUM standard
-        "m/s" => "m/s".to_string(),          // UCUM standard
-        "rpm" => "rpm".to_string(),          // Not UCUM standard
-        "cfm" => "[cft_i]/min".to_string(),  // UCUM standard (cubic foot per minute)
-        "bytes" => "By".to_string(),         // UCUM standard
-        "packets" => "tot.".to_string(),     // UCUM standard for a count
-        _ => unit_str.to_string(),           // Return as-is if already UCUM or unknown
+        "watt" => "W",           // UCUM standard
+        "kilowatt" => "kW",      // UCUM standard
+        "watthour" => "W.h",     // UCUM standard
+        "celsius" => "Cel",      // UCUM standard
+        "percent" | "%" => "%",  // UCUM standard
+        "VA" => "V.A",           // Not UCUM standard (Volt-Ampere)
+        "VAr" => "V.A_r",        // Not UCUM standard (Reactive Volt-Ampere)
+        "amp" | "ampere" => "A", // UCUM standard
+        "volt" => "V",           // UCUM standard
+        "hertz" => "Hz",         // UCUM standard
+        "lux" => "lx",           // UCUM standard
+        "bar" => "bar",          // UCUM standard
+        "deg" => "°",            // UCUM standard
+        "m/s" => "m/s",          // UCUM standard
+        "rpm" => "rpm",          // Not UCUM standard
+        "cfm" => "[cft_i]/min",  // UCUM standard (cubic foot per minute)
+        "bytes" => "By",         // UCUM standard
+        "packets" => "tot.",     // UCUM standard for a count
+        _ => unit_str,           // Return as-is if already UCUM or unknown
     }
 }
 
 /// Extracts the unit from a metric name.
 /// The unit is typically the last segment of the metric name, unless the name ends with "total".
 /// In that case, the unit is the segment before "total", or the segment before "discard" or "error" if present.
-fn extract_unit_from_metric_name(metric_name: &str) -> String {
+fn extract_unit_from_metric_name(metric_name: &str) -> &str {
     let parts: Vec<&str> = metric_name.split('_').collect();
     // Special handling if the last part is "total"
     if parts.len() >= 3


### PR DESCRIPTION
# Plugin Kwollect Input: enhance metrics, timestamp, and timezone configuration

This PR introduces significant improvements to the Kwollect Input Plugin:

- Extended metrics support: Enables the use of nearly all Kwollect metrics (excluding Prometheus exporter metrics, which are already handled by a [dedicated plugin](https://github.com/alumet-dev/alumet/tree/main/plugins/prometheus-exporter)).
- UTC offset configuration: Replaces static system time configuration with a flexible UTC offset setting.
- Robust timestamp parsing: Supports timestamps with varying precision (nanoseconds, microseconds, milliseconds, and no fractions).

## **Changes**

### **1. Allowing use of ~all metrics of Kwollect**

**Goal**: Enable the use of nearly all Kwollect metrics, with units normalized to the UCUM standard.

#### Adding `normalize_unit` function to normalizes unit strings to the UCUM standard.
- Added support for standard UCUM units (e.g., `watt` → `W`, `celsius` → `Cel`).
- Added handling for non-UCUM units (e.g., `VA` → `V.A`, `VAr` → `V.A_r`).
- Added fallback to return the original string if the unit is unknown or already in UCUM format.

#### Adding `extract_unit_from_metric_name` function to extracts the unit from a metric name, especially for metrics ending with `total`, `discard`, or `error`.
- Improved logic to handle edge cases where the unit is not the last segment (e.g., `*_discard_total`, `*_error_total`).
- Defaults to the last segment if no special case is detected.

#### **Metric Creation**
- Added logic to parse and normalize units for each metric.
- Implemented fallback to create custom units if the unit is not recognized.
- Ensured all metrics are created with a descriptive label (e.g., `Metric: {metric_name}`).

#### **Output example** 

``` bash
    📏 49 metrics registered:
        - active_power_watt: F64 (W)
        - apparent_power_VA: F64 (V.A)
        - bmc_ambient_temp_celsius: F64 (°C)
        - bmc_cpu_power_watt: F64 (W)
        - bmc_cpu_temp_celsius: F64 (°C)
        - bmc_cpu_usage_percent: F64 (%)
        - bmc_dimm_power_watt: F64 (W)
        - bmc_dimm_temp_celsius: F64 (°C)
        - bmc_exhaust_temp_celsius: F64 (°C)
        - bmc_fan_power_watt: F64 (W)
        - bmc_fan_speed_rpm: F64 (rpm)
        - bmc_fan_usage_percent: F64 (%)
        - bmc_gpu_power_watt: F64 (W)
        - bmc_gpu_temp_celsius: F64 (°C)
        - bmc_mem_power_watt: F64 (W)
        - bmc_node_power_watt: F64 (W)
        - bmc_node_power_watthour_total: F64 (Wh)
        - bmc_other_airflow_cfm: F64 ([cft_i]/min)
        - bmc_other_current_amp: F64 (A)
        - bmc_other_power_watt: F64 (W)
        - bmc_other_speed_rpm: F64 (rpm)
        - bmc_other_temp_celsius: F64 (°C)
        - bmc_other_usage_percent: F64 (%)
        - bmc_other_voltage_volt: F64 (V)
        - bmc_psu_current_amp: F64 (A)
        - bmc_psu_temp_celsius: F64 (°C)
        - bmc_psu_voltage_volt: F64 (V)
        - cooling_fan_speed_percent: F64 (%)
        - cooling_power_kilowatt: F64 (kW)
        - cooling_return_temperature_celsius: F64 (°C)
        - cooling_supply_temperature_celsius: F64 (°C)
        - humidity_meter_%: F64 (%)
        - luminosity_lux: F64 (lx)
        - network_ifacein_bytes_total: F64 (B)
        - network_ifacein_packets_discard_total: F64 (tot.)
        - network_ifacein_packets_error_total: F64 (tot.)
        - network_ifacein_packets_total: F64 (tot.)
        - network_ifaceout_bytes_total: F64 (B)
        - network_ifaceout_packets_error_total: F64 (tot.)
        - network_ifaceout_packets_total: F64 (tot.)
        - pdu_outlet_power_watt: F64 (W)
        - pdu_temperature_celsius: F64 (°C)
        - pressure_bar: F64 (bar)
        - solar_production_ampere: F64 (A)
        - solar_production_watt: F64 (W)
        - temperature_celsius: F64 (°C)
        - wattmetre_power_watt: F64 (W)
        - wind_direction_deg: F64 (°)
        - wind_speed_m/s: F64 (m/s)
```

---

### **2. UTC Offset Configuration**

**Goal**: Replace static system time configuration with a configurable UTC offset.

#### Changed `post_pipeline_start` to configures the UTC offset for timestamp handling.
- Added support for a configurable UTC offset in the plugin configuration (config.utc_offset).
- If utc_offset is provided, the plugin uses it to set the local timezone offset (e.g., 2 for Paris, which is UTC+2).
- Falls back to UTC (offset 0) if no offset is specified.
- Updated the start_paris calculation to use the configured offset instead of a hardcoded value.

---

### **3. Timestamp Parsing**
#### Adding `parse_timestamp` function to parses timestamps in multiple formats (nanoseconds, microseconds, milliseconds, and no fractions).
- Added support for multiple timestamp formats to improve robustness.
