### PR TITLE
feat(plugin-slurm): made possible to start sources in pause mode

### DIFF
--- a/plugins/cgroups/slurm/README.md
+++ b/plugins/cgroups/slurm/README.md
@@ -45,6 +45,8 @@ poll_interval = "1s"
 cgroupv1_refresh_interval = "30s"
 # Only monitor the job cgroup related metrics and skip the others
 jobs_only = true
+# If true, the slurm sources will be started in pause state (only for advanced setup with a control plugin enabled)
+add_source_in_pause_state = false
 ```
 
 ## More information

--- a/plugins/cgroups/slurm/src/lib.rs
+++ b/plugins/cgroups/slurm/src/lib.rs
@@ -61,7 +61,10 @@ impl AlumetPlugin for SlurmPlugin {
         // Prepare for cgroup detection.
         let starting_state = StartingState {
             metrics: Metrics::create(alumet)?,
-            reactor_config: ReactorConfig::default(),
+            reactor_config: ReactorConfig {
+                add_source_in_pause_state: config.add_source_in_pause_state,
+                ..Default::default()
+            },
             source_setup: source::JobSourceSetup::new(config)?,
         };
         self.starting_state = Some(starting_state);
@@ -104,6 +107,14 @@ pub struct Config {
     pub cgroupv1_refresh_interval: Option<Duration>,
     /// Only monitor the job cgroup related metrics and skip the others
     pub jobs_only: bool,
+
+    /// If true, the slurm sources will be started in pause state.
+    /// If None: the value is false.
+    ///
+    /// This behavior is necessary to have fine-grained control over which cgroup to monitor.
+    /// !! It's essentially needed for advanced Alumet setup with a control plugin that manage the state of sources.
+    #[serde(default)]
+    pub add_source_in_pause_state: bool,
 }
 
 impl Default for Config {
@@ -113,6 +124,7 @@ impl Default for Config {
             poll_interval: Duration::from_secs(1),
             cgroupv1_refresh_interval: None,
             jobs_only: true,
+            add_source_in_pause_state: false,
         }
     }
 }

--- a/plugins/cgroups/util-cgroups/src/detect.rs
+++ b/plugins/cgroups/util-cgroups/src/detect.rs
@@ -60,10 +60,17 @@ pub struct Config {
     ///
     /// Only applies to cgroup v1 hierarchies (cgroupv2 supports inotify).
     pub v1_refresh_interval: Duration,
+
     /// If `true`, always use a poll-based approach instead of `inotify`.
     ///
     /// This is less efficient, but could prove useful for debugging purposes.
     pub force_polling: bool,
+
+    /// If true, the reactor will add new cgroup sources in pause state.
+    ///
+    /// This behavior is necessary to have fine-grained control over which cgroup to monitor.
+    /// It's essentially needed for advanced Alumet setup with a control plugin that manage the state of sources.
+    pub add_source_in_pause_state: bool,
 }
 
 impl Default for Config {
@@ -71,6 +78,7 @@ impl Default for Config {
         Self {
             v1_refresh_interval: Duration::from_secs(30),
             force_polling: false,
+            add_source_in_pause_state: false,
         }
     }
 }

--- a/plugins/cgroups/util-cgroups/tests/cgroupv1.rs
+++ b/plugins/cgroups/util-cgroups/tests/cgroupv1.rs
@@ -83,6 +83,7 @@ fn one_cgroup_created_after_v1() {
     let config = Config {
         v1_refresh_interval: Duration::from_millis(10),
         force_polling: false,
+        add_source_in_pause_state: false,
     };
     let f1 = callback(move |cgroups| {
         for cgroup in cgroups {
@@ -121,6 +122,7 @@ fn severale_cgroup_created_after_v1() {
     let config = Config {
         v1_refresh_interval: Duration::from_millis(10),
         force_polling: false,
+        add_source_in_pause_state: false,
     };
 
     let f1 = callback(move |cgroups| {
@@ -278,6 +280,7 @@ fn cgroup_missing_element_v1() {
     let config = Config {
         v1_refresh_interval: Duration::from_millis(10),
         force_polling: false,
+        add_source_in_pause_state: false,
     };
     let f1 = callback(move |cgroups| {
         for cgroup in cgroups {
@@ -358,6 +361,7 @@ fn creation_of_cgroup_before_and_after_v1() {
     let config = Config {
         v1_refresh_interval: Duration::from_millis(10),
         force_polling: false,
+        add_source_in_pause_state: false,
     };
     let f1 = callback(move |cgroups| {
         for cgroup in cgroups {


### PR DESCRIPTION
Added a configuration in Slurm plugin Config propagated to cgroup ReactorConfig and DetectConfig to make configurable to start new cgroup sources in pause mode.

This behavior can be useful in some scenario where we need a fine-grained control over which source to monitor or not - over a control plugin.

The Slurm configuration parameter is optional and by default is false.