### PR TITLE
Network stats for procfs plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2810,7 +2810,7 @@ dependencies = [
 
 [[package]]
 name = "plugin-procfs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "alumet",
  "anyhow",

--- a/core/alumet/src/agent/plugin.rs
+++ b/core/alumet/src/agent/plugin.rs
@@ -198,6 +198,8 @@ impl PluginSet {
     pub fn set_plugin_enabled(&mut self, plugin_name: &str, enabled: bool) {
         if let Some(plugin) = self.0.get_mut(plugin_name) {
             plugin.enabled = enabled;
+        } else {
+            log::error!("Plugin {plugin_name} is not available in this binary of Alumet Agent.");
         }
     }
 

--- a/plugins/procfs/Cargo.toml
+++ b/plugins/procfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plugin-procfs"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 repository.workspace = true
 

--- a/plugins/procfs/README.md
+++ b/plugins/procfs/README.md
@@ -9,7 +9,7 @@ Collects processes and system-related metrics by reading the [proc](https://www.
 
 ## Metrics
 
-There are various information collected by this plugin relative to Kernel, CPU, memory and processes:
+There are various information collected by this plugin relative to Kernel, CPU, memory, network and processes:
 
 |Name|Type|Unit|Description|Resource|ResourceConsumer|Attributes|
 |----|----|----|-----------|--------|----------------|----------|
@@ -20,6 +20,10 @@ There are various information collected by this plugin relative to Kernel, CPU, 
 |`kernel_n_procs_blocked`|Gauge|none|Numbers of processes that are blocked on input/output operations|LocalMachine|LocalMachine||
 |`cpu_time_delta`|CounterDiff|millisecond|CPU usage|LocalMachine|Process|[kind](#kind)|
 |`memory_usage`|Gauge|bytes|Memory usage|LocalMachine|Process|[kind](#kind)|
+|`network_bytes`|Gauge|bytes|Tx/Rx bytes per interface|LocalMachine|LocalMachine|direction,interface|
+|`network_packets`|Gauge|bytes|Tx/Rx packets per interface|LocalMachine|LocalMachine|direction,interface|
+|`network_packet_drops`|Gauge|bytes|Tx/Rx packets dropped per interface|LocalMachine|LocalMachine|direction,interface|
+|`network_errors`|Gauge|bytes|Tx/Rx network errors per interface|LocalMachine|LocalMachine|direction,interface|
 
 - ***Context switches**: Operation allowing a single CPU to manage multiple processes efficiently, involves saving the state of a currently running process and loading the state of another process, enabling multitasking and optimal CPU utilization.
 - ***Forks**: When a process creates a copy of itself.
@@ -72,7 +76,7 @@ To active the plugin to collect metrics relative to the kernel utilization:
 [plugins.procfs.kernel]
 # `true` to enable the monitoring of kernel information.
 enabled = true
-# How frequently should the kernel information be flushed to the rest of the pipeline.
+# Interval between two measurements.
 poll_interval = "5s"
 ```
 
@@ -84,7 +88,7 @@ Moreover, you can collect more or less precise metrics on memory consumption, by
 [plugins.procfs.memory]
 # `true` to enable the monitoring of memory information.
 enabled = true
-# How frequently should the memory information be flushed to the rest of the pipeline.
+# Interval between two measurements.
 poll_interval = "5s"
 # The entry to parse from `/proc/meminfo`.
 metrics = [
@@ -97,6 +101,18 @@ metrics = [
     "Inactive",
     "Mapped",
 ]
+```
+
+### Network metrics
+
+When enabled, it can also provide RX/TX network metrics per interface at the host level. It provides access to bytes, packets, drops and errors from /proc/net/dev:
+
+```toml
+[plugins.procfs.network]
+# `true` to enable the monitoring of host network information.
+enabled = true
+# Interval between two measurements.
+poll_interval = "5s"
 ```
 
 ### Process metrics
@@ -124,7 +140,7 @@ Also, you can monitor groups of processes, i.e. processes defined by common char
 [[plugins.procfs.processes.groups]]
 # Only monitor the processes whose executable path matches this regex.
 exe_regex = ""
-# How frequently should the processes information be refreshed.
+# Interval between two measurements.
 poll_interval = "2s"
 # How frequently should the processes information be flushed to the rest of the pipeline.
 flush_interval = "4s"

--- a/plugins/procfs/src/lib.rs
+++ b/plugins/procfs/src/lib.rs
@@ -13,6 +13,7 @@ use rlimit::{Resource, getrlimit, setrlimit};
 
 mod kernel;
 mod memory;
+mod network;
 mod process;
 mod serde_regex;
 
@@ -50,6 +51,9 @@ impl AlumetPlugin for ProcfsPlugin {
         if config.memory.enabled {
             start_memory_probe(config.memory, alumet)?;
         }
+        if config.network.enabled {
+            start_network_probe(config.network, alumet)?;
+        }
         if config.processes.enabled {
             let metrics = process::ProcessMetrics {
                 metric_cpu_time_delta: alumet
@@ -62,7 +66,6 @@ impl AlumetPlugin for ProcfsPlugin {
                     .create_metric("memory_usage", Unit::Byte, "Memory usage")
                     .context("unable to register metric memory for process probe")?,
             };
-
             match config.processes.strategy {
                 config::ProcessWatchStrategy::SystemWatcher => {
                     start_process_watcher(config.processes, alumet, metrics);
@@ -91,6 +94,18 @@ fn start_kernel_probe(
     let source =
         kernel::KernelStatsProbe::new(metrics, procfs::KernelStats::PATH).context("unable to create kernel probe")?;
     alumet.add_source("kernel", Box::new(source), trigger)?;
+    Ok(())
+}
+
+fn start_network_probe(
+    config_network: config::NetworkMonitoring,
+    alumet: &mut alumet::plugin::AlumetPluginStart<'_>,
+) -> Result<(), anyhow::Error> {
+    let trigger = TriggerSpec::at_interval(config_network.poll_interval);
+    let metrics = network::NetworkMetrics::new(alumet).context("unable to register metrics for network probe")?;
+    let source = network::NetworkProbe::new(metrics, procfs::net::InterfaceDeviceStatus::PATH)
+        .context("unable to create network probe")?;
+    alumet.add_source("network", Box::new(source), trigger)?;
     Ok(())
 }
 
@@ -204,11 +219,20 @@ mod config {
     pub struct Config {
         pub kernel: KernelStatsMonitoring,
         pub memory: MeminfoMonitoring,
+        pub network: NetworkMonitoring,
         pub processes: ProcessMonitoring,
     }
 
     #[derive(Serialize, Deserialize)]
     pub struct KernelStatsMonitoring {
+        #[serde(default = "default_enabled")]
+        pub enabled: bool,
+        #[serde(with = "humantime_serde")]
+        pub poll_interval: Duration,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    pub struct NetworkMonitoring {
         #[serde(default = "default_enabled")]
         pub enabled: bool,
         #[serde(with = "humantime_serde")]
@@ -282,6 +306,15 @@ mod config {
     }
 
     impl Default for KernelStatsMonitoring {
+        fn default() -> Self {
+            Self {
+                enabled: true,
+                poll_interval: Duration::from_secs(5),
+            }
+        }
+    }
+
+    impl Default for NetworkMonitoring {
         fn default() -> Self {
             Self {
                 enabled: true,

--- a/plugins/procfs/src/network.rs
+++ b/plugins/procfs/src/network.rs
@@ -1,0 +1,199 @@
+//! System-level network metrics read from `/proc/net/dev`.
+
+use std::{
+    fs::File,
+    io::{BufReader, Seek},
+};
+
+use alumet::{
+    measurement::{MeasurementAccumulator, MeasurementPoint, Timestamp},
+    metrics::{TypedMetricId, error::MetricCreationError},
+    pipeline::{Source, elements::error::PollError},
+    plugin::AlumetPluginStart,
+    resources::{Resource, ResourceConsumer},
+    units::Unit,
+};
+use anyhow::Context;
+use procfs::{
+    FromBufRead,
+    net::{DeviceStatus, InterfaceDeviceStatus},
+};
+
+/// Reads network metrics from /proc/net/dev
+pub struct NetworkProbe {
+    reader: BufReader<File>,
+    previous: Option<InterfaceDeviceStatus>,
+    metrics: NetworkMetrics,
+}
+
+pub struct NetworkMetrics {
+    // More metrics available as part of InterfaceDeviceStatus but not considered for now
+    pub bytes: TypedMetricId<u64>,
+    pub packets: TypedMetricId<u64>,
+    pub drops: TypedMetricId<u64>,
+    pub errors: TypedMetricId<u64>,
+}
+
+impl NetworkMetrics {
+    pub fn new(alumet: &mut AlumetPluginStart) -> Result<Self, MetricCreationError> {
+        Ok(Self {
+            bytes: alumet.create_metric("network_bytes", Unit::Byte, "Number of bytes (rx/tx) per interface")?,
+            packets: alumet.create_metric(
+                "network_packets",
+                Unit::Unity,
+                "Number of packets (rx/tx) per interface",
+            )?,
+            drops: alumet.create_metric(
+                "network_packet_drops",
+                Unit::Unity,
+                "Number of dropped packets (rx/tx) per interface",
+            )?,
+            errors: alumet.create_metric("network_errors", Unit::Unity, "Number of errors (rx/tx) per interface")?,
+        })
+    }
+}
+
+impl NetworkProbe {
+    pub fn new(metrics: NetworkMetrics, path: &str) -> anyhow::Result<Self> {
+        let file = File::open(path).with_context(|| format!("cannot open {path}"))?;
+        Ok(Self {
+            reader: BufReader::new(file),
+            previous: None,
+            metrics,
+        })
+    }
+}
+
+impl Source for NetworkProbe {
+    fn poll(&mut self, acc: &mut MeasurementAccumulator, ts: Timestamp) -> Result<(), PollError> {
+        self.reader.rewind()?;
+        let now = InterfaceDeviceStatus::from_buf_read(&mut self.reader).context("error parsing /proc/net/dev")?;
+        // Only push deltas, not the baseline value before the plugin starts
+        if let Some(ref prev) = self.previous {
+            for (if_name, now_stats) in &now.0 {
+                // Also consider the first value when a new interface appears at runtime
+                let prev_stats = match prev.0.get(if_name) {
+                    Some(p) => p,
+                    // Default not implemented by procfs
+                    None => &DeviceStatus {
+                        name: if_name.clone(),
+                        recv_bytes: 0,
+                        recv_packets: 0,
+                        recv_errs: 0,
+                        recv_drop: 0,
+                        sent_bytes: 0,
+                        sent_packets: 0,
+                        sent_errs: 0,
+                        sent_drop: 0,
+                        recv_fifo: 0,
+                        recv_frame: 0,
+                        recv_compressed: 0,
+                        recv_multicast: 0,
+                        sent_fifo: 0,
+                        sent_colls: 0,
+                        sent_carrier: 0,
+                        sent_compressed: 0,
+                    },
+                };
+                //};
+                let res = Resource::LocalMachine;
+                let cons = ResourceConsumer::LocalMachine;
+
+                // ---------- rx ----------
+                acc.push(
+                    MeasurementPoint::new(
+                        ts,
+                        self.metrics.bytes,
+                        res.clone(),
+                        cons.clone(),
+                        now_stats.recv_bytes - prev_stats.recv_bytes,
+                    )
+                    .with_attr("interface", if_name.clone())
+                    .with_attr("direction", "rx"),
+                );
+                acc.push(
+                    MeasurementPoint::new(
+                        ts,
+                        self.metrics.packets,
+                        res.clone(),
+                        cons.clone(),
+                        now_stats.recv_packets - prev_stats.recv_packets,
+                    )
+                    .with_attr("interface", if_name.clone())
+                    .with_attr("direction", "rx"),
+                );
+                acc.push(
+                    MeasurementPoint::new(
+                        ts,
+                        self.metrics.drops,
+                        res.clone(),
+                        cons.clone(),
+                        now_stats.recv_drop - prev_stats.recv_drop,
+                    )
+                    .with_attr("interface", if_name.clone())
+                    .with_attr("direction", "rx"),
+                );
+                acc.push(
+                    MeasurementPoint::new(
+                        ts,
+                        self.metrics.errors,
+                        res.clone(),
+                        cons.clone(),
+                        now_stats.recv_errs - prev_stats.recv_errs,
+                    )
+                    .with_attr("interface", if_name.clone())
+                    .with_attr("direction", "rx"),
+                );
+
+                // ---------- tx ----------
+                acc.push(
+                    MeasurementPoint::new(
+                        ts,
+                        self.metrics.bytes,
+                        res.clone(),
+                        cons.clone(),
+                        now_stats.sent_bytes - prev_stats.sent_bytes,
+                    )
+                    .with_attr("interface", if_name.clone())
+                    .with_attr("direction", "tx"),
+                );
+                acc.push(
+                    MeasurementPoint::new(
+                        ts,
+                        self.metrics.packets,
+                        res.clone(),
+                        cons.clone(),
+                        now_stats.sent_packets - prev_stats.sent_packets,
+                    )
+                    .with_attr("interface", if_name.clone())
+                    .with_attr("direction", "tx"),
+                );
+                acc.push(
+                    MeasurementPoint::new(
+                        ts,
+                        self.metrics.drops,
+                        res.clone(),
+                        cons.clone(),
+                        now_stats.sent_drop - prev_stats.sent_drop,
+                    )
+                    .with_attr("interface", if_name.clone())
+                    .with_attr("direction", "tx"),
+                );
+                acc.push(
+                    MeasurementPoint::new(
+                        ts,
+                        self.metrics.errors,
+                        res.clone(),
+                        cons.clone(),
+                        now_stats.sent_errs - prev_stats.sent_errs,
+                    )
+                    .with_attr("interface", if_name.clone())
+                    .with_attr("direction", "tx"),
+                );
+            }
+        }
+
+        self.previous = Some(now);
+        Ok(())
+    }
+}


### PR DESCRIPTION
Added a configurable network monitoring for the host.

e.g, of output
```csv
metric;timestamp;value;resource_kind;resource_id;consumer_kind;consumer_id;__late_attributes
network_bytes_B;2025-10-29T11:30:26.119098152Z;174136;local_machine;;local_machine;;direction=rx,interface=lo
network_packets;2025-10-29T11:30:26.119098152Z;156;local_machine;;local_machine;;direction=rx,interface=lo
network_drops;2025-10-29T11:30:26.119098152Z;0;local_machine;;local_machine;;direction=rx,interface=lo
network_errors;2025-10-29T11:30:26.119098152Z;0;local_machine;;local_machine;;direction=rx,interface=lo
network_bytes_B;2025-10-29T11:30:26.119098152Z;174136;local_machine;;local_machine;;direction=tx,interface=lo
network_packets;2025-10-29T11:30:26.119098152Z;156;local_machine;;local_machine;;direction=tx,interface=lo
network_drops;2025-10-29T11:30:26.119098152Z;0;local_machine;;local_machine;;direction=tx,interface=lo
network_errors;2025-10-29T11:30:26.119098152Z;0;local_machine;;local_machine;;direction=tx,interface=lo
network_bytes_B;2025-10-29T11:30:26.119098152Z;6410;local_machine;;local_machine;;direction=rx,interface=eth0
network_packets;2025-10-29T11:30:26.119098152Z;14;local_machine;;local_machine;;direction=rx,interface=eth0
network_drops;2025-10-29T11:30:26.119098152Z;0;local_machine;;local_machine;;direction=rx,interface=eth0
network_errors;2025-10-29T11:30:26.119098152Z;0;local_machine;;local_machine;;direction=rx,interface=eth0
network_bytes_B;2025-10-29T11:30:26.119098152Z;7459;local_machine;;local_machine;;direction=tx,interface=eth0
network_packets;2025-10-29T11:30:26.119098152Z;16;local_machine;;local_machine;;direction=tx,interface=eth0
network_drops;2025-10-29T11:30:26.119098152Z;0;local_machine;;local_machine;;direction=tx,interface=eth0
network_errors;2025-10-29T11:30:26.119098152Z;0;local_machine;;local_machine;;direction=tx,interface=eth0
network_bytes_B;2025-10-29T11:30:31.118607856Z;11522;local_machine;;local_machine;;direction=rx,interface=lo
```