### PR TITLE
feat(plugin-nvml): don't push measurement when counters stay unchanged

### DIFF
--- a/plugins/nvidia-nvml/README.md
+++ b/plugins/nvidia-nvml/README.md
@@ -68,3 +68,9 @@ The `minimal` mode only works on GPU that support the `nvmlDeviceGetPowerUsage` 
 
 Not all software use the GPU to its full extent.
 For instance, to obtain non-zero values for the video encoding/decoding metrics, use a video software like `ffmpeg`.
+
+### GPU counter updates
+
+NVML requires 20-100ms to refresh counter values based on GPU model.
+When `poll_interval` is set too low, the plugin queries identical counter values repeatedly during polling.
+Since some measurements are calculated from previous polls, these measurements are discarded rather than reported as zero values.


### PR DESCRIPTION
Added a behavior that check if the counter diff difference value is upper than zero to push it.

Note that we're sure that the GPU's energy-consumption grow over time even if it's not used by a process.

This happens when the poll frequency is higher than the nvml registry's refresh frequency.