### PR TITLE
feat(plugins/amd-gpu): Use the new multi-version amd-smi-wrapper

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -61,6 +61,7 @@ rustfmt
 sagittaire
 SCPI
 servan
+simplifiable
 slurm
 slurmstep
 slurmstepd

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@ agent/perf.data
 agent/perf.data.old
 agent/*output.csv
 .DS_Store
-.vscode
+.vscode/
+.idea/
 tmp/
 .cargo
 tarpaulin-report.html

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,14 +132,21 @@ dependencies = [
 
 [[package]]
 name = "amd-smi-wrapper"
-version = "0.3.0"
-source = "git+https://github.com/alumet-dev/amd-smi-wrapper.git?tag=v0.3.0#7f9991a4b354ef959a64be2a48a9afbdb3e19937"
+version = "0.7.0"
+source = "git+https://github.com/alumet-dev/amd-smi-wrapper.git#6dad086064c325aa2f17b1a83588fb333f1a7cb1"
 dependencies = [
- "bindgen",
- "bitflags",
- "libloading",
+ "amd-smi-wrapper-sys",
+ "log",
  "mockall",
- "reqwest",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "amd-smi-wrapper-sys"
+version = "1.1.1"
+source = "git+https://github.com/alumet-dev/amd-smi-wrapper.git#6dad086064c325aa2f17b1a83588fb333f1a7cb1"
+dependencies = [
+ "libloading",
  "thiserror 2.0.18",
 ]
 
@@ -366,26 +373,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,15 +525,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,17 +574,6 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -740,16 +707,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -1100,15 +1057,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,12 +1361,6 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
-
-[[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
@@ -1798,11 +1740,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.3",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -2885,6 +2825,7 @@ version = "0.1.5"
 dependencies = [
  "alumet",
  "amd-smi-wrapper",
+ "amd-smi-wrapper-sys",
  "anyhow",
  "env_logger",
  "humantime-serde",
@@ -3735,7 +3676,6 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -3749,7 +3689,6 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
- "mime",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -3953,7 +3892,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4275,27 +4214,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -5266,17 +5184,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
-]
 
 [[package]]
 name = "windows-result"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,7 @@ dependencies = [
  "libc",
  "log",
  "plugin-aggregation",
+ "plugin-amd-gpu",
  "plugin-csv",
  "plugin-elasticsearch",
  "plugin-energy-attribution",
@@ -2821,7 +2822,7 @@ dependencies = [
 
 [[package]]
 name = "plugin-amd-gpu"
-version = "0.1.5"
+version = "1.0.0"
 dependencies = [
  "alumet",
  "amd-smi-wrapper",

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -34,6 +34,7 @@ plugin-kwollect-input = { path = "../plugins/kwollect-input" }
 plugin-kwollect-output = { path = "../plugins/kwollect-output" }
 plugin-filter = { path = "../plugins/filter" }
 plugin-energy-to-carbon = { path = "../plugins/energy-to-carbon" }
+plugin-amd-gpu = { path = "../plugins/amd-gpu" }
 
 # Linux-only dependencies
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/agent/src/bin/main.rs
+++ b/agent/src/bin/main.rs
@@ -57,6 +57,7 @@ fn load_plugins_metadata() -> Vec<PluginMetadata> {
             plugin_nvidia_nvml::NvmlPlugin<plugin_nvidia_nvml::NvmlLoader>,
             plugin_process_to_cgroup_bridge::ProcessToCgroupBridgePlugin,
             plugin_nvidia_jetson::JetsonPlugin,
+            plugin_amd_gpu::AmdGpuPlugin<plugin_amd_gpu::AmdSmiProvider>,
             plugin_quarch::QuarchPlugin,
         ]);
     }

--- a/plugins/amd-gpu/Cargo.toml
+++ b/plugins/amd-gpu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plugin-amd-gpu"
-version = "0.1.5"
+version = "1.0.0"
 edition.workspace = true
 repository.workspace = true
 

--- a/plugins/amd-gpu/Cargo.toml
+++ b/plugins/amd-gpu/Cargo.toml
@@ -10,13 +10,14 @@ anyhow.workspace = true
 log.workspace = true
 humantime-serde.workspace = true
 serde = { workspace = true, features = ["derive"] }
-amd-smi-wrapper = { git = "https://github.com/alumet-dev/amd-smi-wrapper.git", tag = "v0.4.0", version = "0.4.0" }
+amd-smi-wrapper = { git = "https://github.com/alumet-dev/amd-smi-wrapper.git", version = "0.7" }
 
 [dev-dependencies]
 alumet = { workspace = true, features = ["test"] }
 toml.workspace = true
 env_logger.workspace = true
-amd-smi-wrapper = { git = "https://github.com/alumet-dev/amd-smi-wrapper.git", tag = "v0.4.0", version = "0.4.0", features = ["mock"] }
+amd-smi-wrapper = { git = "https://github.com/alumet-dev/amd-smi-wrapper.git", version = "0.7", features = ["mock"]}
+amd-smi-wrapper-sys = { git = "https://github.com/alumet-dev/amd-smi-wrapper.git", version = "1.1.1" }
 
 [lints]
 workspace = true

--- a/plugins/amd-gpu/src/amd/device.rs
+++ b/plugins/amd-gpu/src/amd/device.rs
@@ -1,6 +1,5 @@
 use amd_smi_wrapper::{
     AmdInterface,
-    error::AmdError,
     handles::{ProcessorHandle, SocketHandle},
 };
 use std::collections::HashMap;
@@ -73,11 +72,7 @@ impl<H: ProcessorHandle> AmdGpuDevices<H> {
                             failure_count += 1;
                             log::warn!("Skipping GPU device because of error: {e:?}");
                         } else {
-                            return Err(AmdError {
-                                status: e,
-                                message: None,
-                            }
-                            .into());
+                            return Err(e.into());
                         }
                     }
                 }
@@ -112,10 +107,11 @@ mod test {
     };
     use amd_smi_wrapper::{
         MockAmdInterface,
-        error::AmdStatus,
+        error::AmdError,
         handles::{MockProcessorHandle, MockSocketHandle},
         metrics::AmdTemperatureMetric,
     };
+    use amd_smi_wrapper_sys::versions::stable::{AMDSMI_STATUS_ADDRESS_FAULT, AMDSMI_STATUS_INVAL};
     use log::LevelFilter::Warn;
     use std::{
         io::Write,
@@ -169,11 +165,11 @@ mod test {
             .expect_device_energy_consumption()
             .returning(|| Ok(MOCK_ENERGY[0]));
 
-        mock_processor
-            .expect_device_power_consumption()
-            .returning(|| Ok(MOCK_POWER));
+        mock_processor.expect_device_power_info().returning(|| Ok(MOCK_POWER));
 
-        mock_processor.expect_device_power_managment().returning(|| Ok(true));
+        mock_processor
+            .expect_is_power_managment_enabled()
+            .returning(|| Ok(true));
         mock_processor
             .expect_device_process_list()
             .returning(|| Ok(vec![mock_process()]));
@@ -186,27 +182,18 @@ mod test {
                 .iter()
                 .find(|(t, _)| *t == mem_type)
                 .map(|(_, v)| Ok(*v))
-                .unwrap_or(Err(AmdError {
-                    status: AmdStatus::AMDSMI_STATUS_UNEXPECTED_DATA,
-                    message: None,
-                }))
+                .unwrap_or(Err(AmdError::from_status_code(AMDSMI_STATUS_INVAL)))
         });
 
         mock_processor.expect_device_temperature().returning(|sensor, metric| {
             if metric != AmdTemperatureMetric::AMDSMI_TEMP_CURRENT {
-                return Err(AmdError {
-                    status: AmdStatus::AMDSMI_STATUS_UNEXPECTED_DATA,
-                    message: None,
-                });
+                return Err(AmdError::from_status_code(AMDSMI_STATUS_INVAL));
             }
             MOCK_TEMPERATURE
                 .iter()
                 .find(|(s, _)| *s == sensor)
                 .map(|(_, v)| Ok(*v))
-                .unwrap_or(Err(AmdError {
-                    status: AmdStatus::AMDSMI_STATUS_UNEXPECTED_DATA,
-                    message: None,
-                }))
+                .unwrap_or(Err(AmdError::from_status_code(AMDSMI_STATUS_INVAL)))
         });
 
         mock_socket
@@ -232,60 +219,33 @@ mod test {
             .expect_device_uuid()
             .returning(|| Ok(MOCK_UUID.to_owned()));
 
-        mock_processor.expect_device_activity().returning(|| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNEXPECTED_DATA,
-                message: None,
-            })
-        });
-        mock_processor.expect_device_asic_info().returning(|| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNEXPECTED_DATA,
-                message: None,
-            })
-        });
-        mock_processor.expect_device_energy_consumption().returning(|| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNEXPECTED_DATA,
-                message: None,
-            })
-        });
-        mock_processor.expect_device_power_consumption().returning(|| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNEXPECTED_DATA,
-                message: None,
-            })
-        });
-        mock_processor.expect_device_power_managment().returning(|| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNEXPECTED_DATA,
-                message: None,
-            })
-        });
-        mock_processor.expect_device_process_list().returning(|| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNEXPECTED_DATA,
-                message: None,
-            })
-        });
-        mock_processor.expect_device_voltage().returning(|_, _| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNEXPECTED_DATA,
-                message: None,
-            })
-        });
-        mock_processor.expect_device_memory_usage().returning(|_| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNEXPECTED_DATA,
-                message: None,
-            })
-        });
-        mock_processor.expect_device_temperature().returning(|_, _| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNEXPECTED_DATA,
-                message: None,
-            })
-        });
+        mock_processor
+            .expect_device_activity()
+            .returning(|| Err(AmdError::from_status_code(AMDSMI_STATUS_INVAL)));
+        mock_processor
+            .expect_device_asic_info()
+            .returning(|| Err(AmdError::from_status_code(AMDSMI_STATUS_INVAL)));
+        mock_processor
+            .expect_device_energy_consumption()
+            .returning(|| Err(AmdError::from_status_code(AMDSMI_STATUS_INVAL)));
+        mock_processor
+            .expect_device_power_info()
+            .returning(|| Err(AmdError::from_status_code(AMDSMI_STATUS_INVAL)));
+        mock_processor
+            .expect_is_power_managment_enabled()
+            .returning(|| Err(AmdError::from_status_code(AMDSMI_STATUS_INVAL)));
+        mock_processor
+            .expect_device_process_list()
+            .returning(|| Err(AmdError::from_status_code(AMDSMI_STATUS_INVAL)));
+        mock_processor
+            .expect_device_voltage()
+            .returning(|_, _| Err(AmdError::from_status_code(AMDSMI_STATUS_INVAL)));
+        mock_processor
+            .expect_device_memory_usage()
+            .returning(|_| Err(AmdError::from_status_code(AMDSMI_STATUS_INVAL)));
+        mock_processor
+            .expect_device_temperature()
+            .returning(|_, _| Err(AmdError::from_status_code(AMDSMI_STATUS_INVAL)));
 
         mock_socket
             .expect_processor_handles()
@@ -312,60 +272,33 @@ mod test {
             .expect_device_uuid()
             .returning(|| Ok(MOCK_UUID.to_owned()));
 
-        mock_processor.expect_device_activity().returning(|| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNKNOWN_ERROR,
-                message: None,
-            })
-        });
-        mock_processor.expect_device_asic_info().returning(|| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNKNOWN_ERROR,
-                message: None,
-            })
-        });
-        mock_processor.expect_device_energy_consumption().returning(|| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNKNOWN_ERROR,
-                message: None,
-            })
-        });
-        mock_processor.expect_device_power_consumption().returning(|| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNKNOWN_ERROR,
-                message: None,
-            })
-        });
-        mock_processor.expect_device_power_managment().returning(|| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNKNOWN_ERROR,
-                message: None,
-            })
-        });
-        mock_processor.expect_device_process_list().returning(|| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNKNOWN_ERROR,
-                message: None,
-            })
-        });
-        mock_processor.expect_device_voltage().returning(|_, _| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNKNOWN_ERROR,
-                message: None,
-            })
-        });
-        mock_processor.expect_device_memory_usage().returning(|_| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNKNOWN_ERROR,
-                message: None,
-            })
-        });
-        mock_processor.expect_device_temperature().returning(|_, _| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNKNOWN_ERROR,
-                message: None,
-            })
-        });
+        mock_processor
+            .expect_device_activity()
+            .returning(|| Err(AmdError::from_status_code(AMDSMI_STATUS_ADDRESS_FAULT)));
+        mock_processor
+            .expect_device_asic_info()
+            .returning(|| Err(AmdError::from_status_code(AMDSMI_STATUS_ADDRESS_FAULT)));
+        mock_processor
+            .expect_device_energy_consumption()
+            .returning(|| Err(AmdError::from_status_code(AMDSMI_STATUS_ADDRESS_FAULT)));
+        mock_processor
+            .expect_device_power_info()
+            .returning(|| Err(AmdError::from_status_code(AMDSMI_STATUS_ADDRESS_FAULT)));
+        mock_processor
+            .expect_is_power_managment_enabled()
+            .returning(|| Err(AmdError::from_status_code(AMDSMI_STATUS_ADDRESS_FAULT)));
+        mock_processor
+            .expect_device_process_list()
+            .returning(|| Err(AmdError::from_status_code(AMDSMI_STATUS_ADDRESS_FAULT)));
+        mock_processor
+            .expect_device_voltage()
+            .returning(|_, _| Err(AmdError::from_status_code(AMDSMI_STATUS_ADDRESS_FAULT)));
+        mock_processor
+            .expect_device_memory_usage()
+            .returning(|_| Err(AmdError::from_status_code(AMDSMI_STATUS_ADDRESS_FAULT)));
+        mock_processor
+            .expect_device_temperature()
+            .returning(|_, _| Err(AmdError::from_status_code(AMDSMI_STATUS_ADDRESS_FAULT)));
 
         mock_socket
             .expect_processor_handles()
@@ -402,60 +335,33 @@ mod test {
             .expect_device_uuid()
             .returning(|| Ok(MOCK_UUID.to_owned()));
 
-        mock_processor.expect_device_activity().returning(|| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNKNOWN_ERROR,
-                message: None,
-            })
-        });
-        mock_processor.expect_device_asic_info().returning(|| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNKNOWN_ERROR,
-                message: None,
-            })
-        });
-        mock_processor.expect_device_energy_consumption().returning(|| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNKNOWN_ERROR,
-                message: None,
-            })
-        });
-        mock_processor.expect_device_power_consumption().returning(|| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNKNOWN_ERROR,
-                message: None,
-            })
-        });
-        mock_processor.expect_device_power_managment().returning(|| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNKNOWN_ERROR,
-                message: None,
-            })
-        });
-        mock_processor.expect_device_process_list().returning(|| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNKNOWN_ERROR,
-                message: None,
-            })
-        });
-        mock_processor.expect_device_voltage().returning(|_, _| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNKNOWN_ERROR,
-                message: None,
-            })
-        });
-        mock_processor.expect_device_memory_usage().returning(|_| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNKNOWN_ERROR,
-                message: None,
-            })
-        });
-        mock_processor.expect_device_temperature().returning(|_, _| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNKNOWN_ERROR,
-                message: None,
-            })
-        });
+        mock_processor
+            .expect_device_activity()
+            .returning(|| Err(AmdError::from_status_code(AMDSMI_STATUS_ADDRESS_FAULT)));
+        mock_processor
+            .expect_device_asic_info()
+            .returning(|| Err(AmdError::from_status_code(AMDSMI_STATUS_ADDRESS_FAULT)));
+        mock_processor
+            .expect_device_energy_consumption()
+            .returning(|| Err(AmdError::from_status_code(AMDSMI_STATUS_ADDRESS_FAULT)));
+        mock_processor
+            .expect_device_power_info()
+            .returning(|| Err(AmdError::from_status_code(AMDSMI_STATUS_ADDRESS_FAULT)));
+        mock_processor
+            .expect_is_power_managment_enabled()
+            .returning(|| Err(AmdError::from_status_code(AMDSMI_STATUS_ADDRESS_FAULT)));
+        mock_processor
+            .expect_device_process_list()
+            .returning(|| Err(AmdError::from_status_code(AMDSMI_STATUS_ADDRESS_FAULT)));
+        mock_processor
+            .expect_device_voltage()
+            .returning(|_, _| Err(AmdError::from_status_code(AMDSMI_STATUS_ADDRESS_FAULT)));
+        mock_processor
+            .expect_device_memory_usage()
+            .returning(|_| Err(AmdError::from_status_code(AMDSMI_STATUS_ADDRESS_FAULT)));
+        mock_processor
+            .expect_device_temperature()
+            .returning(|_, _| Err(AmdError::from_status_code(AMDSMI_STATUS_ADDRESS_FAULT)));
 
         mock_socket
             .expect_processor_handles()

--- a/plugins/amd-gpu/src/amd/features.rs
+++ b/plugins/amd-gpu/src/amd/features.rs
@@ -1,10 +1,11 @@
 use amd_smi_wrapper::{
-    error::{AmdError, AmdStatus},
+    error::AmdError,
     handles::ProcessorHandle,
     metrics::{AmdMemoryType, AmdTemperatureMetric, AmdTemperatureType, AmdVoltageMetric, AmdVoltageType},
 };
 
 use crate::amd::utils::{MEMORY_TYPE, SENSOR_TYPE};
+use amd_smi_wrapper::error::SimplifiedStatus;
 use std::fmt::{self, Display, Formatter};
 
 /// Indicates which features are available on a given ADM GPU device.
@@ -21,7 +22,7 @@ pub struct OptionalFeatures {
     /// GPU electric power consumption feature validity.
     pub gpu_power_consumption: bool,
     /// GPU power management feature validity.
-    pub gpu_power_state_management: bool,
+    pub gpu_power_management_enabled: bool,
     /// GPU temperature feature validity.
     pub gpu_temperatures: Vec<(AmdTemperatureType, bool)>,
     /// GPU power management feature validity.
@@ -31,22 +32,28 @@ pub struct OptionalFeatures {
 }
 
 /// Checks if a feature is supported by the available GPU by inspecting the return type of an AMD-SMI function.
-pub fn is_supported<T>(res: Result<T, AmdError>) -> Result<bool, AmdStatus> {
+pub fn is_supported<T>(res: Result<T, AmdError>) -> Result<bool, AmdError> {
     match res {
         Ok(_) => Ok(true),
-        Err(AmdError { status, .. }) => match status {
-            AmdStatus::AMDSMI_STATUS_NO_PERM
-            | AmdStatus::AMDSMI_STATUS_NOT_SUPPORTED
-            | AmdStatus::AMDSMI_STATUS_NOT_YET_IMPLEMENTED
-            | AmdStatus::AMDSMI_STATUS_UNEXPECTED_DATA => Ok(false),
-            err => Err(err),
-        },
+        Err(AmdError {
+            status:
+                Some(
+                    SimplifiedStatus::Invalid
+                    | SimplifiedStatus::NotSupported
+                    | SimplifiedStatus::NotYetImplemented
+                    | SimplifiedStatus::FailLoadSymbol
+                    | SimplifiedStatus::NoPermission
+                    | SimplifiedStatus::UnexpectedData,
+                ),
+            ..
+        }) => Ok(false),
+        Err(err) => Err(err),
     }
 }
 
 impl OptionalFeatures {
     /// Detect the features available on the given device.
-    pub fn detect_on(processor_handle: &impl ProcessorHandle) -> Result<Self, AmdStatus> {
+    pub fn detect_on(processor_handle: &impl ProcessorHandle) -> Result<Self, AmdError> {
         let mut gpu_temperatures = Vec::new();
         let mut gpu_memories_usage = Vec::new();
 
@@ -65,8 +72,8 @@ impl OptionalFeatures {
             gpu_activity_usage: is_supported(processor_handle.device_activity())?,
             gpu_asic_info: is_supported(processor_handle.device_asic_info())?,
             gpu_energy_consumption: is_supported(processor_handle.device_energy_consumption())?,
-            gpu_power_consumption: is_supported(processor_handle.device_power_consumption())?,
-            gpu_power_state_management: is_supported(processor_handle.device_power_managment())?,
+            gpu_power_consumption: is_supported(processor_handle.device_power_info())?,
+            gpu_power_management_enabled: is_supported(processor_handle.is_power_managment_enabled())?,
             gpu_process: is_supported(processor_handle.device_process_list())?,
             gpu_voltage: is_supported(processor_handle.device_voltage(
                 AmdVoltageType::AMDSMI_VOLT_TYPE_VDDGFX,
@@ -78,7 +85,7 @@ impl OptionalFeatures {
     }
 
     /// Test and return the availability of feature on a given
-    pub fn with_detected_features<H: ProcessorHandle>(device: &H) -> Result<(&H, Self), AmdStatus> {
+    pub fn with_detected_features<H: ProcessorHandle>(device: &H) -> Result<(&H, Self), AmdError> {
         Self::detect_on(device).map(|features| (device, features))
     }
 
@@ -87,7 +94,7 @@ impl OptionalFeatures {
             || self.gpu_activity_usage
             || self.gpu_asic_info
             || self.gpu_power_consumption
-            || self.gpu_power_state_management
+            || self.gpu_power_management_enabled
             || self.gpu_process
             || self.gpu_voltage
             || self.gpu_memories_usage.iter().any(|&(_memory, supported)| supported)
@@ -111,8 +118,8 @@ impl Display for OptionalFeatures {
         if self.gpu_power_consumption {
             available.push("gpu_power_consumption".to_string());
         }
-        if self.gpu_power_state_management {
-            available.push("gpu_power_state_management".to_string());
+        if self.gpu_power_management_enabled {
+            available.push("gpu_power_management_enabled".to_string());
         }
         if self.gpu_process {
             available.push("gpu_process_info".to_string());
@@ -146,6 +153,7 @@ mod test {
         mock_process,
     };
 
+    use amd_smi_wrapper_sys::versions::stable::{AMDSMI_STATUS_INVAL, AMDSMI_STATUS_NO_PERM};
     use std::ptr::eq;
 
     // Mock optional features
@@ -166,7 +174,7 @@ mod test {
             gpu_asic_info: false,
             gpu_energy_consumption: false,
             gpu_power_consumption: false,
-            gpu_power_state_management: false,
+            gpu_power_management_enabled: false,
             gpu_process: false,
             gpu_voltage: false,
             gpu_memories_usage,
@@ -183,7 +191,7 @@ mod test {
         features.gpu_asic_info = true;
         features.gpu_energy_consumption = true;
         features.gpu_power_consumption = true;
-        features.gpu_power_state_management = true;
+        features.gpu_power_management_enabled = true;
         features.gpu_process = true;
         features.gpu_voltage = true;
 
@@ -196,38 +204,45 @@ mod test {
 
         assert_eq!(
             format!("{features}"),
-            "gpu_activity_usage, gpu_asic_info, gpu_energy_consumption, gpu_power_consumption, gpu_power_state_management, gpu_process_info, gpu_voltage, gpu_memory_usages::amdsmi_memory_type_t(0), gpu_temperatures::amdsmi_temperature_type_t(0)"
+            "gpu_activity_usage, gpu_asic_info, gpu_energy_consumption, gpu_power_consumption, gpu_power_management_enabled, gpu_process_info, gpu_voltage, gpu_memory_usages::amdsmi_memory_type_t(0), gpu_temperatures::amdsmi_temperature_type_t(0)"
         );
     }
 
     // Test `is_supported` function with identified amdsmi status errors to disable a feature
     #[test]
-    fn test_is_supported_errors() {
-        let errors = [
-            AmdStatus::AMDSMI_STATUS_NO_PERM,
-            AmdStatus::AMDSMI_STATUS_NOT_SUPPORTED,
-            AmdStatus::AMDSMI_STATUS_NOT_YET_IMPLEMENTED,
-            AmdStatus::AMDSMI_STATUS_UNEXPECTED_DATA,
+    fn test_is_supported_not() {
+        use amd_smi_wrapper_sys::versions::stable;
+
+        let unsupported_codes = [
+            stable::AMDSMI_STATUS_NOT_SUPPORTED,
+            stable::AMDSMI_STATUS_NOT_YET_IMPLEMENTED,
+            stable::AMDSMI_STATUS_NO_PERM,
         ];
-        for &err in &errors {
-            let res = is_supported::<u32>(Err(AmdError {
-                status: err,
+        for status_code in unsupported_codes {
+            let status = status_code.try_into().expect("this status code should be simplifiable");
+            let err: Result<(), _> = Err(AmdError {
+                status: Some(status),
+                status_code,
                 message: None,
-            }))
-            .unwrap();
-            assert!(!res);
+            });
+            assert_eq!(is_supported(err).unwrap(), false);
         }
     }
 
     // Test `is_supported` function with other amdsmi status errors
     #[test]
     fn test_is_supported_other_error() {
-        let res = is_supported::<u32>(Err(AmdError {
-            status: AmdStatus::AMDSMI_STATUS_UNKNOWN_ERROR,
+        use amd_smi_wrapper_sys::versions::stable;
+
+        let status = stable::AMDSMI_STATUS_IO
+            .try_into()
+            .expect("this status code should be simplifiable");
+        let err: Result<(), _> = Err(AmdError {
+            status: Some(status),
+            status_code: stable::AMDSMI_STATUS_IO,
             message: None,
-        }));
-        assert!(res.is_err());
-        assert_eq!(res.unwrap_err(), AmdStatus::AMDSMI_STATUS_UNKNOWN_ERROR);
+        });
+        assert_eq!(is_supported(err).unwrap_err().status, Some(status));
     }
 
     // Test `has_any` function with no feature available
@@ -238,7 +253,7 @@ mod test {
             gpu_asic_info: false,
             gpu_energy_consumption: false,
             gpu_power_consumption: false,
-            gpu_power_state_management: false,
+            gpu_power_management_enabled: false,
             gpu_process: false,
             gpu_voltage: false,
             gpu_memories_usage: Vec::new(),
@@ -255,7 +270,7 @@ mod test {
             gpu_asic_info: is_supported(Ok(())).unwrap(),
             gpu_energy_consumption: is_supported(Ok(())).unwrap(),
             gpu_power_consumption: is_supported(Ok(())).unwrap(),
-            gpu_power_state_management: is_supported(Ok(())).unwrap(),
+            gpu_power_management_enabled: is_supported(Ok(())).unwrap(),
             gpu_process: is_supported(Ok(())).unwrap(),
             gpu_voltage: is_supported(Ok(())).unwrap(),
             gpu_memories_usage: vec![(AmdMemoryType::AMDSMI_MEM_TYPE_VRAM, true)],
@@ -269,44 +284,31 @@ mod test {
     fn test_detect_on_success() {
         let mut mock = MockProcessorHandle::new();
 
-        mock.expect_device_activity().returning(|| Ok(MOCK_ACTIVITY));
-
         mock.expect_device_asic_info().returning(|| Ok(mock_asic_info()));
-
+        mock.expect_device_activity().returning(|| Ok(MOCK_ACTIVITY));
         mock.expect_device_energy_consumption().returning(|| Ok(MOCK_ENERGY[0]));
-
-        mock.expect_device_power_consumption().returning(|| Ok(MOCK_POWER));
-
-        mock.expect_device_power_managment().returning(|| Ok(true));
-        mock.expect_device_process_list().returning(|| Ok(vec![mock_process()]));
+        mock.expect_device_power_info().returning(|| Ok(MOCK_POWER));
         mock.expect_device_voltage().returning(|_, _| Ok(MOCK_VOLTAGE));
+        mock.expect_is_power_managment_enabled().returning(|| Ok(true));
+        mock.expect_device_process_list().returning(|| Ok(vec![mock_process()]));
 
         mock.expect_device_memory_usage().returning(|mem_type| {
             MOCK_MEMORY
                 .iter()
                 .find(|(t, _)| *t == mem_type)
                 .map(|(_, v)| Ok(*v))
-                .unwrap_or(Err(AmdError {
-                    status: AmdStatus::AMDSMI_STATUS_UNEXPECTED_DATA,
-                    message: None,
-                }))
+                .unwrap_or(Err(AmdError::from_status_code(AMDSMI_STATUS_INVAL)))
         });
 
         mock.expect_device_temperature().returning(|sensor, metric| {
             if metric != AmdTemperatureMetric::AMDSMI_TEMP_CURRENT {
-                return Err(AmdError {
-                    status: AmdStatus::AMDSMI_STATUS_UNEXPECTED_DATA,
-                    message: None,
-                });
+                return Err(AmdError::from_status_code(AMDSMI_STATUS_INVAL));
             }
             MOCK_TEMPERATURE
                 .iter()
                 .find(|(s, _)| *s == sensor)
                 .map(|(_, v)| Ok(*v))
-                .unwrap_or(Err(AmdError {
-                    status: AmdStatus::AMDSMI_STATUS_UNEXPECTED_DATA,
-                    message: None,
-                }))
+                .unwrap_or(Err(AmdError::from_status_code(AMDSMI_STATUS_INVAL)))
         });
 
         let features = OptionalFeatures::detect_on(&mock).unwrap();
@@ -323,34 +325,19 @@ mod test {
 
         mock.expect_device_asic_info().returning(|| Ok(mock_asic_info()));
 
-        mock.expect_device_energy_consumption().returning(|| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_NO_PERM,
-                message: None,
-            })
-        });
-        mock.expect_device_power_consumption().returning(|| Ok(MOCK_POWER));
-        mock.expect_device_power_managment().returning(|| Ok(true));
+        mock.expect_device_energy_consumption()
+            .returning(|| Err(AmdError::from_status_code(AMDSMI_STATUS_NO_PERM)));
+        mock.expect_device_power_info().returning(|| Ok(MOCK_POWER));
+        mock.expect_is_power_managment_enabled().returning(|| Ok(true));
         mock.expect_device_process_list().returning(|| Ok(vec![mock_process()]));
-        mock.expect_device_voltage().returning(|_, _| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNEXPECTED_DATA,
-                message: None,
-            })
-        });
-        mock.expect_device_memory_usage().returning(|_| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNEXPECTED_DATA,
-                message: None,
-            })
-        });
-        mock.expect_device_temperature().returning(|_, _| {
-            Err(AmdError {
-                status: AmdStatus::AMDSMI_STATUS_UNEXPECTED_DATA,
-                message: None,
-            })
-        });
+        mock.expect_device_voltage()
+            .returning(|_, _| Err(AmdError::from_status_code(AMDSMI_STATUS_INVAL)));
+        mock.expect_device_memory_usage()
+            .returning(|_| Err(AmdError::from_status_code(AMDSMI_STATUS_INVAL)));
+        mock.expect_device_temperature()
+            .returning(|_, _| Err(AmdError::from_status_code(AMDSMI_STATUS_INVAL)));
 
+        // TODO refactor this, `eq` and `with_…` don't need to be there
         let (res, features) = OptionalFeatures::with_detected_features(&mock).unwrap();
 
         assert!(eq(res, &mock));

--- a/plugins/amd-gpu/src/amd/probe.rs
+++ b/plugins/amd-gpu/src/amd/probe.rs
@@ -147,14 +147,16 @@ impl<H: ProcessorHandle> AmdGpuSource<H> {
                 let consumer = ResourceConsumer::Process { pid: process.pid };
                 let name = &process.name;
 
-                if compute_units_number > 0 {
+                if compute_units_number > 0
+                    && let Some(cu_occupancy) = process.cu_occupancy
+                {
                     push(
                         measurements,
                         timestamp,
                         self.metrics.process_cu_occupancy,
                         resource,
                         &consumer,
-                        (process.cu_occupancy as f64 / compute_units_number as f64) * 100.0,
+                        (cu_occupancy as f64 / compute_units_number as f64) * 100.0,
                         || (KEY, name.to_string()),
                     );
                 }
@@ -242,7 +244,7 @@ impl<H: ProcessorHandle> Source for AmdGpuSource<H> {
             if features.gpu_asic_info
                 && let Ok(value) = device.handle.device_asic_info()
             {
-                // Push GPU compute-graphic process informations if processes existing
+                // Push GPU compute-graphic process information if processes existing
                 self.handle_gpu_processes(device, measurements, timestamp, &resource, value.num_of_compute_units);
             }
 
@@ -263,15 +265,17 @@ impl<H: ProcessorHandle> Source for AmdGpuSource<H> {
 
             // GPU instant electric power consumption metric pushed
             if features.gpu_power_consumption
-                && device.handle.device_power_managment()?
-                && let Ok(value) = device.handle.device_power_consumption()
+                && device.handle.is_power_managment_enabled()?
+                && let Ok(value) = device.handle.device_power_info()
+                && let Some(power) = value.socket_power
             {
+                // TODO should we signal the difference between current and average socket power?
                 measurements.push(MeasurementPoint::new(
                     timestamp,
                     self.metrics.gpu_power_consumption,
                     resource.clone(),
                     consumer.clone(),
-                    value.socket_power,
+                    power,
                 ));
             }
 

--- a/plugins/amd-gpu/src/lib.rs
+++ b/plugins/amd-gpu/src/lib.rs
@@ -61,7 +61,13 @@ impl AmdInterfaceProvider for AmdSmiProvider {
     type A = AmdSmi;
 
     fn get() -> anyhow::Result<AmdSmi> {
-        Ok(AmdSmi::init(AmdInitFlags::AMDSMI_INIT_AMD_GPUS)?)
+        let lib = AmdSmi::init(AmdInitFlags::AMDSMI_INIT_AMD_GPUS)?;
+        if !lib.version().is_officially_supported {
+            log::warn!(
+                "You are running a version of AMD SMI that is newer than the last version tested with this plugin. Please report any bug/crash on our repository."
+            );
+        }
+        Ok(lib)
     }
 }
 

--- a/plugins/amd-gpu/src/tests/mocks.rs
+++ b/plugins/amd-gpu/src/tests/mocks.rs
@@ -1,7 +1,7 @@
-use amd_smi_wrapper::metrics::{
-    AmdAsicInfo, AmdEnergyConsumption, AmdEngineUsage, AmdMemoryType, AmdPowerConsumption, AmdProcess,
-    AmdProcessEngineUsage, AmdProcessMemoryUsage, AmdTemperatureType,
-};
+use amd_smi_wrapper::metrics::asic_info::AmdAsicInfo;
+use amd_smi_wrapper::metrics::power_info::AmdPowerInfo;
+use amd_smi_wrapper::metrics::process_info::{AmdProcessEngineUsage, AmdProcessInfo, AmdProcessMemoryUsage};
+use amd_smi_wrapper::metrics::{AmdEnergyConsumption, AmdEngineUsage, AmdMemoryType, AmdTemperatureType};
 
 pub const MOCK_SOURCE_NAME: &str = "amd_gpu_devices";
 pub const MOCK_TIMESTAMP: u64 = 1712024507665;
@@ -31,10 +31,10 @@ pub const MOCK_ENERGY: [AmdEnergyConsumption; 2] = [
     },
 ];
 
-pub const MOCK_POWER: AmdPowerConsumption = AmdPowerConsumption {
-    socket_power: 43,
-    current_socket_power: 45,
-    average_socket_power: 47,
+pub const MOCK_POWER: AmdPowerInfo = AmdPowerInfo {
+    socket_power: Some(43),
+    current_socket_power: Some(45),
+    average_socket_power: Some(47),
     gfx_voltage: 850,
     soc_voltage: 840,
     mem_voltage: 830,
@@ -68,12 +68,12 @@ pub fn mock_asic_info() -> AmdAsicInfo {
         oam_id: 1,
         num_of_compute_units: 104,
         target_graphics_version: 2314,
-        subsystem_id: 3124,
+        subsystem_id: Some(3124),
     }
 }
 
-pub fn mock_process() -> AmdProcess {
-    AmdProcess {
+pub fn mock_process() -> AmdProcessInfo {
+    AmdProcessInfo {
         name: MOCK_PROCESS_NAME.to_string(),
         pid: 1,
         mem: 131072,
@@ -87,7 +87,7 @@ pub fn mock_process() -> AmdProcess {
             vram_mem: 3456789,
         },
         container_name: MOCK_PROCESS_NAME.to_string(),
-        cu_occupancy: 42,
-        evicted_time: 65535,
+        cu_occupancy: Some(42),
+        evicted_time: Some(65535),
     }
 }

--- a/plugins/amd-gpu/src/tests/tests.rs
+++ b/plugins/amd-gpu/src/tests/tests.rs
@@ -27,10 +27,11 @@ use alumet::{
 };
 use amd_smi_wrapper::{
     MockAmdInterface,
-    error::{AmdError, AmdStatus},
+    error::AmdError,
     handles::{MockProcessorHandle, MockSocketHandle},
     metrics::AmdTemperatureMetric,
 };
+use amd_smi_wrapper_sys::versions::stable::{AMDSMI_STATUS_INVAL, AMDSMI_STATUS_NOT_SUPPORTED};
 
 // Mock fake toml table for configuration
 #[cfg(test)]
@@ -62,11 +63,11 @@ fn test_start_success() {
                 .expect_device_energy_consumption()
                 .returning(|| Ok(MOCK_ENERGY[0]));
 
-            mock_processor
-                .expect_device_power_consumption()
-                .returning(|| Ok(MOCK_POWER));
+            mock_processor.expect_device_power_info().returning(|| Ok(MOCK_POWER));
 
-            mock_processor.expect_device_power_managment().returning(|| Ok(true));
+            mock_processor
+                .expect_is_power_managment_enabled()
+                .returning(|| Ok(true));
 
             mock_processor
                 .expect_device_process_list()
@@ -81,28 +82,19 @@ fn test_start_success() {
                     .iter()
                     .find(|(t, _)| *t == mem_type)
                     .map(|(_, v)| Ok(*v))
-                    .unwrap_or(Err(AmdError {
-                        status: AmdStatus::AMDSMI_STATUS_UNEXPECTED_DATA,
-                        message: None,
-                    }))
+                    .unwrap_or(Err(AmdError::from_status_code(AMDSMI_STATUS_INVAL)))
             });
 
             mock_processor.expect_device_temperature().returning(|sensor, metric| {
                 if metric != AmdTemperatureMetric::AMDSMI_TEMP_CURRENT {
-                    return Err(AmdError {
-                        status: AmdStatus::AMDSMI_STATUS_UNEXPECTED_DATA,
-                        message: None,
-                    });
+                    return Err(AmdError::from_status_code(AMDSMI_STATUS_INVAL));
                 }
 
                 MOCK_TEMPERATURE
                     .iter()
                     .find(|(s, _)| *s == sensor)
                     .map(|(_, v)| Ok(*v))
-                    .unwrap_or(Err(AmdError {
-                        status: AmdStatus::AMDSMI_STATUS_UNEXPECTED_DATA,
-                        message: None,
-                    }))
+                    .unwrap_or(Err(AmdError::from_status_code(AMDSMI_STATUS_INVAL)))
             });
 
             Ok(vec![mock_processor])
@@ -262,7 +254,7 @@ fn test_start_success() {
             {
                 let metric = metric(METRIC_LABEL_POWER);
                 let p = gpu_points(metric).next().expect("Unexpected value");
-                assert_eq!(p.value, WrappedMeasurementValue::U64(MOCK_POWER.socket_power as u64));
+                assert_eq!(p.value, WrappedMeasurementValue::U64(MOCK_POWER.socket_power.unwrap()));
             }
 
             // GPU voltage
@@ -307,7 +299,9 @@ fn test_start_success() {
 
                         let expected_value = match (process_name.as_str(), metric_id) {
                             ("p1", METRIC_LABEL_PROCESS_COMPUTE_UNIT_OCCUPANCY) => WrappedMeasurementValue::F64(
-                                mock_process.cu_occupancy as f64 / mock_asic_info.num_of_compute_units as f64 * 100.0,
+                                mock_process.cu_occupancy.unwrap_or_default() as f64
+                                    / mock_asic_info.num_of_compute_units as f64
+                                    * 100.0,
                             ),
                             ("p1", METRIC_LABEL_PROCESS_MEMORY) => WrappedMeasurementValue::U64(mock_process.mem),
                             ("p1", METRIC_LABEL_PROCESS_ENCODE) => {
@@ -379,60 +373,33 @@ fn test_start_success_without_stats() {
                 .expect_device_uuid()
                 .returning(|| Ok(MOCK_UUID.to_owned()));
 
-            mock_processor.expect_device_activity().returning(|| {
-                Err(AmdError {
-                    status: AmdStatus::AMDSMI_STATUS_UNKNOWN_ERROR,
-                    message: None,
-                })
-            });
-            mock_processor.expect_device_asic_info().returning(|| {
-                Err(AmdError {
-                    status: AmdStatus::AMDSMI_STATUS_UNKNOWN_ERROR,
-                    message: None,
-                })
-            });
-            mock_processor.expect_device_energy_consumption().returning(|| {
-                Err(AmdError {
-                    status: AmdStatus::AMDSMI_STATUS_UNKNOWN_ERROR,
-                    message: None,
-                })
-            });
-            mock_processor.expect_device_power_consumption().returning(|| {
-                Err(AmdError {
-                    status: AmdStatus::AMDSMI_STATUS_UNKNOWN_ERROR,
-                    message: None,
-                })
-            });
-            mock_processor.expect_device_power_managment().returning(|| {
-                Err(AmdError {
-                    status: AmdStatus::AMDSMI_STATUS_UNKNOWN_ERROR,
-                    message: None,
-                })
-            });
-            mock_processor.expect_device_process_list().returning(|| {
-                Err(AmdError {
-                    status: AmdStatus::AMDSMI_STATUS_UNKNOWN_ERROR,
-                    message: None,
-                })
-            });
-            mock_processor.expect_device_voltage().returning(|_, _| {
-                Err(AmdError {
-                    status: AmdStatus::AMDSMI_STATUS_UNKNOWN_ERROR,
-                    message: None,
-                })
-            });
-            mock_processor.expect_device_memory_usage().returning(|_| {
-                Err(AmdError {
-                    status: AmdStatus::AMDSMI_STATUS_UNKNOWN_ERROR,
-                    message: None,
-                })
-            });
-            mock_processor.expect_device_temperature().returning(|_, _| {
-                Err(AmdError {
-                    status: AmdStatus::AMDSMI_STATUS_UNKNOWN_ERROR,
-                    message: None,
-                })
-            });
+            mock_processor
+                .expect_device_activity()
+                .returning(|| Err(AmdError::from_status_code(AMDSMI_STATUS_NOT_SUPPORTED)));
+            mock_processor
+                .expect_device_asic_info()
+                .returning(|| Err(AmdError::from_status_code(AMDSMI_STATUS_NOT_SUPPORTED)));
+            mock_processor
+                .expect_device_energy_consumption()
+                .returning(|| Err(AmdError::from_status_code(AMDSMI_STATUS_NOT_SUPPORTED)));
+            mock_processor
+                .expect_device_power_info()
+                .returning(|| Err(AmdError::from_status_code(AMDSMI_STATUS_NOT_SUPPORTED)));
+            mock_processor
+                .expect_is_power_managment_enabled()
+                .returning(|| Err(AmdError::from_status_code(AMDSMI_STATUS_NOT_SUPPORTED)));
+            mock_processor
+                .expect_device_process_list()
+                .returning(|| Err(AmdError::from_status_code(AMDSMI_STATUS_NOT_SUPPORTED)));
+            mock_processor
+                .expect_device_voltage()
+                .returning(|_, _| Err(AmdError::from_status_code(AMDSMI_STATUS_NOT_SUPPORTED)));
+            mock_processor
+                .expect_device_memory_usage()
+                .returning(|_| Err(AmdError::from_status_code(AMDSMI_STATUS_NOT_SUPPORTED)));
+            mock_processor
+                .expect_device_temperature()
+                .returning(|_, _| Err(AmdError::from_status_code(AMDSMI_STATUS_NOT_SUPPORTED)));
 
             Ok(vec![mock_processor])
         });


### PR DESCRIPTION
After all this time spent on amd-smi-wrapper, the multi-version support is finally ready! This PR updates the amd-gpu plugin to use the new wrapper crate, which brings automatic detection of multiple versions of AMD SMI (6.3.0-7.2.x).