### PR TITLE
feat(plugin-perf): compensate for counter multiplexing

### DIFF
--- a/plugins/perf/README.md
+++ b/plugins/perf/README.md
@@ -43,6 +43,21 @@ Note that based on your kernel version, some events could be unavailable.
 
 ### Attributes
 
+Every measurement carries an `accuracy` attribute describing how faithful its value is (see
+[Counter multiplexing](#counter-multiplexing) below):
+
+- `exact`: an exact count.
+- `extrapolated`: the value includes at least one multiplexed interval that was extrapolated (only
+  happens when `multiplexing_auto_scale` is on). It is an estimate, which may be slightly above or
+  below the truth.
+- `underestimated`: the value is known to be too low, either because multiplexed intervals were
+  reported raw (`multiplexing_auto_scale` off) or because the counter was starved for some intervals
+  (the events could not be counted at all).
+
+Because the reported values are cumulative counters, the accuracy only ever degrades from `exact` to
+`extrapolated` to `underestimated`, and never improves: a single imperfect interval affects every
+value reported afterwards.
+
 ## Configuration
 
 Here is a configuration example of the plugin. It's part of the Alumet configuration file (eg: `alumet-config.toml`).
@@ -67,9 +82,32 @@ cache_events = [
     "LL_READ_MISS",
 #   // any combination of {cache-id}_{cache-op}_{cache-result} from the lists previously mentionned
 ]
+
+# Compensate for counter multiplexing (optional, true by default).
+# See the "Counter multiplexing" section below.
+multiplexing_auto_scale = true
 ```
 
 ## More information
+
+### Counter multiplexing
+
+A CPU only has a few hardware counters. When you configure more events than it can hold, the kernel
+cannot count them all at once: it puts them on the counters in turn, so each event is only counted
+during a fraction of the time. The raw values are then underestimated by that fraction.
+
+By default (`multiplexing_auto_scale = true`), the plugin compensates for this the same way the
+`perf` tool does: it extrapolates the missing part, assuming the events kept occurring at the same
+rate while they were not on a counter. This is an **estimation**, not an exact measurement, so the
+affected measurements are marked `accuracy = "extrapolated"` (see [Attributes](#attributes)).
+
+Set `multiplexing_auto_scale = false` to report the raw kernel values instead, without any
+compensation. Those values are marked `accuracy = "underestimated"`, so you can still tell which
+ones are affected.
+
+The surest way to avoid multiplexing altogether is to configure no more events than the CPU has
+hardware counters (typically 4 to 8). Note that a single event can already be multiplexed if
+something else is using the PMU, for example another `perf` process running system-wide.
 
 ### perf_event_paranoid and capabilities
 

--- a/plugins/perf/README.md
+++ b/plugins/perf/README.md
@@ -10,7 +10,106 @@ This plugin works in a similar way to the [`perf` command-line tool](https://man
 - [Required capabilities](#perf_event_paranoid-and-capabilities).
 - [libpfm4](#libpfm-events). **Optional**. Only required to read libpfm-encoded events.
 
-## Events
+## Metrics
+
+### Metric naming
+
+By default the metric is named `perf_{name}` (e.g. `INSTRUCTIONS` → `perf_instructions`). The name
+is always normalized: letters are lowercased, and any character that is not a letter or digit
+becomes `_` (leading/trailing `_` are trimmed). So `LL_READ_MISS` → `perf_ll_read_miss` and
+`RESOURCE_STALLS:ANY` → `perf_resource_stalls_any`.
+
+The modifiers do not change the metric name, so if you measure the same event with different
+modifiers, give at least one of them a `rename` to avoid a name clash. A `rename` replaces the whole
+suffix (and is normalized the same way); the metric then becomes `perf_{rename}`.
+
+### Attributes
+
+Every measurement carries an `accuracy` attribute describing how faithful its value is (see
+[Counter multiplexing](#counter-multiplexing) below):
+
+- `exact`: an exact count.
+- `extrapolated`: the value includes at least one multiplexed interval that was extrapolated (only
+  happens when `multiplexing_auto_scale` is on). It is an estimate, which may be slightly above or
+  below the truth.
+- `underestimated`: the value is known to be too low, either because multiplexed intervals were
+  reported raw (`multiplexing_auto_scale` off) or because the counter was starved for some intervals
+  (the events could not be counted at all).
+
+Because the reported values are cumulative counters, the accuracy only ever degrades from `exact` to
+`extrapolated` to `underestimated`, and never improves: a single imperfect interval affects every
+value reported afterwards.
+
+## Configuration
+
+Here is a configuration example of the plugin. It's part of the Alumet configuration file (eg: `alumet-config.toml`).
+
+```toml
+[plugins.perf]
+# Description.
+poll_interval = "1s"
+flush_interval = "1s"
+events = [
+    "REF_CPU_CYCLES",
+    "CACHE_MISSES",
+    "BRANCH_MISSES",
+    "INSTRUCTIONS#u:k",                              # user-space and kernel instructions only
+    "RESOURCE_STALLS:ANY",                           # libpfm event with a unit mask
+    { event = "CONTEXT_SWITCHES", rename = "ctxsw" }, # -> metric perf_ctxsw
+    { event = "LL_READ_MISS#h", rename = "LL_READ_MISS_HYPERVISOR"}, # hypervisor only
+]
+
+# If true, start the sources in "paused" state.
+# This is useful in combination with other plugins that will resume the sources.
+add_source_in_pause_state = false
+# Compensate for counter multiplexing (optional, true by default).
+# See the "Counter multiplexing" section below.
+multiplexing_auto_scale = true
+```
+
+See [Event formats](#event-formats) section for more information about the supported syntax of events.
+
+## More information
+
+### Use cases
+
+The `perf` plugin can be used for multiple use cases:
+
+#### Read counters for a single process
+
+You can collect measurements for a single process using Alumet in `exec` mode.
+
+Example: `alumet --config alumet-config.toml --plugins perf,csv exec -- stress --cpu 8 --timeout 10s`
+
+In this example, Alumet will launch the `stress` process and collect measurements based on the configured counters in `alumet-config.toml`.
+
+#### Read counters for running processes
+
+Not supported. The implementation will be done in the future.
+
+#### Read counters for a single cgroup
+
+Not supported. The implementation will be done in the future.
+
+#### Read counters for running cgroups
+
+You can collect measurements for all the running cgroups using Alumet in `watch` mode combined with a `cgroups` **Observer**.
+
+Example: `alumet --config alumet-config.toml --plugins perf,cgroups,csv`
+
+Make sure that the plugin `cgroups` (or `slurm`, `k8s`, `oar`) is activated in your configuration file:
+
+Example:
+
+```toml
+[plugins.cgroups]
+poll_interval = "1s"
+sources_disable = true
+```
+
+Having the `sources_disable = true` make the **Observer** feature alive without having their own sources activated.
+
+### Events syntax
 
 Events to measure are described with a single unified syntax. The **event name** have a syntax inspired from
 `perf stat -e` [event selection syntax](https://man7.org/linux/man-pages/man1/perf-stat.1.html).
@@ -21,9 +120,9 @@ Each event is a string of the form:
 <event>[#<modifiers>]
 ```
 
-### Event formats
+#### Event formats
 
-The `<event>` part can be one of five forms:
+The `<event>` part can be one of three forms:
 
 - **native** : a symbolic event name (e.g. `INSTRUCTIONS`, `LL_READ_MISS`), resolved against the
   built-in kernel tables listed in [Native event names](#native-event-names). (**Supported**)
@@ -36,7 +135,7 @@ The `<event>` part can be one of five forms:
 Any event may be followed by `#` and a list of [modifiers](#modifiers), e.g.
 `INSTRUCTIONS#u` or `CACHE_MISSES#u:k`.
 
-### Native event names
+#### Native event names
 
 Currently the plugin resolves symbolic names against the **native** kernel tables. The name is one of:
 
@@ -57,7 +156,7 @@ To learn more about the standard events, please refer to the [`perf_event_open` 
 To list the events that are available on your machine, run the `perf list` command.
 Note that based on your kernel version, some events could be unavailable.
 
-### Libpfm events
+#### Libpfm events
 
 The native tables above are a small, vendor-neutral subset. Any name they don't recognise is passed
 to [libpfm4](https://perfmon2.sourceforge.net/), which knows the hundreds of microarchitecture-specific
@@ -87,7 +186,7 @@ libpfm is **loaded at runtime** (via `dlopen`), not linked at build time:
 - Install it from your distribution (e.g. `libpfm4` on Debian/Ubuntu). By default the plugin looks
   for `libpfm.so.4` and `libpfm.so`. Set `ALUMET_LIBPFM_LIB` to a `.so` name or full path to override.
 
-### Raw events
+#### Raw events
 
 When a symbolic name is not enough, you can give the raw event code directly, just like `perf`:
 
@@ -101,9 +200,9 @@ value as-is.
 Modifiers work here too: `r0x412e#u:k`. The metric is named after the sanitized event string, so
 `r0x412e` → `perf_r0x412e` (use a `rename` for something friendlier).
 
-### Modifiers
+#### Modifiers
 
-Modifiers are attached after a `#`, one per `:`-separated token (e.g. `INSTRUCTIONS#u:k`). Each
+Modifiers are attached after a `#`, one per `:`-separated token (e.g. `INSTRUCTIONS#u:k`).
 An unknown token (e.g. `INSTRUCTIONS#z`) is rejected.
 
 For now these modifiers are supported:
@@ -122,68 +221,24 @@ hypervisor are excluded. The domain modifiers (`u`/`k`/`h`) work as a group: as 
 at least one of them, the domains you *don't* list are excluded, so `#u` means "user space only" and
 `#u:k` means "user and kernel, but not hypervisor".
 
-### Metric naming
+### Counter multiplexing
 
-By default the metric is named `perf_{name}` (e.g. `INSTRUCTIONS` → `perf_instructions`). The name
-is always normalized: letters are lowercased, and any character that is not a letter or digit
-becomes `_` (leading/trailing `_` are trimmed). So `LL_READ_MISS` → `perf_ll_read_miss` and
-`RESOURCE_STALLS:ANY` → `perf_resource_stalls_any`.
+A CPU only has a few hardware counters. When you configure more events than it can hold, the kernel
+cannot count them all at once: it puts them on the counters in turn, so each event is only counted
+during a fraction of the time. The raw values are then underestimated by that fraction.
 
-The modifiers do not change the metric name, so if you measure the same event with different
-modifiers, give at least one of them a `rename` to avoid a name clash. A `rename` replaces the whole
-suffix (and is normalized the same way); the metric then becomes `perf_{rename}`.
+By default (`multiplexing_auto_scale = true`), the plugin compensates for this the same way the
+`perf` tool does: it extrapolates the missing part, assuming the events kept occurring at the same
+rate while they were not on a counter. This is an **estimation**, not an exact measurement, so the
+affected measurements are marked `accuracy = "extrapolated"` (see [Attributes](#attributes)).
 
-## Configuration
+Set `multiplexing_auto_scale = false` to report the raw kernel values instead, without any
+compensation. Those values are marked `accuracy = "underestimated"`, so you can still tell which
+ones are affected.
 
-Here is a configuration example of the plugin. It's part of the Alumet configuration file (eg: `alumet-config.toml`).
-
-```toml
-[plugins.perf]
-# Description.
-poll_interval = "1s"
-flush_interval = "1s"
-events = [
-    "REF_CPU_CYCLES",
-    "CACHE_MISSES",
-    "BRANCH_MISSES",
-    "INSTRUCTIONS#u:k",                              # user-space and kernel instructions only
-    "RESOURCE_STALLS:ANY",                           # libpfm event with a unit mask
-    { event = "CONTEXT_SWITCHES", rename = "ctxsw" }, # -> metric perf_ctxsw
-    { event = "LL_READ_MISS#h", rename = "LL_READ_MISS_HYPERVISOR"}, # hypervisor only
-]
-
-# If true, start the sources in "paused" state.
-# This is useful in combination with other plugins that will resume the sources.
-add_source_in_pause_state = false
-```
-
-⚠️ Note that by default, the plugin will only collect measurements when running Alumet in `exec` mode.
-
-Example: `alumet --plugins perf,csv exec -- sleep 10`
-
-In this case, the plugin will collect the measurements for that specific sleep process.
-
-Another use case would be to collect the measurements in a typical `watch` scenarios.
-
-The plugin currently supports `watch` mode only for cgroups, see how to configure the plugin for this scenario [here](#collecting-cgroups-in-watch-mode).
-
-### Collecting cgroups in watch mode
-
-To dynamically collect measurements about cgroups, the perf plugin needs another Observer plugin that can detect new cgroups and notify Alumet.
-
-All the cgroups plugins (cgroups-raw, k8s, slurm, oar) have this Observer capability.
-
-Make sure that one of this plugin is activated in your configuration file.
-
-Example:
-
-```toml
-[plugins.cgroups]
-poll_interval = "1s"
-sources_disable = true
-```
-
-## More information
+The surest way to avoid multiplexing altogether is to configure no more events than the CPU has
+hardware counters (typically 4 to 8). Note that a single event can already be multiplexed if
+something else is using the PMU, for example another `perf` process running system-wide.
 
 ### perf_event_paranoid and capabilities
 

--- a/plugins/perf/src/lib.rs
+++ b/plugins/perf/src/lib.rs
@@ -26,6 +26,7 @@ compile_error!("This plugin only works on Linux.");
 
 mod cpu;
 mod events;
+mod multiplexing;
 mod source;
 
 pub struct PerfPlugin {
@@ -70,6 +71,7 @@ impl AlumetPlugin for PerfPlugin {
                 .map(|e| events::parse_cache(&e))
                 .try_collect()
                 .context("invalid cache event in config")?,
+            multiplexing_auto_scale: config.multiplexing_auto_scale,
             // The metrics are initialized in start()
             hardware_metrics: Vec::new(),
             software_metrics: Vec::new(),
@@ -136,7 +138,7 @@ impl AlumetPlugin for PerfPlugin {
                 if let Some((o, source_name)) = observable {
                     log::info!("Starting to observe {o:?}...");
                     let config = config_cloned.lock().unwrap();
-                    let mut builder = PerfEventSourceBuilder::observe(o)?;
+                    let mut builder = PerfEventSourceBuilder::observe(o, config.multiplexing_auto_scale)?;
                     for (event, metric) in config.hardware_events.iter().zip(&config.hardware_metrics) {
                         builder.add(event.event, *metric).with_context(|| {
                             format!(
@@ -193,6 +195,22 @@ struct Config {
     hardware_events: Vec<String>,
     software_events: Vec<String>,
     cache_events: Vec<String>,
+
+    /// Whether to compensate for the multiplexing of the perf events.
+    ///
+    /// A CPU only has a few hardware counters. When more events are requested than it can hold, the
+    /// kernel only counts them part of the time, and the raw values are underestimated. When this is
+    /// enabled (the default), the plugin extrapolates the missing part, like the `perf` tool does.
+    /// When disabled, the raw values are reported as they are.
+    ///
+    /// Either way, every measurement carries an `accuracy` attribute telling whether its value is
+    /// exact, extrapolated or underestimated.
+    #[serde(default = "default_multiplexing_auto_scale")]
+    multiplexing_auto_scale: bool,
+}
+
+fn default_multiplexing_auto_scale() -> bool {
+    true
 }
 
 impl Default for Config {
@@ -208,6 +226,7 @@ impl Default for Config {
             ],
             software_events: vec![],
             cache_events: vec!["LL_READ_MISS".to_owned()],
+            multiplexing_auto_scale: default_multiplexing_auto_scale(),
         }
     }
 }
@@ -223,4 +242,5 @@ struct ParsedConfig {
     hardware_metrics: Vec<TypedMetricId<u64>>,
     software_metrics: Vec<TypedMetricId<u64>>,
     cache_metrics: Vec<TypedMetricId<u64>>,
+    multiplexing_auto_scale: bool,
 }

--- a/plugins/perf/src/lib.rs
+++ b/plugins/perf/src/lib.rs
@@ -28,6 +28,7 @@ use crate::source::{Observable, PerfEventSourceBuilder};
 compile_error!("This plugin only works on Linux.");
 
 mod cpu;
+mod multiplexing;
 mod native;
 mod pfm;
 mod raw;
@@ -64,6 +65,7 @@ impl AlumetPlugin for PerfPlugin {
                 .map(spec::parse)
                 .try_collect()
                 .context("invalid event in config")?,
+            multiplexing_auto_scale: config.multiplexing_auto_scale,
             // The metrics are initialized in start()
             metrics: Vec::new(),
             add_source_in_pause_state: config.add_source_in_pause_state,
@@ -129,7 +131,7 @@ impl AlumetPlugin for PerfPlugin {
                 if let Some((o, source_name)) = observable {
                     log::info!("Starting to observe {o:?}...");
                     let config = config_cloned.lock().unwrap();
-                    let mut builder = PerfEventSourceBuilder::observe(o)?;
+                    let mut builder = PerfEventSourceBuilder::observe(o, config.multiplexing_auto_scale)?;
                     for (event, metric) in config.events.iter().zip(&config.metrics) {
                         builder
                             .add(&event.event, *metric)
@@ -230,6 +232,17 @@ struct Config {
     /// !! It's essentially needed for advanced Alumet setup with a control plugin that manage the state of sources.
     #[serde(default)]
     pub add_source_in_pause_state: bool,
+
+    /// Whether to compensate for the multiplexing of the perf events.
+    ///
+    /// A CPU only has a few hardware counters. When more events are requested than it can hold, the
+    /// kernel only counts them part of the time, and the raw values are underestimated. When this is
+    /// enabled (the default), the plugin extrapolates the missing part, like the `perf` tool does.
+    /// When disabled, the raw values are reported as they are.
+    ///
+    /// Either way, every measurement carries an `accuracy` attribute telling whether its value is
+    /// exact, extrapolated or underestimated.
+    multiplexing_auto_scale: bool,
 }
 
 impl Default for Config {
@@ -246,6 +259,8 @@ impl Default for Config {
             ],
 
             add_source_in_pause_state: false,
+
+            multiplexing_auto_scale: true,
         }
     }
 }
@@ -259,4 +274,6 @@ struct ParsedConfig {
     metrics: Vec<TypedMetricId<u64>>,
 
     add_source_in_pause_state: bool,
+
+    multiplexing_auto_scale: bool,
 }

--- a/plugins/perf/src/multiplexing.rs
+++ b/plugins/perf/src/multiplexing.rs
@@ -1,0 +1,332 @@
+//! Compensation for perf counter multiplexing.
+//!
+//! A CPU only has a handful of hardware counters. When more events are requested than it can hold,
+//! the kernel multiplexes them: a group is only on the PMU during a fraction `running / enabled` of
+//! the time we asked it to count, and its raw values are underestimated by that same fraction. Like
+//! the `perf` tool, we extrapolate the missing part by assuming that the events kept occurring at
+//! the same rate while we were not looking.
+//!
+//! The correction is applied to each polling interval, not to the whole lifetime of the group, so
+//! that an interval whose rate is overestimated cannot make the corrected value go backwards later
+//! on: the metrics are counters, they must never decrease.
+
+/// One read of a group.
+///
+/// The kernel reports cumulative values, never reset, hence the need to keep the previous read
+/// around and to work on differences.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct Snapshot {
+    /// For how long we asked the group to count, in nanoseconds.
+    ///
+    /// Beware: this is *not* wall clock time. It only advances while the observed entity (process
+    /// or cgroup) is actually running on a CPU. A sleeping process makes both times stand still.
+    pub time_enabled: u128,
+    /// For how long the group was really on the PMU, in nanoseconds.
+    pub time_running: u128,
+    /// Raw counter values, in the same order as the group's counters.
+    pub values: Vec<u64>,
+}
+
+/// How faithful a reported (cumulative) value is.
+///
+/// This describes the whole value reported so far, not the last interval, because the value is a
+/// cumulative counter. It therefore only ever degrades (`exact` → `extrapolated` → `underestimated`)
+/// and never improves: a single imperfect interval taints every value reported afterwards. The
+/// variants are ordered from best to worst so that [`Accuracy::max`] keeps the worst seen.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum Accuracy {
+    /// Every interval was counted exactly.
+    #[default]
+    Exact,
+    /// At least one multiplexed interval was extrapolated (only in `auto_scale` mode). The value is
+    /// an estimate, which may be slightly above or below the truth.
+    Extrapolated,
+    /// The value is known to be too low: either multiplexed intervals were kept raw (no
+    /// `auto_scale`), or some intervals were missed entirely (the group was starved).
+    Underestimated,
+}
+
+impl Accuracy {
+    /// The value used for the `accuracy` measurement attribute.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Accuracy::Exact => "exact",
+            Accuracy::Extrapolated => "extrapolated",
+            Accuracy::Underestimated => "underestimated",
+        }
+    }
+}
+
+/// What happened to a group during one polling interval.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum Interval {
+    /// The observed entity did not run at all: nothing happened, and nothing had to be counted.
+    /// This is by far the most common case, hence the absence of any log.
+    Idle,
+    /// The group was on the PMU for the whole interval: the values are exact.
+    Exact,
+    /// The group was only on the PMU for part of the interval, so the raw values are underestimated
+    /// by the ratio `running / enabled`.
+    Multiplexed { running: u128, enabled: u128 },
+    /// The entity ran but the group never made it onto the PMU: everything that happened during the
+    /// interval was missed, and there is nothing to extrapolate from.
+    Starved,
+}
+
+/// Multiplexing correction state of one group.
+///
+/// The kernel schedules a group atomically: either all of its counters are on the PMU, or none of
+/// them are. Every counter of a group therefore shares the same `time_enabled`/`time_running`, and
+/// a single correction applies to all of them.
+#[derive(Debug, Default)]
+pub(crate) struct Scaling {
+    /// Previous read. Starts at zero: when the group is enabled it has counted nothing, during no
+    /// time at all, so the first poll is an interval like any other.
+    prev: Snapshot,
+    /// Corrected cumulative value of each counter, in the same order as the group's counters.
+    corrected: Vec<u64>,
+    /// Faithfulness of the reported values so far. Only ever degrades, see [`Accuracy`].
+    accuracy: Accuracy,
+}
+
+impl Scaling {
+    pub fn new(n_counters: usize) -> Self {
+        Self {
+            prev: Snapshot {
+                time_enabled: 0,
+                time_running: 0,
+                values: vec![0; n_counters],
+            },
+            corrected: vec![0; n_counters],
+            accuracy: Accuracy::Exact,
+        }
+    }
+
+    /// Corrected cumulative value of each counter, in the same order as the group's counters.
+    pub fn corrected(&self) -> &[u64] {
+        &self.corrected
+    }
+
+    /// Faithfulness of the reported values so far. See [`Accuracy`]: it only ever degrades.
+    pub fn accuracy(&self) -> Accuracy {
+        self.accuracy
+    }
+
+    /// Accounts for a new reading, updating the corrected totals, and returns what happened during
+    /// the interval.
+    pub fn account(&mut self, now: Snapshot, auto_scale: bool) -> Interval {
+        let interval = correct_interval(&self.prev, &now, auto_scale, &mut self.corrected);
+        let interval_accuracy = match interval {
+            Interval::Idle | Interval::Exact => Accuracy::Exact,
+            Interval::Multiplexed { .. } if auto_scale => Accuracy::Extrapolated,
+            // multiplexed without auto-scaling, or a starved interval that could not be extrapolated
+            Interval::Multiplexed { .. } | Interval::Starved => Accuracy::Underestimated,
+        };
+        self.accuracy = self.accuracy.max(interval_accuracy);
+        self.prev = now;
+        interval
+    }
+}
+
+/// Adds the (possibly corrected) contribution of one polling interval to `corrected`, and reports
+/// what happened. See the [module documentation](self) for the rationale.
+fn correct_interval(prev: &Snapshot, now: &Snapshot, auto_scale: bool, corrected: &mut [u64]) -> Interval {
+    let d_enabled = now.time_enabled.saturating_sub(prev.time_enabled);
+    let d_running = now.time_running.saturating_sub(prev.time_running);
+
+    if d_enabled == 0 {
+        return Interval::Idle;
+    }
+    if d_running == 0 {
+        // Nothing was counted, so there is nothing to extrapolate from. Leave the totals alone,
+        // which keeps the counters flat instead of making up a value. Note that dividing by
+        // `d_running` below would panic, integer division by zero is not `inf`.
+        return Interval::Starved;
+    }
+
+    let multiplexed = d_running < d_enabled;
+    for (i, total) in corrected.iter_mut().enumerate() {
+        let delta = u128::from(now.values[i].saturating_sub(prev.values[i]));
+        let contribution = if multiplexed && auto_scale {
+            // Rule of three: `delta` events were counted during `d_running`, estimate how many
+            // occurred during the whole `d_enabled`.
+            delta * d_enabled / d_running
+        } else {
+            delta
+        };
+        *total = total.saturating_add(u64::try_from(contribution).unwrap_or(u64::MAX));
+    }
+
+    if multiplexed {
+        Interval::Multiplexed {
+            running: d_running,
+            enabled: d_enabled,
+        }
+    } else {
+        Interval::Exact
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Interval, Snapshot, correct_interval};
+
+    const SEC: u128 = 1_000_000_000;
+
+    fn snap(enabled: u128, running: u128, values: &[u64]) -> Snapshot {
+        Snapshot {
+            time_enabled: enabled,
+            time_running: running,
+            values: values.to_vec(),
+        }
+    }
+
+    /// When the group is enabled, everything is zero, so the first poll is an interval like any
+    /// other and must be corrected too.
+    #[test]
+    fn first_poll_is_an_interval_like_any_other() {
+        let mut corrected = vec![0];
+        let interval = correct_interval(&snap(0, 0, &[0]), &snap(SEC, SEC / 4, &[1000]), true, &mut corrected);
+        assert_eq!(
+            interval,
+            Interval::Multiplexed {
+                running: SEC / 4,
+                enabled: SEC
+            }
+        );
+        // counted 1000 while on the PMU a quarter of the time
+        assert_eq!(corrected, vec![4000]);
+    }
+
+    #[test]
+    fn exact_when_running_equals_enabled() {
+        let mut corrected = vec![0];
+        let interval = correct_interval(&snap(0, 0, &[0]), &snap(SEC, SEC, &[1000]), true, &mut corrected);
+        assert_eq!(interval, Interval::Exact);
+        assert_eq!(corrected, vec![1000]);
+    }
+
+    /// The observed entity did not run: both times stand still. This is the most common case and it
+    /// must not be mistaken for a starved group.
+    #[test]
+    fn idle_entity_changes_nothing() {
+        let mut corrected = vec![1000];
+        let prev = snap(SEC, SEC, &[1000]);
+        let interval = correct_interval(&prev, &prev.clone(), true, &mut corrected);
+        assert_eq!(interval, Interval::Idle);
+        assert_eq!(corrected, vec![1000]);
+    }
+
+    /// The entity ran but the group never made it onto the PMU. Dividing by `d_running` here would
+    /// panic, and there is nothing to extrapolate from anyway.
+    #[test]
+    fn starved_group_does_not_divide_by_zero() {
+        let mut corrected = vec![1000];
+        let prev = snap(SEC, SEC / 4, &[1000]);
+        let now = snap(2 * SEC, SEC / 4, &[1000]);
+        let interval = correct_interval(&prev, &now, true, &mut corrected);
+        assert_eq!(interval, Interval::Starved);
+        assert_eq!(corrected, vec![1000], "the total must stay flat, not be made up");
+    }
+
+    #[test]
+    fn without_auto_scale_the_raw_delta_is_kept() {
+        let mut corrected = vec![0];
+        let interval = correct_interval(&snap(0, 0, &[0]), &snap(SEC, SEC / 4, &[1000]), false, &mut corrected);
+        assert_eq!(
+            interval,
+            Interval::Multiplexed {
+                running: SEC / 4,
+                enabled: SEC
+            },
+            "multiplexing is still reported, it is just not compensated"
+        );
+        assert_eq!(corrected, vec![1000]);
+    }
+
+    #[test]
+    fn every_counter_of_the_group_is_corrected() {
+        let mut corrected = vec![0, 0, 0];
+        correct_interval(&snap(0, 0, &[0, 0, 0]), &snap(SEC, SEC / 2, &[10, 20, 30]), true, &mut corrected);
+        assert_eq!(corrected, vec![20, 40, 60]);
+    }
+
+    /// Each interval is corrected on its own and added to a total that only ever grows, so that a
+    /// badly extrapolated interval cannot make the counter go backwards later on.
+    #[test]
+    fn totals_accumulate_and_never_decrease() {
+        let mut corrected = vec![0];
+        let mut totals = Vec::new();
+
+        // poll 1: 1000 counted over a quarter of a second of PMU time -> 4000
+        let s1 = snap(SEC, SEC / 4, &[1000]);
+        correct_interval(&snap(0, 0, &[0]), &s1, true, &mut corrected);
+        totals.push(corrected[0]);
+
+        // poll 2: +500 counted over another quarter -> +2000
+        let s2 = snap(2 * SEC, SEC / 2, &[1500]);
+        correct_interval(&s1, &s2, true, &mut corrected);
+        totals.push(corrected[0]);
+
+        // poll 3: the group is starved, nothing is added
+        let s3 = snap(3 * SEC, SEC / 2, &[1500]);
+        correct_interval(&s2, &s3, true, &mut corrected);
+        totals.push(corrected[0]);
+
+        // poll 4: +200 counted over half a second -> +400
+        let s4 = snap(4 * SEC, SEC, &[1700]);
+        correct_interval(&s3, &s4, true, &mut corrected);
+        totals.push(corrected[0]);
+
+        assert_eq!(totals, vec![4000, 6000, 6000, 6400]);
+        assert!(totals.windows(2).all(|w| w[1] >= w[0]), "a counter must never decrease");
+    }
+
+    /// `account` reports each interval on its own; the caller is the one tracking streaks.
+    #[test]
+    fn account_reports_the_interval_and_degrades_accuracy() {
+        use super::{Accuracy, Interval, Scaling};
+        let mut scaling = Scaling::new(1);
+
+        assert_eq!(scaling.account(snap(SEC, SEC, &[10]), true), Interval::Exact);
+        // a starved interval is reported as such every time it happens, without any streak state
+        assert_eq!(scaling.account(snap(2 * SEC, SEC, &[10]), true), Interval::Starved);
+        assert_eq!(scaling.account(snap(3 * SEC, SEC, &[10]), true), Interval::Starved);
+        assert_eq!(
+            scaling.accuracy(),
+            Accuracy::Underestimated,
+            "a starved interval misses data, so the total is underestimated"
+        );
+    }
+
+    /// The accuracy only ever degrades, and a starvation makes it worse than a mere extrapolation.
+    #[test]
+    fn accuracy_degrades_to_the_worst_interval() {
+        use super::{Accuracy, Scaling};
+
+        let mut scaling = Scaling::new(1);
+        assert_eq!(scaling.accuracy(), Accuracy::Exact);
+
+        scaling.account(snap(SEC, SEC, &[10]), true); // exact
+        assert_eq!(scaling.accuracy(), Accuracy::Exact);
+
+        scaling.account(snap(2 * SEC, SEC + SEC / 2, &[20]), true); // multiplexed, auto-scaled
+        assert_eq!(scaling.accuracy(), Accuracy::Extrapolated);
+
+        scaling.account(snap(3 * SEC, SEC + SEC / 2, &[20]), true); // starved
+        assert_eq!(scaling.accuracy(), Accuracy::Underestimated);
+
+        scaling.account(snap(4 * SEC, 2 * SEC + SEC / 2, &[30]), true); // exact again
+        assert_eq!(scaling.accuracy(), Accuracy::Underestimated, "accuracy never improves");
+    }
+
+    /// Without auto-scaling, a multiplexed interval is reported raw, hence underestimated.
+    #[test]
+    fn accuracy_is_underestimated_without_auto_scale() {
+        use super::{Accuracy, Scaling};
+
+        let mut scaling = Scaling::new(1);
+        scaling.account(snap(SEC, SEC / 2, &[10]), false); // multiplexed, not scaled
+        assert_eq!(scaling.accuracy(), Accuracy::Underestimated);
+    }
+}

--- a/plugins/perf/src/multiplexing.rs
+++ b/plugins/perf/src/multiplexing.rs
@@ -1,0 +1,333 @@
+//! Compensation for perf counter multiplexing.
+//!
+//! A CPU only has a handful of hardware counters. When more events are requested than it can hold,
+//! the kernel multiplexes them: a group is only on the PMU during a fraction `running / enabled` of
+//! the time we asked it to count, and its raw values are underestimated by that same fraction.
+//!
+//! The correction is applied to each polling interval, not to the whole lifetime of the group, so
+//! that an interval whose rate is overestimated cannot make the corrected value go backwards later
+//! on: the metrics are monotonic counters, they must never decrease.
+
+/// One read of a group.
+///
+/// The kernel reports cumulative values, never reset, hence the need to keep the previous read
+/// around and to work on differences.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct Snapshot {
+    /// For how long we asked the group to count, in nanoseconds.
+    ///
+    /// Beware: this is *not* wall clock time. It only advances while the observed entity (process
+    /// or cgroup) is actually running on a CPU. A sleeping process makes both times stand still.
+    pub time_enabled: u128,
+    /// For how long the group was really on the PMU, in nanoseconds.
+    pub time_running: u128,
+    /// Raw counter values, in the same order as the group's counters.
+    pub values: Vec<u64>,
+}
+
+/// What happened to a group during one polling interval.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum Interval {
+    /// The observed entity did not run at all: nothing happened, and nothing had to be counted.
+    Idle,
+    /// The group was on the PMU for the whole interval: the values are exact.
+    Exact,
+    /// The group was only on the PMU for part of the interval.
+    Multiplexed { running: u128, enabled: u128 },
+    /// The entity ran but the group never made it onto the PMU: everything that happened during the
+    /// interval was missed, and there is nothing to extrapolate from.
+    /// This can happen for many reasons, such as having too many counters in a single group, or (on
+    /// hybrid CPUs) a group bound to one PMU while the entity runs on the other PMU.
+    Starved,
+}
+
+/// How faithful a reported (cumulative) value is.
+///
+/// This describes the whole value reported so far, not the last interval, because the value is a
+/// cumulative counter. It therefore only ever degrades (`exact` -> `extrapolated` -> `underestimated`)
+/// and never improves: a single imperfect interval taints every value reported afterwards. The
+/// variants are ordered from best to worst so that [`Accuracy::max`] keeps the worst seen.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum Accuracy {
+    /// Every interval was counted exactly.
+    #[default]
+    Exact,
+    /// At least one multiplexed interval was extrapolated (only in `auto_scale` mode). The value is
+    /// an estimate, which may be slightly above or below the truth.
+    Extrapolated,
+    /// The value is known to be too low: either multiplexed intervals were kept raw (no
+    /// `auto_scale`), or some intervals were missed entirely (the group was starved).
+    Underestimated,
+}
+
+impl Accuracy {
+    /// The value used for the `accuracy` measurement attribute.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Accuracy::Exact => "exact",
+            Accuracy::Extrapolated => "extrapolated",
+            Accuracy::Underestimated => "underestimated",
+        }
+    }
+}
+
+/// Multiplexing correction state of one group.
+///
+/// The kernel schedules a group atomically: either all of its counters are on the PMU, or none of
+/// them are. Every counter of a group therefore shares the same `time_enabled`/`time_running`, and
+/// a single correction applies to all of them.
+#[derive(Debug, Default)]
+pub(crate) struct GroupCounters {
+    /// Previous read. Starts at zero: when the group is enabled it has counted nothing, during no
+    /// time at all, so the first poll is an interval like any other.
+    prev: Snapshot,
+    /// Corrected cumulative value of each counter, in the same order as the group's counters.
+    corrected: Vec<u64>,
+    /// Faithfulness of the reported values so far. Only ever degrades, see [`Accuracy`].
+    accuracy: Accuracy,
+}
+
+impl GroupCounters {
+    pub fn new(n_counters: usize) -> Self {
+        Self {
+            prev: Snapshot {
+                time_enabled: 0,
+                time_running: 0,
+                values: vec![0; n_counters],
+            },
+            corrected: vec![0; n_counters],
+            accuracy: Accuracy::Exact,
+        }
+    }
+
+    /// Corrected cumulative value of each counter, in the same order as the group's counters.
+    pub fn corrected(&self) -> &[u64] {
+        &self.corrected
+    }
+
+    /// Faithfulness of the reported values so far. See [`Accuracy`]: it only ever degrades.
+    pub fn accuracy(&self) -> Accuracy {
+        self.accuracy
+    }
+
+    /// Accounts for a new reading, updating the corrected totals, and returns what happened during
+    /// the interval.
+    pub fn account(&mut self, now: Snapshot, auto_scale: bool) -> Interval {
+        let interval = correct_interval(&self.prev, &now, auto_scale, &mut self.corrected);
+        let interval_accuracy = match interval {
+            Interval::Idle | Interval::Exact => Accuracy::Exact,
+            Interval::Multiplexed { .. } if auto_scale => Accuracy::Extrapolated,
+            // multiplexed without auto-scaling, or a starved interval that could not be extrapolated
+            Interval::Multiplexed { .. } | Interval::Starved => Accuracy::Underestimated,
+        };
+        self.accuracy = self.accuracy.max(interval_accuracy);
+        self.prev = now;
+        interval
+    }
+}
+
+/// Adds the (possibly corrected) contribution of one polling interval to `corrected`, and reports
+/// what happened. See the [module documentation](self) for the rationale.
+fn correct_interval(prev: &Snapshot, now: &Snapshot, auto_scale: bool, corrected: &mut [u64]) -> Interval {
+    let d_enabled = now.time_enabled.saturating_sub(prev.time_enabled);
+    let d_running = now.time_running.saturating_sub(prev.time_running);
+
+    if d_enabled == 0 {
+        return Interval::Idle;
+    }
+    if d_running == 0 {
+        // Nothing was counted, so there is nothing to extrapolate from.
+        return Interval::Starved;
+    }
+
+    let multiplexed = d_running < d_enabled;
+    for (i, total) in corrected.iter_mut().enumerate() {
+        let delta = u128::from(now.values[i].saturating_sub(prev.values[i]));
+        let contribution = if multiplexed && auto_scale {
+            // Rule of three: `delta` events were counted during `d_running`, estimate how many
+            // occurred during the whole `d_enabled`.
+            delta * d_enabled / d_running
+        } else {
+            delta
+        };
+        *total = total.saturating_add(u64::try_from(contribution).unwrap_or(u64::MAX));
+    }
+
+    if multiplexed {
+        Interval::Multiplexed {
+            running: d_running,
+            enabled: d_enabled,
+        }
+    } else {
+        Interval::Exact
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Interval, Snapshot, correct_interval};
+
+    const SEC: u128 = 1_000_000_000;
+
+    fn snap(enabled: u128, running: u128, values: &[u64]) -> Snapshot {
+        Snapshot {
+            time_enabled: enabled,
+            time_running: running,
+            values: values.to_vec(),
+        }
+    }
+
+    /// When the group is enabled, everything is zero, so the first poll is an interval like any
+    /// other and must be corrected too.
+    #[test]
+    fn first_poll_is_an_interval_like_any_other() {
+        let mut corrected = vec![0];
+        let interval = correct_interval(&snap(0, 0, &[0]), &snap(SEC, SEC / 4, &[1000]), true, &mut corrected);
+        assert_eq!(
+            interval,
+            Interval::Multiplexed {
+                running: SEC / 4,
+                enabled: SEC
+            }
+        );
+        // counted 1000 while on the PMU a quarter of the time
+        assert_eq!(corrected, vec![4000]);
+    }
+
+    #[test]
+    fn exact_when_running_equals_enabled() {
+        let mut corrected = vec![0];
+        let interval = correct_interval(&snap(0, 0, &[0]), &snap(SEC, SEC, &[1000]), true, &mut corrected);
+        assert_eq!(interval, Interval::Exact);
+        assert_eq!(corrected, vec![1000]);
+    }
+
+    /// The observed entity did not run: both times stand still. This is the most common case and it
+    /// must not be mistaken for a starved group.
+    #[test]
+    fn idle_entity_changes_nothing() {
+        let mut corrected = vec![1000];
+        let prev = snap(SEC, SEC, &[1000]);
+        let interval = correct_interval(&prev, &prev.clone(), true, &mut corrected);
+        assert_eq!(interval, Interval::Idle);
+        assert_eq!(corrected, vec![1000]);
+    }
+
+    /// The entity ran but the group never made it onto the PMU. Dividing by `d_running` here would
+    /// panic, and there is nothing to extrapolate from anyway.
+    #[test]
+    fn starved_group_does_not_divide_by_zero() {
+        let mut corrected = vec![1000];
+        let prev = snap(SEC, SEC / 4, &[1000]);
+        let now = snap(2 * SEC, SEC / 4, &[1000]);
+        let interval = correct_interval(&prev, &now, true, &mut corrected);
+        assert_eq!(interval, Interval::Starved);
+        assert_eq!(corrected, vec![1000], "the total must stay flat, not be made up");
+    }
+
+    #[test]
+    fn without_auto_scale_the_raw_delta_is_kept() {
+        let mut corrected = vec![0];
+        let interval = correct_interval(&snap(0, 0, &[0]), &snap(SEC, SEC / 4, &[1000]), false, &mut corrected);
+        assert_eq!(
+            interval,
+            Interval::Multiplexed {
+                running: SEC / 4,
+                enabled: SEC
+            },
+            "multiplexing is still reported, it is just not compensated"
+        );
+        assert_eq!(corrected, vec![1000]);
+    }
+
+    #[test]
+    fn every_counter_of_the_group_is_corrected() {
+        let mut corrected = vec![0, 0, 0];
+        correct_interval(
+            &snap(0, 0, &[0, 0, 0]),
+            &snap(SEC, SEC / 2, &[10, 20, 30]),
+            true,
+            &mut corrected,
+        );
+        assert_eq!(corrected, vec![20, 40, 60]);
+    }
+
+    /// Each interval is corrected on its own and added to a total that only ever grows, so that a
+    /// badly extrapolated interval cannot make the counter go backwards later on.
+    #[test]
+    fn totals_accumulate_and_never_decrease() {
+        let mut corrected = vec![0];
+        let mut totals = Vec::new();
+
+        // poll 1: 1000 counted over a quarter of a second of PMU time -> 4000
+        let s1 = snap(SEC, SEC / 4, &[1000]);
+        correct_interval(&snap(0, 0, &[0]), &s1, true, &mut corrected);
+        totals.push(corrected[0]);
+
+        // poll 2: +500 counted over another quarter -> +2000
+        let s2 = snap(2 * SEC, SEC / 2, &[1500]);
+        correct_interval(&s1, &s2, true, &mut corrected);
+        totals.push(corrected[0]);
+
+        // poll 3: the group is starved, nothing is added
+        let s3 = snap(3 * SEC, SEC / 2, &[1500]);
+        correct_interval(&s2, &s3, true, &mut corrected);
+        totals.push(corrected[0]);
+
+        // poll 4: +200 counted over half a second -> +400
+        let s4 = snap(4 * SEC, SEC, &[1700]);
+        correct_interval(&s3, &s4, true, &mut corrected);
+        totals.push(corrected[0]);
+
+        assert_eq!(totals, vec![4000, 6000, 6000, 6400]);
+        assert!(totals.windows(2).all(|w| w[1] >= w[0]), "a counter must never decrease");
+    }
+
+    /// `account` reports each interval on its own; the caller is the one tracking streaks.
+    #[test]
+    fn account_reports_the_interval_and_degrades_accuracy() {
+        use super::{Accuracy, GroupCounters, Interval};
+        let mut scaling = GroupCounters::new(1);
+
+        assert_eq!(scaling.account(snap(SEC, SEC, &[10]), true), Interval::Exact);
+        // a starved interval is reported as such every time it happens, without any streak state
+        assert_eq!(scaling.account(snap(2 * SEC, SEC, &[10]), true), Interval::Starved);
+        assert_eq!(scaling.account(snap(3 * SEC, SEC, &[10]), true), Interval::Starved);
+        assert_eq!(
+            scaling.accuracy(),
+            Accuracy::Underestimated,
+            "a starved interval misses data, so the total is underestimated"
+        );
+    }
+
+    /// The accuracy only ever degrades, and a starvation makes it worse than a mere extrapolation.
+    #[test]
+    fn accuracy_degrades_to_the_worst_interval() {
+        use super::{Accuracy, GroupCounters};
+
+        let mut scaling = GroupCounters::new(1);
+        assert_eq!(scaling.accuracy(), Accuracy::Exact);
+
+        scaling.account(snap(SEC, SEC, &[10]), true); // exact
+        assert_eq!(scaling.accuracy(), Accuracy::Exact);
+
+        scaling.account(snap(2 * SEC, SEC + SEC / 2, &[20]), true); // multiplexed, auto-scaled
+        assert_eq!(scaling.accuracy(), Accuracy::Extrapolated);
+
+        scaling.account(snap(3 * SEC, SEC + SEC / 2, &[20]), true); // starved
+        assert_eq!(scaling.accuracy(), Accuracy::Underestimated);
+
+        scaling.account(snap(4 * SEC, 2 * SEC + SEC / 2, &[30]), true); // exact again
+        assert_eq!(scaling.accuracy(), Accuracy::Underestimated, "accuracy never improves");
+    }
+
+    /// Without auto-scaling, a multiplexed interval is reported raw, hence underestimated.
+    #[test]
+    fn accuracy_is_underestimated_without_auto_scale() {
+        use super::{Accuracy, GroupCounters};
+
+        let mut scaling = GroupCounters::new(1);
+        scaling.account(snap(SEC, SEC / 2, &[10]), false); // multiplexed, not scaled
+        assert_eq!(scaling.accuracy(), Accuracy::Underestimated);
+    }
+}

--- a/plugins/perf/src/source.rs
+++ b/plugins/perf/src/source.rs
@@ -11,6 +11,7 @@ use anyhow::Context;
 use itertools::Itertools;
 
 use crate::cpu;
+use crate::multiplexing::{Scaling, Snapshot};
 
 #[derive(Debug)]
 pub enum Observable {
@@ -27,6 +28,8 @@ pub enum Observable {
 
 pub struct PerfEventSource {
     event_groups: Vec<EventGroup>,
+    /// See [`Config::multiplexing_auto_scale`](crate::Config).
+    multiplexing_auto_scale: bool,
 }
 
 struct EventGroup {
@@ -35,35 +38,81 @@ struct EventGroup {
     observed_consumer: ResourceConsumer,
     cpu_id: Option<u32>,
     counters: Vec<(perf_event::Counter, TypedMetricId<u64>)>,
+    scaling: Scaling,
+    /// Whether the previous poll found the group starved, so that we only warn on the transition
+    /// into starvation and not on every poll while it lasts.
+    starved: bool,
+}
+
+impl EventGroup {
+    /// Reads the group, updates the corrected cumulative value of each of its counters, and logs
+    /// anything worth reporting about the multiplexing.
+    fn read_and_correct(&mut self, auto_scale: bool) -> Result<(), PollError> {
+        use crate::multiplexing::Interval;
+
+        let counts = self.perf_group.read()?;
+
+        // Always available: `new_group_builder` asks for TOTAL_TIME_ENABLED and TOTAL_TIME_RUNNING.
+        let (Some(time_enabled), Some(time_running)) = (counts.time_enabled(), counts.time_running()) else {
+            return Err(PollError::Fatal(anyhow::anyhow!(
+                "perf_events did not report time_enabled/time_running, which are required to detect multiplexing"
+            )));
+        };
+        let now = Snapshot {
+            time_enabled: time_enabled.as_nanos(),
+            time_running: time_running.as_nanos(),
+            values: self.counters.iter().map(|(counter, _)| counts[counter]).collect(),
+        };
+
+        let interval = self.scaling.account(now, auto_scale);
+        // Only warn on the transition: starvation can last for the whole lifetime of the source.
+        let just_starved = interval == Interval::Starved && !self.starved;
+        self.starved = interval == Interval::Starved;
+        match interval {
+            Interval::Idle | Interval::Exact => (),
+            Interval::Multiplexed { running, enabled } => {
+                log::debug!(
+                    "perf group of {:?} (cpu {:?}) was only on the PMU {:.1}% of the time, its values are {}",
+                    self.observed_consumer,
+                    self.cpu_id,
+                    100.0 * (running as f64) / (enabled as f64),
+                    if auto_scale { "extrapolated" } else { "underestimated" },
+                );
+            }
+            Interval::Starved if just_starved => {
+                log::warn!(
+                    "perf group of {:?} (cpu {:?}) ran but never made it onto the PMU, its counters are stalled. \
+                     Possible causes: more events configured than the CPU has hardware counters, another tool \
+                     using the PMU system-wide, or a CPU whose PMU does not provide these events (on hybrid CPUs, \
+                     generic events are only available on some cores).",
+                    self.observed_consumer,
+                    self.cpu_id,
+                );
+            }
+            Interval::Starved => (),
+        }
+        Ok(())
+    }
 }
 
 impl Source for PerfEventSource {
     fn poll(&mut self, measurements: &mut MeasurementAccumulator, timestamp: Timestamp) -> Result<(), PollError> {
+        let auto_scale = self.multiplexing_auto_scale;
         for group in &mut self.event_groups {
-            // read all counters in the group
-            let counts = group.perf_group.read()?;
+            // read all counters in the group and account for the multiplexing
+            group.read_and_correct(auto_scale)?;
 
             // get some metadata about the measurement perimeter
             let resource = &group.observed_resource;
             let consumer = &group.observed_consumer;
+            let accuracy = group.scaling.accuracy().as_str();
 
-            // TODO: check time_enabled and time_running to detect issues
-            log::trace!(
-                "Got perf_events measurements: time_enabled={:?}, time_running={:?}",
-                counts.time_enabled(),
-                counts.time_running()
-            );
-
-            // for each counter, push its value
-            for (perf_counter, alumet_metric) in &group.counters {
-                let value = counts[perf_counter];
-                measurements.push(MeasurementPoint::new(
-                    timestamp,
-                    *alumet_metric,
-                    resource.clone(),
-                    consumer.clone(),
-                    value,
-                ))
+            // for each counter, push its value (the two vecs are in the same order by construction)
+            for ((_, alumet_metric), value) in group.counters.iter().zip(group.scaling.corrected()) {
+                measurements.push(
+                    MeasurementPoint::new(timestamp, *alumet_metric, resource.clone(), consumer.clone(), *value)
+                        .with_attr("accuracy", accuracy),
+                )
             }
         }
         Ok(())
@@ -78,14 +127,17 @@ pub struct PerfEventSourceBuilder {
     groups: Vec<EventGroup>,
     /// The available CPUs to monitor.
     online_cpus: Vec<u32>,
+    /// See [`Config::multiplexing_auto_scale`](crate::Config).
+    multiplexing_auto_scale: bool,
 }
 
 impl PerfEventSourceBuilder {
-    pub fn observe(observable: Observable) -> anyhow::Result<Self> {
+    pub fn observe(observable: Observable, multiplexing_auto_scale: bool) -> anyhow::Result<Self> {
         Ok(Self {
             observable,
             groups: Vec::new(),
             online_cpus: cpu::online_cpus().context("could not detect online CPUs")?,
+            multiplexing_auto_scale,
         })
     }
 
@@ -133,6 +185,9 @@ impl PerfEventSourceBuilder {
                         },
                         cpu_id: None,
                         counters: vec![(counter, alumet_metric)],
+                        // properly sized in build(), once all the events have been added
+                        scaling: Scaling::default(),
+                        starved: false,
                     };
 
                     // done
@@ -170,6 +225,9 @@ impl PerfEventSourceBuilder {
                             },
                             cpu_id: None,
                             counters: vec![(counter, alumet_metric)],
+                            // properly sized in build(), once all the events have been added
+                            scaling: Scaling::default(),
+                            starved: false,
                         };
                         groups.push(group_with_info);
                     }
@@ -215,11 +273,15 @@ impl PerfEventSourceBuilder {
                 .join(", ")
         );
         for group in &mut self.groups {
+            // All the events have been added, the number of counters is now known.
+            group.scaling = Scaling::new(group.counters.len());
             group.perf_group.enable()?;
         }
 
         Ok(PerfEventSource {
             event_groups: self.groups,
+            multiplexing_auto_scale: self.multiplexing_auto_scale,
         })
     }
 }
+

--- a/plugins/perf/src/source.rs
+++ b/plugins/perf/src/source.rs
@@ -11,6 +11,7 @@ use anyhow::Context;
 use itertools::Itertools;
 
 use crate::cpu;
+use crate::multiplexing::{GroupCounters, Snapshot};
 use crate::spec::ConfiguredEvent;
 
 #[derive(Debug)]
@@ -28,6 +29,7 @@ pub enum Observable {
 
 pub struct PerfEventSource {
     event_groups: Vec<EventGroup>,
+    multiplexing_auto_scale: bool,
 }
 
 struct EventGroup {
@@ -36,35 +38,82 @@ struct EventGroup {
     observed_consumer: ResourceConsumer,
     cpu_id: Option<u32>,
     counters: Vec<(perf_event::Counter, TypedMetricId<u64>)>,
+    scaling: GroupCounters,
+    /// Whether the previous poll found the group starved, so that we only warn on the transition
+    /// into starvation and not on every poll while it lasts.
+    starved: bool,
+}
+
+impl EventGroup {
+    /// Reads the group, updates the corrected cumulative value of each of its counters, and logs
+    /// anything worth reporting about the multiplexing.
+    fn read_and_correct(&mut self, auto_scale: bool) -> Result<(), PollError> {
+        use crate::multiplexing::Interval;
+
+        let counts = self.perf_group.read()?;
+
+        // Always available: `new_group_builder` asks for TOTAL_TIME_ENABLED and TOTAL_TIME_RUNNING.
+        let (Some(time_enabled), Some(time_running)) = (counts.time_enabled(), counts.time_running()) else {
+            return Err(PollError::Fatal(anyhow::anyhow!(
+                "perf_events did not report time_enabled/time_running, which are required to detect multiplexing"
+            )));
+        };
+        let now = Snapshot {
+            time_enabled: time_enabled.as_nanos(),
+            time_running: time_running.as_nanos(),
+            values: self.counters.iter().map(|(counter, _)| counts[counter]).collect(),
+        };
+
+        let interval = self.scaling.account(now, auto_scale);
+        // Only warn on the transition: starvation can last for the whole lifetime of the source.
+        let starved = interval == Interval::Starved;
+        let just_starved = starved && !self.starved;
+        self.starved = starved;
+        match interval {
+            Interval::Idle | Interval::Exact => (),
+            Interval::Multiplexed { running, enabled } => {
+                log::debug!(
+                    "perf group of {:?} (cpu {:?}) was only on the PMU {:.1}% of the time, its values are {}",
+                    self.observed_consumer,
+                    self.cpu_id,
+                    100.0 * (running as f64) / (enabled as f64),
+                    if auto_scale { "extrapolated" } else { "underestimated" },
+                );
+            }
+            Interval::Starved if just_starved => {
+                log::warn!(
+                    "perf group of {:?} (cpu {:?}) ran but never made it onto the PMU, its counters are stalled. \
+                     Possible causes: more events configured than the CPU has hardware counters, another tool \
+                     using the PMU system-wide, or a CPU whose PMU does not provide these events (on hybrid CPUs, \
+                     generic events are only available on some cores).",
+                    self.observed_consumer,
+                    self.cpu_id,
+                );
+            }
+            Interval::Starved => (),
+        }
+        Ok(())
+    }
 }
 
 impl Source for PerfEventSource {
     fn poll(&mut self, measurements: &mut MeasurementAccumulator, timestamp: Timestamp) -> Result<(), PollError> {
+        let auto_scale = self.multiplexing_auto_scale;
         for group in &mut self.event_groups {
-            // read all counters in the group
-            let counts = group.perf_group.read()?;
+            // read all counters in the group and account for the multiplexing
+            group.read_and_correct(auto_scale)?;
 
             // get some metadata about the measurement perimeter
             let resource = &group.observed_resource;
             let consumer = &group.observed_consumer;
+            let accuracy = group.scaling.accuracy().as_str();
 
-            // TODO: check time_enabled and time_running to detect issues
-            log::trace!(
-                "Got perf_events measurements: time_enabled={:?}, time_running={:?}",
-                counts.time_enabled(),
-                counts.time_running()
-            );
-
-            // for each counter, push its value
-            for (perf_counter, alumet_metric) in &group.counters {
-                let value = counts[perf_counter];
-                measurements.push(MeasurementPoint::new(
-                    timestamp,
-                    *alumet_metric,
-                    resource.clone(),
-                    consumer.clone(),
-                    value,
-                ))
+            // for each counter, push its value (the two vecs are in the same order by construction)
+            for ((_, alumet_metric), value) in group.counters.iter().zip(group.scaling.corrected()) {
+                measurements.push(
+                    MeasurementPoint::new(timestamp, *alumet_metric, resource.clone(), consumer.clone(), *value)
+                        .with_attr("accuracy", accuracy),
+                )
             }
         }
         Ok(())
@@ -79,14 +128,17 @@ pub struct PerfEventSourceBuilder {
     groups: Vec<EventGroup>,
     /// The available CPUs to monitor.
     online_cpus: Vec<u32>,
+    /// Activate auto_scaling in case of detected multiplexing
+    multiplexing_auto_scale: bool,
 }
 
 impl PerfEventSourceBuilder {
-    pub fn observe(observable: Observable) -> anyhow::Result<Self> {
+    pub fn observe(observable: Observable, multiplexing_auto_scale: bool) -> anyhow::Result<Self> {
         Ok(Self {
             observable,
             groups: Vec::new(),
             online_cpus: cpu::online_cpus().context("could not detect online CPUs")?,
+            multiplexing_auto_scale,
         })
     }
 
@@ -133,6 +185,8 @@ impl PerfEventSourceBuilder {
                         },
                         cpu_id: None,
                         counters: vec![(counter, alumet_metric)],
+                        scaling: GroupCounters::default(),
+                        starved: false,
                     };
 
                     // done
@@ -169,6 +223,8 @@ impl PerfEventSourceBuilder {
                             },
                             cpu_id: Some(cpu_id as u32),
                             counters: vec![(counter, alumet_metric)],
+                            scaling: GroupCounters::default(),
+                            starved: false,
                         };
                         groups.push(group_with_info);
                     }
@@ -215,11 +271,14 @@ impl PerfEventSourceBuilder {
                 .join(", ")
         );
         for group in &mut self.groups {
+            // All the events have been added, the number of counters is now known.
+            group.scaling = GroupCounters::new(group.counters.len());
             group.perf_group.enable()?;
         }
 
         Ok(PerfEventSource {
             event_groups: self.groups,
+            multiplexing_auto_scale: self.multiplexing_auto_scale,
         })
     }
 }


### PR DESCRIPTION
Introduce a new attribute that give accuracy of the time series depending on whether or not the series had counters multiplexed.

Multiplexing happens when there is no more generic counter slot available.

The PR also introduce a new config that allow to compensate the counter value in case of multiplexing, by infering the value based on the time_running and time_enabled of the counter. 