### PR TITLE
Feat/brseed 1457 nvml new metric

### DIFF
--- a/core/alumet/src/test/runtime.rs
+++ b/core/alumet/src/test/runtime.rs
@@ -1,6 +1,5 @@
 use std::{
     cell::RefCell,
-    collections::HashMap,
     ops::Deref,
     rc::Rc,
     sync::{Arc, Mutex},
@@ -16,7 +15,7 @@ use wrapped_transform::{SetTransformOutputCheck, TransformDone, WrappedTransform
 
 use crate::{
     agent::builder::TestExpectations,
-    measurement::{MeasurementBuffer, MeasurementPoint, MeasurementType},
+    measurement::{AttributeValue, MeasurementBuffer, MeasurementPoint, MeasurementType},
     metrics::{
         Metric, RawMetricId,
         duplicate::{DuplicateCriteria, DuplicateReaction},
@@ -712,7 +711,9 @@ impl<'a> SourceCheckOutputContext<'a> {
         self.metrics
     }
 
-    pub fn points_by_metric_and_consumer(&'a self) -> IndexMap<(&'a str, ResourceConsumer), &'a MeasurementPoint> {
+    pub fn points_by_metric_and_consumer(
+        &'a self,
+    ) -> IndexMap<(&'a str, ResourceConsumer, Option<AttributeValue>), &'a MeasurementPoint> {
         self.measurements()
             .into_iter()
             .map(|p| {
@@ -721,8 +722,19 @@ impl<'a> SourceCheckOutputContext<'a> {
                     .by_id(&p.metric)
                     .unwrap_or_else(|| panic!("unknown metric with id {} in {p:?}", &p.metric.0));
                 let metric_name = metric.name.as_str();
+
+                // If the metric has an attribute "kind", the value of the attribute is stored
+                // Otherwise, the Option<AttributeValue> field should be equal to None
+                let kind = p
+                    .attributes()
+                    .find(|(key, _value)| match *key {
+                        "kind" => true,
+                        _ => false,
+                    })
+                    .map(|(_key, value)| value.clone());
+
                 let consumer = p.consumer.clone();
-                ((metric_name, consumer), p)
+                ((metric_name, consumer, kind), p)
             })
             .collect()
     }

--- a/core/alumet/src/test/runtime.rs
+++ b/core/alumet/src/test/runtime.rs
@@ -713,6 +713,7 @@ impl<'a> SourceCheckOutputContext<'a> {
 
     pub fn points_by_metric_and_consumer(
         &'a self,
+        attribute_key: Option<&str>,
     ) -> IndexMap<(&'a str, ResourceConsumer, Option<AttributeValue>), &'a MeasurementPoint> {
         self.measurements()
             .into_iter()
@@ -722,19 +723,20 @@ impl<'a> SourceCheckOutputContext<'a> {
                     .by_id(&p.metric)
                     .unwrap_or_else(|| panic!("unknown metric with id {} in {p:?}", &p.metric.0));
                 let metric_name = metric.name.as_str();
+                let consumer = p.consumer.clone();
 
                 // If the metric has an attribute "kind", the value of the attribute is stored
                 // Otherwise, the Option<AttributeValue> field should be equal to None
-                let kind = p
-                    .attributes()
-                    .find(|(key, _value)| match *key {
-                        "kind" => true,
-                        _ => false,
-                    })
-                    .map(|(_key, value)| value.clone());
-
-                let consumer = p.consumer.clone();
-                ((metric_name, consumer, kind), p)
+                match attribute_key {
+                    None => ((metric_name, consumer, None), p),
+                    Some(key_wanted) => {
+                        let kind = p
+                            .attributes()
+                            .find(|(key, _value)| *key == key_wanted)
+                            .map(|(_key, value)| value.clone());
+                        ((metric_name, consumer, kind), p)
+                    }
+                }
             })
             .collect()
     }

--- a/plugins/nvidia-nvml/README.md
+++ b/plugins/nvidia-nvml/README.md
@@ -19,7 +19,7 @@ One source will be created per GPU device.
 |`nvml_instant_power`|Gauge|milliWatt|Instant power consumption|GPU|LocalMachine||
 |`nvml_temperature_gpu`|Gauge|Celsius|Main temperature emitted by a given device|GPU|LocalMachine||
 |`nvml_gpu_utilization`|Gauge|Percentage (0-100)|GPU rate utilization|GPU|LocalMachine||
-|`nvml_gpu_memory_allocation`|Gauge|bytes|GPU VRAM allocation|GPU|LocalMachine|[kind](#kind)|
+|`nvml_gpu_memory_info`|Gauge|bytes|GPU VRAM information. Only available with recent versions of NVIDIA drivers ($\geq510$)|GPU|LocalMachine|[kind](#kind)|
 |`nvml_encoder_sampling_period`|Gauge|Microsecond|Current utilization and sampling size for the encoder|GPU|LocalMachine||
 |`nvml_decoder_sampling_period`|Gauge|Microsecond|Current utilization and sampling size for the decoder|GPU|LocalMachine||
 |`nvml_n_compute_processes`|Gauge|None|Relevant currently running computing processes data|GPU|LocalMachine||
@@ -36,16 +36,13 @@ Some metrics can be disabled, see the `mode` configuration option.
 #### Kind
 
 The kind of the memory is the type of the allocated memory space reserved by the system or the hardware.
-Depending on the the version of the version of your NVIDIA drivers and your GPU model, the output may slightly vary. See:
-- Version 1: https://docs.nvidia.com/deploy/nvml-api/structnvmlMemory__t.html
-- Version 2: https://docs.nvidia.com/deploy/nvml-api/structnvmlMemory__v2__t.html
 
 |Value|Description|
 |-----|-----------|
 |`free`|Unallocated device memory|
 |`total`|Total physical device memory|
 |`used`|Allocated device memory|
-|`reserved`|Device memory (in bytes) reserved for system use (driver or firmware). Only available with recent versions of NVIDIA drivers and recent GPU models.|
+|`reserved`|Device memory (in bytes) reserved for system use (driver or firmware)|
 
 ## Configuration
 

--- a/plugins/nvidia-nvml/README.md
+++ b/plugins/nvidia-nvml/README.md
@@ -19,6 +19,7 @@ One source will be created per GPU device.
 |`nvml_instant_power`|Gauge|milliWatt|Instant power consumption|GPU|LocalMachine||
 |`nvml_temperature_gpu`|Gauge|Celsius|Main temperature emitted by a given device|GPU|LocalMachine||
 |`nvml_gpu_utilization`|Gauge|Percentage (0-100)|GPU rate utilization|GPU|LocalMachine||
+|`nvml_gpu_memory_allocation`|Gauge|bytes|GPU VRAM allocation|GPU|LocalMachine|[kind](#kind)|
 |`nvml_encoder_sampling_period`|Gauge|Microsecond|Current utilization and sampling size for the encoder|GPU|LocalMachine||
 |`nvml_decoder_sampling_period`|Gauge|Microsecond|Current utilization and sampling size for the decoder|GPU|LocalMachine||
 |`nvml_n_compute_processes`|Gauge|None|Relevant currently running computing processes data|GPU|LocalMachine||
@@ -29,6 +30,22 @@ One source will be created per GPU device.
 |`nvml_sm_utilization`|Gauge|Percentage|Utilization of the GPU streaming multiprocessors by a process (3D task and rendering, etc...)|Process|LocalMachine||
 
 Some metrics can be disabled, see the `mode` configuration option.
+
+### Attributes
+
+#### Kind
+
+The kind of the memory is the type of the allocated memory space reserved by the system or the hardware.
+Depending on the the version of the version of your NVIDIA drivers and your GPU model, the output may slightly vary. See:
+- Version 1: https://docs.nvidia.com/deploy/nvml-api/structnvmlMemory__t.html
+- Version 2: https://docs.nvidia.com/deploy/nvml-api/structnvmlMemory__v2__t.html
+
+|Value|Description|
+|-----|-----------|
+|`free`|Unallocated device memory|
+|`total`|Total physical device memory|
+|`used`|Allocated device memory|
+|`reserved`|Device memory (in bytes) reserved for system use (driver or firmware). Only available with recent versions of NVIDIA drivers and recent GPU models.|
 
 ## Configuration
 
@@ -74,3 +91,11 @@ For instance, to obtain non-zero values for the video encoding/decoding metrics,
 NVML requires 20-100ms to refresh counter values based on GPU model.
 When `poll_interval` is set too low, the plugin queries identical counter values repeatedly during polling.
 Since some measurements are calculated from previous polls, these measurements are discarded rather than reported as zero values.
+
+## Note on NVIDIA 'utilization'
+
+When NVIDIA measures 'utilization', they actually mean the percent of time that the resource was solicited over the last sample of time.
+
+For example, if *memory utilization* $= 60\%$, then it means that during the last **sample of time** (for instance, the past 1 second), 60% of **that time** ($=600ms$) was spent reading or writing the memory.
+
+This is also true for **nvml_gpu_utilization**, **nvml_memory_utilization**, **nvml_encoder_utilization**, **nvml_decoder_utilization** and **nvml_sm_utilization**.

--- a/plugins/nvidia-nvml/src/lib.rs
+++ b/plugins/nvidia-nvml/src/lib.rs
@@ -171,7 +171,7 @@ mod tests {
 
     use alumet::{
         agent::plugin::{PluginInfo, PluginSet},
-        measurement::MeasurementPoint,
+        measurement::{AttributeValue, MeasurementPoint},
         pipeline::naming::SourceName,
         plugin::PluginMetadata,
         resources::ResourceConsumer,
@@ -181,7 +181,7 @@ mod tests {
     use enum_map::{Enum, EnumMap};
     use nvml_wrapper::{
         enums::device::UsedGpuMemory,
-        struct_wrappers::device::{ProcessInfo, ProcessUtilizationSample, Utilization},
+        struct_wrappers::device::{MemoryInfo, ProcessInfo, ProcessUtilizationSample, Utilization},
         structs::device::UtilizationInfo,
     };
 
@@ -281,6 +281,15 @@ mod tests {
             device
                 .expect_utilization_rates()
                 .returning(|| Ok(Utilization { gpu: 50, memory: 60 }));
+            device.expect_memory_allocation().returning(|| {
+                Ok(MemoryInfo {
+                    free: 20,
+                    reserved: 50,
+                    total: 70,
+                    used: 0,
+                    version: 2,
+                })
+            });
             device.expect_decoder_utilization().returning(|| {
                 Ok(UtilizationInfo {
                     utilization: 50,
@@ -397,7 +406,7 @@ mod tests {
                     let points = out.points_by_metric_and_consumer();
                     assert_eq!(points.len(), 2, "wrong number of points, got {points:?}");
                     assert_eq!(
-                        points[&("nvml_instant_power", ResourceConsumer::LocalMachine)]
+                        points[&("nvml_instant_power", ResourceConsumer::LocalMachine, None)]
                             .value
                             .as_u64(),
                         150
@@ -405,7 +414,7 @@ mod tests {
 
                     // FIXME: the value depends on the time difference between the two calls, and we cannot mock that for the moment…
                     assert!(
-                        points[&("nvml_energy_consumption", ResourceConsumer::LocalMachine)]
+                        points[&("nvml_energy_consumption", ResourceConsumer::LocalMachine, None)]
                             .value
                             .as_f64()
                             >= 0.0
@@ -452,6 +461,7 @@ mod tests {
             .expect_metric::<u64>("nvml_n_compute_processes", Unit::Unity)
             .expect_metric::<u64>("nvml_n_graphic_processes", Unit::Unity)
             .expect_metric::<u64>("nvml_memory_utilization", Unit::Percent)
+            .expect_metric::<u64>("nvml_gpu_memory_allocation", Unit::Byte)
             .expect_metric::<u64>("nvml_decoder_utilization", Unit::Percent)
             .expect_metric::<u64>("nvml_encoder_utilization", Unit::Percent)
             .expect_metric::<u64>("nvml_sm_utilization", Unit::Percent);
@@ -469,64 +479,108 @@ mod tests {
                     // first trigger
                     let points = out.points_by_metric_and_consumer();
 
-                    assert_eq!(points.len(), 10, "wrong number of points, got {points:?}");
+                    assert_eq!(points.len(), 14, "wrong number of points, got {points:?}");
 
                     assert_eq!(
-                        points[&("nvml_encoder_utilization", ResourceConsumer::LocalMachine)]
+                        points[&("nvml_encoder_utilization", ResourceConsumer::LocalMachine, None)]
                             .value
                             .as_u64(),
                         1
                     );
                     assert_eq!(
-                        points[&("nvml_decoder_utilization", ResourceConsumer::LocalMachine)]
+                        points[&("nvml_decoder_utilization", ResourceConsumer::LocalMachine, None)]
                             .value
                             .as_u64(),
                         50
                     );
                     assert_eq!(
-                        points[&("nvml_gpu_utilization", ResourceConsumer::LocalMachine)]
+                        points[&("nvml_gpu_utilization", ResourceConsumer::LocalMachine, None)]
                             .value
                             .as_u64(),
                         50
                     );
                     assert_eq!(
-                        points[&("nvml_memory_utilization", ResourceConsumer::LocalMachine)]
+                        points[&("nvml_memory_utilization", ResourceConsumer::LocalMachine, None)]
                             .value
                             .as_u64(),
                         60
                     );
                     assert_eq!(
-                        points[&("nvml_n_compute_processes", ResourceConsumer::LocalMachine)]
+                        points[&(
+                            "nvml_gpu_memory_allocation",
+                            ResourceConsumer::LocalMachine,
+                            Some(AttributeValue::Str("free"))
+                        )]
+                            .clone()
+                            .value
+                            .as_u64(),
+                        20
+                    );
+                    assert_eq!(
+                        points[&(
+                            "nvml_gpu_memory_allocation",
+                            ResourceConsumer::LocalMachine,
+                            Some(AttributeValue::Str("reserved"))
+                        )]
+                            .clone()
+                            .value
+                            .as_u64(),
+                        50
+                    );
+                    assert_eq!(
+                        points[&(
+                            "nvml_gpu_memory_allocation",
+                            ResourceConsumer::LocalMachine,
+                            Some(AttributeValue::Str("total"))
+                        )]
+                            .clone()
+                            .value
+                            .as_u64(),
+                        70
+                    );
+                    assert_eq!(
+                        points[&(
+                            "nvml_gpu_memory_allocation",
+                            ResourceConsumer::LocalMachine,
+                            Some(AttributeValue::Str("used"))
+                        )]
+                            .clone()
                             .value
                             .as_u64(),
                         0
                     );
                     assert_eq!(
-                        points[&("nvml_n_graphic_processes", ResourceConsumer::LocalMachine)]
+                        points[&("nvml_n_compute_processes", ResourceConsumer::LocalMachine, None)]
+                            .value
+                            .as_u64(),
+                        0
+                    );
+                    assert_eq!(
+                        points[&("nvml_n_graphic_processes", ResourceConsumer::LocalMachine, None)]
                             .value
                             .as_u64(),
                         1
                     );
                     assert_eq!(
-                        points[&("nvml_temperature_gpu", ResourceConsumer::LocalMachine)]
+                        points[&("nvml_temperature_gpu", ResourceConsumer::LocalMachine, None)]
                             .value
                             .as_u64(),
                         65
                     );
                     assert_eq!(
-                        points[&("nvml_instant_power", ResourceConsumer::LocalMachine)]
+                        points[&("nvml_instant_power", ResourceConsumer::LocalMachine, None)]
                             .value
                             .as_u64(),
                         100
                     );
                     assert_eq!(
-                        points[&("nvml_encoder_sampling_period", ResourceConsumer::LocalMachine)]
+                        points[&("nvml_encoder_sampling_period", ResourceConsumer::LocalMachine, None)]
                             .value
                             .as_u64(),
                         10_000
                     );
                     assert_eq!(
-                        points[&("nvml_decoder_sampling_period", ResourceConsumer::LocalMachine)]
+                        points[&("nvml_decoder_sampling_period", ResourceConsumer::LocalMachine, None)]
                             .value
                             .as_u64(),
                         1_000
@@ -539,11 +593,11 @@ mod tests {
                 |out| {
                     // second trigger
                     let points = out.points_by_metric_and_consumer();
-                    assert_eq!(points.len(), 15, "wrong number of points, got {points:?}");
+                    assert_eq!(points.len(), 19, "wrong number of points, got {points:?}");
 
                     // new power value
                     assert_eq!(
-                        points[&("nvml_instant_power", ResourceConsumer::LocalMachine)]
+                        points[&("nvml_instant_power", ResourceConsumer::LocalMachine, None)]
                             .value
                             .as_u64(),
                         150
@@ -553,7 +607,7 @@ mod tests {
                     // new energy counter: 5000
                     // expected difference : 4990
                     assert_eq!(
-                        points[&("nvml_energy_consumption", ResourceConsumer::LocalMachine)]
+                        points[&("nvml_energy_consumption", ResourceConsumer::LocalMachine, None)]
                             .value
                             .as_u64(),
                         4990
@@ -561,7 +615,7 @@ mod tests {
 
                     // per-process metrics
                     assert_eq!(
-                        points[&("nvml_sm_utilization", ResourceConsumer::Process { pid: 1234 })]
+                        points[&("nvml_sm_utilization", ResourceConsumer::Process { pid: 1234 }, None)]
                             .value
                             .as_u64(),
                         50

--- a/plugins/nvidia-nvml/src/lib.rs
+++ b/plugins/nvidia-nvml/src/lib.rs
@@ -281,7 +281,7 @@ mod tests {
             device
                 .expect_utilization_rates()
                 .returning(|| Ok(Utilization { gpu: 50, memory: 60 }));
-            device.expect_memory_allocation().returning(|| {
+            device.expect_memory_info().returning(|| {
                 Ok(MemoryInfo {
                     free: 20,
                     reserved: 50,
@@ -403,7 +403,7 @@ mod tests {
                     // previous power: 100
                     // new power: 150
                     // energy: ?
-                    let points = out.points_by_metric_and_consumer();
+                    let points = out.points_by_metric_and_consumer(None);
                     assert_eq!(points.len(), 2, "wrong number of points, got {points:?}");
                     assert_eq!(
                         points[&("nvml_instant_power", ResourceConsumer::LocalMachine, None)]
@@ -461,7 +461,7 @@ mod tests {
             .expect_metric::<u64>("nvml_n_compute_processes", Unit::Unity)
             .expect_metric::<u64>("nvml_n_graphic_processes", Unit::Unity)
             .expect_metric::<u64>("nvml_memory_utilization", Unit::Percent)
-            .expect_metric::<u64>("nvml_gpu_memory_allocation", Unit::Byte)
+            .expect_metric::<u64>("nvml_gpu_memory_info", Unit::Byte)
             .expect_metric::<u64>("nvml_decoder_utilization", Unit::Percent)
             .expect_metric::<u64>("nvml_encoder_utilization", Unit::Percent)
             .expect_metric::<u64>("nvml_sm_utilization", Unit::Percent);
@@ -477,7 +477,7 @@ mod tests {
                 },
                 |out| {
                     // first trigger
-                    let points = out.points_by_metric_and_consumer();
+                    let points = out.points_by_metric_and_consumer(Some("kind"));
 
                     assert_eq!(points.len(), 14, "wrong number of points, got {points:?}");
 
@@ -507,44 +507,40 @@ mod tests {
                     );
                     assert_eq!(
                         points[&(
-                            "nvml_gpu_memory_allocation",
+                            "nvml_gpu_memory_info",
                             ResourceConsumer::LocalMachine,
                             Some(AttributeValue::Str("free"))
                         )]
-                            .clone()
                             .value
                             .as_u64(),
                         20
                     );
                     assert_eq!(
                         points[&(
-                            "nvml_gpu_memory_allocation",
+                            "nvml_gpu_memory_info",
                             ResourceConsumer::LocalMachine,
                             Some(AttributeValue::Str("reserved"))
                         )]
-                            .clone()
                             .value
                             .as_u64(),
                         50
                     );
                     assert_eq!(
                         points[&(
-                            "nvml_gpu_memory_allocation",
+                            "nvml_gpu_memory_info",
                             ResourceConsumer::LocalMachine,
                             Some(AttributeValue::Str("total"))
                         )]
-                            .clone()
                             .value
                             .as_u64(),
                         70
                     );
                     assert_eq!(
                         points[&(
-                            "nvml_gpu_memory_allocation",
+                            "nvml_gpu_memory_info",
                             ResourceConsumer::LocalMachine,
                             Some(AttributeValue::Str("used"))
                         )]
-                            .clone()
                             .value
                             .as_u64(),
                         0
@@ -592,7 +588,7 @@ mod tests {
                 || {},
                 |out| {
                     // second trigger
-                    let points = out.points_by_metric_and_consumer();
+                    let points = out.points_by_metric_and_consumer(Some("kind"));
                     assert_eq!(points.len(), 19, "wrong number of points, got {points:?}");
 
                     // new power value

--- a/plugins/nvidia-nvml/src/metrics.rs
+++ b/plugins/nvidia-nvml/src/metrics.rs
@@ -17,8 +17,8 @@ pub struct FullMetrics {
     pub major_utilization_gpu: TypedMetricId<u64>,
     /// GPU memory utilization in percentage
     pub major_utilization_memory: TypedMetricId<u64>,
-    /// Used, free and total VRAM memory allocated, in bytes.
-    pub memory_allocation: TypedMetricId<u64>,
+    /// Used, free and total VRAM memory, in bytes.
+    pub memory_info: TypedMetricId<u64>,
     /// GPU video decoding property in percentage.
     pub decoder_utilization: TypedMetricId<u64>,
     /// Get the current utilization and sampling size for the decoder in μs.
@@ -67,7 +67,11 @@ impl FullMetrics {
                 Unit::Percent,
                 "GPU rate utilization",
             )?,
-            memory_allocation: alumet.create_metric("nvml_gpu_memory_allocation", Unit::Byte, "VRAM allocation")?,
+            memory_info: alumet.create_metric(
+                "nvml_gpu_memory_info",
+                Unit::Byte,
+                "VRAM information (free, used, reserved and total size)",
+            )?,
             decoder_sampling_period_us: alumet.create_metric(
                 "nvml_decoder_sampling_period",
                 PrefixedUnit::micro(Unit::Second),

--- a/plugins/nvidia-nvml/src/metrics.rs
+++ b/plugins/nvidia-nvml/src/metrics.rs
@@ -17,6 +17,8 @@ pub struct FullMetrics {
     pub major_utilization_gpu: TypedMetricId<u64>,
     /// GPU memory utilization in percentage
     pub major_utilization_memory: TypedMetricId<u64>,
+    /// Used, free and total VRAM memory allocated, in bytes.
+    pub memory_allocation: TypedMetricId<u64>,
     /// GPU video decoding property in percentage.
     pub decoder_utilization: TypedMetricId<u64>,
     /// Get the current utilization and sampling size for the decoder in μs.
@@ -64,6 +66,11 @@ impl FullMetrics {
                 "nvml_gpu_utilization",
                 Unit::Percent,
                 "GPU rate utilization",
+            )?,
+            memory_allocation: alumet.create_metric(
+                "nvml_gpu_memory_allocation",
+                Unit::Byte,
+                "VRAM allocation",
             )?,
             decoder_sampling_period_us: alumet.create_metric(
                 "nvml_decoder_sampling_period",

--- a/plugins/nvidia-nvml/src/metrics.rs
+++ b/plugins/nvidia-nvml/src/metrics.rs
@@ -67,11 +67,7 @@ impl FullMetrics {
                 Unit::Percent,
                 "GPU rate utilization",
             )?,
-            memory_allocation: alumet.create_metric(
-                "nvml_gpu_memory_allocation",
-                Unit::Byte,
-                "VRAM allocation",
-            )?,
+            memory_allocation: alumet.create_metric("nvml_gpu_memory_allocation", Unit::Byte, "VRAM allocation")?,
             decoder_sampling_period_us: alumet.create_metric(
                 "nvml_decoder_sampling_period",
                 PrefixedUnit::micro(Unit::Second),

--- a/plugins/nvidia-nvml/src/nvml/detect.rs
+++ b/plugins/nvidia-nvml/src/nvml/detect.rs
@@ -129,7 +129,7 @@ mod tests {
                 .returning(|| Err(NvmlError::NotSupported))
                 .times(1);
             device
-                .expect_memory_allocation()
+                .expect_memory_info()
                 .returning(|| Err(NvmlError::NotSupported))
                 .times(1);
             device

--- a/plugins/nvidia-nvml/src/nvml/detect.rs
+++ b/plugins/nvidia-nvml/src/nvml/detect.rs
@@ -129,6 +129,10 @@ mod tests {
                 .returning(|| Err(NvmlError::NotSupported))
                 .times(1);
             device
+                .expect_memory_allocation()
+                .returning(|| Err(NvmlError::NotSupported))
+                .times(1);
+            device
                 .expect_decoder_utilization()
                 .returning(|| Err(NvmlError::NotSupported))
                 .times(1);

--- a/plugins/nvidia-nvml/src/nvml/features.rs
+++ b/plugins/nvidia-nvml/src/nvml/features.rs
@@ -31,6 +31,8 @@ pub struct OptionalFeatures {
     pub temperature_gpu: bool,
     /// GPU rate utilization.
     pub major_utilization: bool,
+    /// GPU memory info.
+    pub memory_allocation: bool,
     /// GPU video decoding property.
     pub decoder_utilization: bool,
     /// GPU video encoding property.
@@ -51,6 +53,7 @@ impl OptionalFeatures {
             instant_power: is_supported(device.power_usage())?,
             temperature_gpu: is_supported(device.temperature(TemperatureSensor::Gpu))?,
             major_utilization: is_supported(device.utilization_rates())?,
+            memory_allocation: is_supported(device.memory_allocation())?,
             decoder_utilization: is_supported(device.decoder_utilization())?,
             encoder_utilization: is_supported(device.encoder_utilization())?,
             process_utilization_stats: is_supported(device.process_utilization_stats(0))?,
@@ -63,6 +66,7 @@ impl OptionalFeatures {
         self.total_energy_consumption
             || self.instant_power
             || self.major_utilization
+            || self.memory_allocation
             || self.decoder_utilization
             || self.encoder_utilization
             || self.temperature_gpu
@@ -82,6 +86,9 @@ impl Display for OptionalFeatures {
         }
         if self.major_utilization {
             available.push("major_utilization");
+        }
+        if self.memory_allocation {
+            available.push("memory_allocation");
         }
         if self.decoder_utilization {
             available.push("decoder_utilization");
@@ -172,6 +179,7 @@ mod tests {
             total_energy_consumption: true,
             instant_power: true,
             major_utilization: true,
+            memory_allocation: true,
             decoder_utilization: true,
             encoder_utilization: true,
             process_utilization_stats: true,
@@ -181,7 +189,7 @@ mod tests {
         };
         assert_eq!(
             format!("{}", features),
-            "total_energy_consumption, instant_power, major_utilization, decoder_utilization, encoder_utilization, process_utilization_stats, temperature_gpu, running_compute_processes(latest), running_graphics_processes(latest)"
+            "total_energy_consumption, instant_power, major_utilization, memory_allocation, decoder_utilization, encoder_utilization, process_utilization_stats, temperature_gpu, running_compute_processes(latest), running_graphics_processes(latest)"
         );
     }
 
@@ -191,6 +199,7 @@ mod tests {
             total_energy_consumption: true,
             instant_power: false,
             major_utilization: true,
+            memory_allocation: true,
             decoder_utilization: true,
             encoder_utilization: true,
             process_utilization_stats: false,
@@ -200,7 +209,7 @@ mod tests {
         };
         assert_eq!(
             format!("{}", features),
-            "total_energy_consumption, major_utilization, decoder_utilization, encoder_utilization, running_compute_processes(v2)"
+            "total_energy_consumption, major_utilization, memory_allocation, decoder_utilization, encoder_utilization, running_compute_processes(v2)"
         );
     }
 
@@ -211,6 +220,7 @@ mod tests {
             total_energy_consumption: false,
             instant_power: false,
             major_utilization: false,
+            memory_allocation: false,
             decoder_utilization: false,
             encoder_utilization: false,
             process_utilization_stats: false,
@@ -229,6 +239,9 @@ mod tests {
         device.expect_temperature().returning(|_| Err(NvmlError::NotSupported));
         device
             .expect_utilization_rates()
+            .returning(|| Err(NvmlError::NotSupported));
+        device
+            .expect_memory_allocation()
             .returning(|| Err(NvmlError::NotSupported));
         device
             .expect_decoder_utilization()
@@ -276,6 +289,7 @@ mod tests {
                 instant_power: true,
                 temperature_gpu: false,
                 major_utilization: false,
+                memory_allocation: false,
                 decoder_utilization: false,
                 encoder_utilization: false,
                 process_utilization_stats: false,
@@ -298,6 +312,7 @@ mod tests {
                 instant_power: true,
                 temperature_gpu: false,
                 major_utilization: false,
+                memory_allocation: false,
                 decoder_utilization: false,
                 encoder_utilization: false,
                 process_utilization_stats: false,

--- a/plugins/nvidia-nvml/src/nvml/features.rs
+++ b/plugins/nvidia-nvml/src/nvml/features.rs
@@ -32,7 +32,7 @@ pub struct OptionalFeatures {
     /// GPU rate utilization.
     pub major_utilization: bool,
     /// GPU memory info.
-    pub memory_allocation: bool,
+    pub memory_info: bool,
     /// GPU video decoding property.
     pub decoder_utilization: bool,
     /// GPU video encoding property.
@@ -53,7 +53,7 @@ impl OptionalFeatures {
             instant_power: is_supported(device.power_usage())?,
             temperature_gpu: is_supported(device.temperature(TemperatureSensor::Gpu))?,
             major_utilization: is_supported(device.utilization_rates())?,
-            memory_allocation: is_supported(device.memory_allocation())?,
+            memory_info: is_supported(device.memory_info())?,
             decoder_utilization: is_supported(device.decoder_utilization())?,
             encoder_utilization: is_supported(device.encoder_utilization())?,
             process_utilization_stats: is_supported(device.process_utilization_stats(0))?,
@@ -66,7 +66,7 @@ impl OptionalFeatures {
         self.total_energy_consumption
             || self.instant_power
             || self.major_utilization
-            || self.memory_allocation
+            || self.memory_info
             || self.decoder_utilization
             || self.encoder_utilization
             || self.temperature_gpu
@@ -87,8 +87,8 @@ impl Display for OptionalFeatures {
         if self.major_utilization {
             available.push("major_utilization");
         }
-        if self.memory_allocation {
-            available.push("memory_allocation");
+        if self.memory_info {
+            available.push("memory_info");
         }
         if self.decoder_utilization {
             available.push("decoder_utilization");
@@ -179,7 +179,7 @@ mod tests {
             total_energy_consumption: true,
             instant_power: true,
             major_utilization: true,
-            memory_allocation: true,
+            memory_info: true,
             decoder_utilization: true,
             encoder_utilization: true,
             process_utilization_stats: true,
@@ -189,7 +189,7 @@ mod tests {
         };
         assert_eq!(
             format!("{}", features),
-            "total_energy_consumption, instant_power, major_utilization, memory_allocation, decoder_utilization, encoder_utilization, process_utilization_stats, temperature_gpu, running_compute_processes(latest), running_graphics_processes(latest)"
+            "total_energy_consumption, instant_power, major_utilization, memory_info, decoder_utilization, encoder_utilization, process_utilization_stats, temperature_gpu, running_compute_processes(latest), running_graphics_processes(latest)"
         );
     }
 
@@ -199,7 +199,7 @@ mod tests {
             total_energy_consumption: true,
             instant_power: false,
             major_utilization: true,
-            memory_allocation: true,
+            memory_info: true,
             decoder_utilization: true,
             encoder_utilization: true,
             process_utilization_stats: false,
@@ -209,7 +209,7 @@ mod tests {
         };
         assert_eq!(
             format!("{}", features),
-            "total_energy_consumption, major_utilization, memory_allocation, decoder_utilization, encoder_utilization, running_compute_processes(v2)"
+            "total_energy_consumption, major_utilization, memory_info, decoder_utilization, encoder_utilization, running_compute_processes(v2)"
         );
     }
 
@@ -220,7 +220,7 @@ mod tests {
             total_energy_consumption: false,
             instant_power: false,
             major_utilization: false,
-            memory_allocation: false,
+            memory_info: false,
             decoder_utilization: false,
             encoder_utilization: false,
             process_utilization_stats: false,
@@ -240,9 +240,7 @@ mod tests {
         device
             .expect_utilization_rates()
             .returning(|| Err(NvmlError::NotSupported));
-        device
-            .expect_memory_allocation()
-            .returning(|| Err(NvmlError::NotSupported));
+        device.expect_memory_info().returning(|| Err(NvmlError::NotSupported));
         device
             .expect_decoder_utilization()
             .returning(|| Err(NvmlError::NotSupported));
@@ -289,7 +287,7 @@ mod tests {
                 instant_power: true,
                 temperature_gpu: false,
                 major_utilization: false,
-                memory_allocation: false,
+                memory_info: false,
                 decoder_utilization: false,
                 encoder_utilization: false,
                 process_utilization_stats: false,
@@ -312,7 +310,7 @@ mod tests {
                 instant_power: true,
                 temperature_gpu: false,
                 major_utilization: false,
-                memory_allocation: false,
+                memory_info: false,
                 decoder_utilization: false,
                 encoder_utilization: false,
                 process_utilization_stats: false,

--- a/plugins/nvidia-nvml/src/nvml/mod.rs
+++ b/plugins/nvidia-nvml/src/nvml/mod.rs
@@ -47,9 +47,10 @@ pub trait NvmlDevice: Display + Send {
     /// See [`nvml_wrapper::Device::utilization_rates`].
     fn utilization_rates(&self) -> NvmlResult<nvml_wrapper::struct_wrappers::device::Utilization>;
 
+    //TODO handle memory info v1 (for older versions of NVML)
     /// Current memory usage.
-    /// See [`nvml_wrapper::Device::memory_allocation`].
-    fn memory_allocation(&self) -> NvmlResult<nvml_wrapper::struct_wrappers::device::MemoryInfo>;
+    /// See [`nvml_wrapper::Device::memory_info`].
+    fn memory_info(&self) -> NvmlResult<nvml_wrapper::struct_wrappers::device::MemoryInfo>;
 
     /// Utilization and sampling size of the decoder.
     /// See [`nvml_wrapper::Device::decoder_utilization`].

--- a/plugins/nvidia-nvml/src/nvml/mod.rs
+++ b/plugins/nvidia-nvml/src/nvml/mod.rs
@@ -47,6 +47,10 @@ pub trait NvmlDevice: Display + Send {
     /// See [`nvml_wrapper::Device::utilization_rates`].
     fn utilization_rates(&self) -> NvmlResult<nvml_wrapper::struct_wrappers::device::Utilization>;
 
+    /// Current memory usage.
+    /// See [`nvml_wrapper::Device::memory_allocation`].
+    fn memory_allocation(&self) -> NvmlResult<nvml_wrapper::struct_wrappers::device::MemoryInfo>;
+
     /// Utilization and sampling size of the decoder.
     /// See [`nvml_wrapper::Device::decoder_utilization`].
     fn decoder_utilization(&self) -> NvmlResult<nvml_wrapper::structs::device::UtilizationInfo>;

--- a/plugins/nvidia-nvml/src/nvml/objects.rs
+++ b/plugins/nvidia-nvml/src/nvml/objects.rs
@@ -117,7 +117,7 @@ impl NvmlDevice for ManagedDevice {
 
     /// Current memory usage.
     /// See [`nvml_wrapper::Device::memory_info`].
-    fn memory_allocation(&self) -> NvmlResult<nvml_wrapper::struct_wrappers::device::MemoryInfo> {
+    fn memory_info(&self) -> NvmlResult<nvml_wrapper::struct_wrappers::device::MemoryInfo> {
         self.as_underlying_device().memory_info()
     }
 

--- a/plugins/nvidia-nvml/src/nvml/objects.rs
+++ b/plugins/nvidia-nvml/src/nvml/objects.rs
@@ -115,6 +115,12 @@ impl NvmlDevice for ManagedDevice {
         self.as_underlying_device().utilization_rates()
     }
 
+    /// Current memory usage.
+    /// See [`nvml_wrapper::Device::memory_info`].
+    fn memory_allocation(&self) -> NvmlResult<nvml_wrapper::struct_wrappers::device::MemoryInfo> {
+        self.as_underlying_device().memory_info()
+    }
+
     /// Utilization and sampling size of the decoder.
     /// See [`nvml_wrapper::Device::decoder_utilization`].
     fn decoder_utilization(&self) -> NvmlResult<nvml_wrapper::structs::device::UtilizationInfo> {

--- a/plugins/nvidia-nvml/src/probe.rs
+++ b/plugins/nvidia-nvml/src/probe.rs
@@ -69,6 +69,7 @@ impl<D: NvmlDevice> Source for FullSource<D> {
     fn poll(&mut self, measurements: &mut MeasurementAccumulator, timestamp: Timestamp) -> Result<(), PollError> {
         let features = &self.device.features;
         let device = &self.device.inner;
+        let device_memory_info = device.memory_info()?;
 
         // no consumer, we just monitor the device here
         let consumer = ResourceConsumer::LocalMachine;
@@ -140,49 +141,47 @@ impl<D: NvmlDevice> Source for FullSource<D> {
             ));
         }
 
-        // Get the current memory allocation information for this device in Bytes
-        if features.memory_allocation {
+        // Get the current memory information for this device in Bytes
+        if features.memory_info {
             measurements.push(
                 MeasurementPoint::new(
                     timestamp,
-                    self.metrics.memory_allocation,
+                    self.metrics.memory_info,
                     self.resource.clone(),
                     consumer.clone(),
-                    device.memory_allocation()?.free,
+                    device_memory_info.free,
                 )
                 .with_attr("kind", "free"),
             );
             // According to NVIDIA documentation, system-reserved memory field
-            // only exists from version 2 onward
-            if device.memory_allocation()?.version > 1 {
-                measurements.push(
-                    MeasurementPoint::new(
-                        timestamp,
-                        self.metrics.memory_allocation,
-                        self.resource.clone(),
-                        consumer.clone(),
-                        device.memory_allocation()?.reserved,
-                    )
-                    .with_attr("kind", "reserved"),
-                );
-            }
+            // only exists from v510 of NVML onward
             measurements.push(
                 MeasurementPoint::new(
                     timestamp,
-                    self.metrics.memory_allocation,
+                    self.metrics.memory_info,
                     self.resource.clone(),
                     consumer.clone(),
-                    device.memory_allocation()?.total,
+                    device_memory_info.reserved,
+                )
+                .with_attr("kind", "reserved"),
+            );
+            measurements.push(
+                MeasurementPoint::new(
+                    timestamp,
+                    self.metrics.memory_info,
+                    self.resource.clone(),
+                    consumer.clone(),
+                    device_memory_info.total,
                 )
                 .with_attr("kind", "total"),
             );
             measurements.push(
                 MeasurementPoint::new(
                     timestamp,
-                    self.metrics.memory_allocation,
+                    self.metrics.memory_info,
                     self.resource.clone(),
                     consumer.clone(),
-                    device.memory_allocation()?.used,
+                    device_memory_info.used,
                 )
                 .with_attr("kind", "used"),
             );

--- a/plugins/nvidia-nvml/src/probe.rs
+++ b/plugins/nvidia-nvml/src/probe.rs
@@ -140,6 +140,54 @@ impl<D: NvmlDevice> Source for FullSource<D> {
             ));
         }
 
+        // Get the current memory allocation information for this device in Bytes
+        if features.memory_allocation {
+            measurements.push(
+                MeasurementPoint::new(
+                    timestamp,
+                    self.metrics.memory_allocation,
+                    self.resource.clone(),
+                    consumer.clone(),
+                    device.memory_allocation()?.free,
+                )
+                .with_attr("kind", "free")
+            );
+            // According to NVIDIA documentation, system-reserved memory field
+            // only exists from version 2 onward
+            if device.memory_allocation()?.version > 1 {
+                measurements.push(
+                    MeasurementPoint::new(
+                        timestamp,
+                        self.metrics.memory_allocation,
+                        self.resource.clone(),
+                        consumer.clone(),
+                        device.memory_allocation()?.reserved,
+                    )
+                    .with_attr("kind", "reserved"),
+                );
+            }
+            measurements.push(
+                MeasurementPoint::new(
+                    timestamp,
+                    self.metrics.memory_allocation,
+                    self.resource.clone(),
+                    consumer.clone(),
+                    device.memory_allocation()?.total,
+                )
+                .with_attr("kind", "total"),
+            );
+            measurements.push(
+                MeasurementPoint::new(
+                    timestamp,
+                    self.metrics.memory_allocation,
+                    self.resource.clone(),
+                    consumer.clone(),
+                    device.memory_allocation()?.used,
+                )
+                .with_attr("kind", "used"),
+            );
+        }
+
         // Get the current utilization and sampling size in μs for the decoder
         if features.decoder_utilization {
             let u = device.decoder_utilization()?;

--- a/plugins/nvidia-nvml/src/probe.rs
+++ b/plugins/nvidia-nvml/src/probe.rs
@@ -150,7 +150,7 @@ impl<D: NvmlDevice> Source for FullSource<D> {
                     consumer.clone(),
                     device.memory_allocation()?.free,
                 )
-                .with_attr("kind", "free")
+                .with_attr("kind", "free"),
             );
             // According to NVIDIA documentation, system-reserved memory field
             // only exists from version 2 onward


### PR DESCRIPTION
Add a new necessary metrics: GPU VRAM allocation (called nvml_gpu_memory_allocation)

Similar to Procfs 'memory_usage' field, this metric measures the allocation of the VRAM. It has an attribute "kind":

- free : the amout of bytes not allocated
- total: the total size of the VRAM
- used: the amount of bytes currently used
- reserved: the amount of bytes reserved for sytem use (may not be available depending on GPU model / NVIDIA driver version)

Also updates the README to add this new metrics