### PR TITLE
chore(core): debug verbosity for paused source

### DIFF
--- a/core/alumet/src/pipeline/elements/source/run.rs
+++ b/core/alumet/src/pipeline/elements/source/run.rs
@@ -102,7 +102,7 @@ pub(crate) async fn run_managed(
             TaskState::Pause => {
                 let pause_timeout = tokio::time::Duration::from_secs(60); // todo: make it configurable
                 if let Err(_) = tokio::time::timeout(pause_timeout, config_change.notified()).await {
-                    log::info!(
+                    log::debug!(
                         "Source {source_name} has been started in Pause state and not be resumed in {:?} - Stopping it",
                         pause_timeout
                     );


### PR DESCRIPTION
Changing the log verbosity from info to debug as it's the normal behavior and can be confusing to see these message for an end user running alumet in production. Make sense to keep it only in debug mode imo.