### PR TITLE
When a plugin is initialized without a config, use its default config

### DIFF
--- a/core/alumet/src/agent/plugin.rs
+++ b/core/alumet/src/agent/plugin.rs
@@ -150,6 +150,7 @@ impl PluginSet {
                 plugin_info.enabled = false;
             }
         }
+        log::trace!("extracting plugins configurations from the global config:\n{global_config}");
 
         // Extract the config and enable the plugins that it contains.
         let extracted = super::config::extract_plugins_config(global_config).context("invalid config")?;

--- a/core/alumet/src/plugin/mod.rs
+++ b/core/alumet/src/plugin/mod.rs
@@ -168,7 +168,7 @@ impl Debug for PluginMetadata {
 /// let my_table: ConfigTable = serialized;
 /// let deserialized: MyConfig = deserialize_config(my_table).expect("deserialization failed");
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ConfigTable(pub toml::Table);
 
 /// Trait for plugins.


### PR DESCRIPTION
Resolves #154