### PR TITLE
Test/brseed 1341 e2e test container

### DIFF
--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -5,7 +5,11 @@ export
 
 # version of Alumet to installed
 ALUMET_VERSION=0.9.4
+# version 1_amd64_ubuntu_22.04 fonctionne pour baremetal
+#ALUMET_DISTRIBUTION=1_amd64_ubuntu_22.04
+#version pour container
 ALUMET_DISTRIBUTION=1_ubuntu_24.04
+
 
 REQUIRED_VARS := NODE GATEWAY USERNAME KEY 
 
@@ -66,8 +70,11 @@ test: check-required-vars
         --metadata "Alumet version":$(ALUMET_VERSION) \
 		--metadata "Alumet distribution":$(ALUMET_DISTRIBUTION) \
 		--metadata "Environnement target node":$(NODE) \
-        ./scenarios/container
-
+		./scenarios/container/
+		#./scenarios/container/plugin-perf.robot
+        #./scenarios/baremetal/
+		#./scenarios/container/
+        #./scenarios/baremetal/plugin-rapl.robot
 
 unused:
 	for type in arguments files keywords returns variables; do \

--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -5,11 +5,11 @@ export
 
 # version of Alumet to installed
 ALUMET_VERSION=0.9.4
-# version 1_amd64_ubuntu_22.04 fonctionne pour baremetal
-#ALUMET_DISTRIBUTION=1_amd64_ubuntu_22.04
-#version pour container
-ALUMET_DISTRIBUTION=1_ubuntu_24.04
-
+# distribution of Alumet to installed
+# Note that all versions are not available as docker images; for example version 22.04 is not available for ubuntu, but 24.04 is.
+# For this version of integration test, we test only the OCI images.
+ALUMET_DISTRIBUTION=ubuntu_24.04
+ALUMET_ARCHITECTURE=amd64
 
 REQUIRED_VARS := NODE GATEWAY USERNAME KEY 
 
@@ -17,10 +17,11 @@ all: init test
 
 help:
 	@echo "Current test set-up:"
-	@echo "  ALUMET_VERSION         $(ALUMET_VERSION)"
-	@echo "  ALUMET_DISTRIBUTION    $(ALUMET_DISTRIBUTION)"	
-	@echo "  Target node            $(NODE)"
-	@echo "  Modify the variables ALUMET_VERSION, ALUMET_DISTRIBUTION in this Makefile if you want to modify the set-up"
+	@echo "  ALUMET_VERSION         	$(ALUMET_VERSION)"
+	@echo "  ALUMET_DISTRIBUTION    	$(ALUMET_DISTRIBUTION)"
+	@echo "  ALUMET_ARCHITECTECTURE    	$(ALUMET_ARCHITECTECTURE)"
+	@echo "  Target node            	$(NODE)"
+	@echo "  Modify the variables ALUMET_VERSION, ALUMET_DISTRIBUTION, ALUMET_ARCHITECTURE in this Makefile if you want to modify the set-up"
 	@echo "  Modify the variables NODE, GATEWAY, USERNAME, KEY in the .env file if you want to modify the set-up"
 
 	@echo "Available commands:"
@@ -53,11 +54,16 @@ lint:
 
 test: check-required-vars
 	@echo "Current test set-up:"
-	@echo "  ALUMET_VERSION         $(ALUMET_VERSION)"
-	@echo "  ALUMET_DISTRIBUTION    $(ALUMET_DISTRIBUTION)"	
-	@echo "  Target node            $(NODE)"
-	@echo "  Modify the variables ALUMET_VERSION, ALUMET_DISTRIBUTION in this Makefile if you want to modify the set-up"
+	@echo "  ALUMET_VERSION         	$(ALUMET_VERSION)"
+	@echo "  ALUMET_DISTRIBUTION    	$(ALUMET_DISTRIBUTION)"	
+	@echo "  ALUMET_ARCHITECTECTURE    	$(ALUMET_ARCHITECTECTURE)"	
+	@echo "  Target node            	$(NODE)"
+	@echo "  Modify the variables ALUMET_VERSION, ALUMET_DISTRIBUTION, ALUMET_ARCHITECTURE in this Makefile if you want to modify the set-up"
 	@echo "  Modify the variables NODE, GATEWAY, USERNAME, KEY in the .env file if you want to modify the set-up"
+
+	# Note: to exclude some tests you can:
+	# scpecify a path to a file or a directory /subdirectory (./scenario/container for example)
+	# or add the option --exclude {tag name} to robot command
 
 	poetry run robot \
 		--outputdir ./output \
@@ -67,14 +73,12 @@ test: check-required-vars
         -v "KEY:$(KEY)" \
         -v "ALUMET_VERSION:$(ALUMET_VERSION)" \
         -v "ALUMET_DISTRIBUTION:$(ALUMET_DISTRIBUTION)" \
+		-v "ALUMET_ARCHITECTURE:$(ALUMET_ARCHITECTURE)" \
         --metadata "Alumet version":$(ALUMET_VERSION) \
 		--metadata "Alumet distribution":$(ALUMET_DISTRIBUTION) \
+		--metadata "Alumet architecture":$(ALUMET_ARCHITECTURE) \
 		--metadata "Environnement target node":$(NODE) \
-		./scenarios/container/
-		#./scenarios/container/plugin-perf.robot
-        #./scenarios/baremetal/
-		#./scenarios/container/
-        #./scenarios/baremetal/plugin-rapl.robot
+		./scenarios/
 
 unused:
 	for type in arguments files keywords returns variables; do \

--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -5,7 +5,7 @@ export
 
 # version of Alumet to installed
 ALUMET_VERSION=0.9.4
-ALUMET_DISTRIBUTION=1_amd64_ubuntu_22.04
+ALUMET_DISTRIBUTION=1_ubuntu_24.04
 
 REQUIRED_VARS := NODE GATEWAY USERNAME KEY 
 
@@ -66,7 +66,7 @@ test: check-required-vars
         --metadata "Alumet version":$(ALUMET_VERSION) \
 		--metadata "Alumet distribution":$(ALUMET_DISTRIBUTION) \
 		--metadata "Environnement target node":$(NODE) \
-        ./scenarios/
+        ./scenarios/container
 
 
 unused:

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -4,7 +4,6 @@ This folder contains all script files and scenarios for testing alumet.
 Below, the structure of this folder.
 
 ```text
-
 ├── Makefile
 ├── output
 │   ├── log.html
@@ -18,8 +17,12 @@ Below, the structure of this folder.
     │   ├── installation.robot
     │   ├── plugin-perf.robot
     │   └── plugin-rapl.robot
-    ├── common
+    ├── container
+    │   ├── installation.robot
+    │   ├── plugin-perf.robot
+    │   └── plugin-rapl.robot
     ├── resources
+    │   ├── alumet-config.toml
     │   ├── alumet_keywords.resource
     │   ├── help-config-option.txt
     │   ├── help-exec-option.txt
@@ -31,7 +34,7 @@ Below, the structure of this folder.
 ```
 
 `scenarios` folder contains all robotframework files.
-One folder per type of test, for example we have `baremetal` folder regarding the test of alumet installed in native mode. For future test, we should have a `container` folder for example.
+One folder per type of test, for example we have `baremetal` folder regarding the test of alumet installed in native mode, `container` folder regarding the test of alumet docker images.
 
 `resources` folder is for keywords that are used by several test suite.
 
@@ -57,8 +60,26 @@ make init
 
 ## Run the tests
 
-The \_\_init\_\_.robot file contains the Suite Setup (Install Alumet) and Teardown (UnInstall Alumet). When this file is present,  robot framework executes at the beginning of the tests the keyword `Install Alumet` and at the end of test execution the keyword `UnInstall alumet`
-Each test can have one or several tags allowing the exclusion of tests from being run by robot framework.
+The \_\_init\_\_.robot file contains the Suite Setup (Install Alumet) and Teardown (UnInstall Alumet). When this file is present,  robot framework executes at the beginning of the tests the keyword `Install Alumet` and at the end of test execution the keyword `UnInstall alumet`.
+Each test can have one or several tags allowing the exclusion of tests from being run by robot framework. For example, use the tag `baremetal` to exclude tests with alumet installation on baremetal. You need to edit the `Makefile` and modify the target test to add the tag you want to exclude (see line 81 below). You can also modify the path of scenarios to be executed to restric to a folder/sub folder or a file (see line 82 below):
+
+```text
+ 68         poetry run robot \
+ 69                 --outputdir ./output \
+ 70                 -v "NODE:$(NODE)"       \
+ 71         -v "GATEWAY:$(GATEWAY)" \
+ 72         -v "USERNAME:$(USERNAME)" \
+ 73         -v "KEY:$(KEY)" \
+ 74         -v "ALUMET_VERSION:$(ALUMET_VERSION)" \
+ 75         -v "ALUMET_DISTRIBUTION:$(ALUMET_DISTRIBUTION)" \
+ 76                 -v "ALUMET_ARCHITECTURE:$(ALUMET_ARCHITECTURE)" \
+ 77         --metadata "Alumet version":$(ALUMET_VERSION) \
+ 78                 --metadata "Alumet distribution":$(ALUMET_DISTRIBUTION) \
+ 79                 --metadata "Alumet architecture":$(ALUMET_ARCHITECTURE) \
+ 80                 --metadata "Environnement target node":$(NODE) \
+ 81                 --exclude baremetal \
+ 82                 ./scenarios/
+```
 
 To run the robot framework test scenarios execute the command:
 

--- a/integration-tests/pyproject.toml
+++ b/integration-tests/pyproject.toml
@@ -27,4 +27,4 @@ build-backend = "poetry.core.masonry.api"
 language = ["en"]
 
 [tool.robocop.lint]
-ignore = ["LEN01"]
+ignore = ["LEN01", "LEN03"]

--- a/integration-tests/scenarios/baremetal/__init__.robot
+++ b/integration-tests/scenarios/baremetal/__init__.robot
@@ -30,11 +30,11 @@ Install Alumet
 
     # first download the right linux package file, exit test suite if download error
     ${output}=    Run
-    ...    wget https://github.com/alumet-dev/alumet/releases/download/v${ALUMET_VERSION}/alumet-agent_${ALUMET_VERSION}-${ALUMET_DISTRIBUTION}.deb
+    ...    wget https://github.com/alumet-dev/alumet/releases/download/v${ALUMET_VERSION}/alumet-agent_${ALUMET_VERSION}-1_${ALUMET_ARCHITECTURE}_${ALUMET_DISTRIBUTION}.deb
     Log    output download package: ${output}
     ${exists}=    Run Keyword And Return Status
     ...    OperatingSystem.File Should Exist
-    ...    alumet-agent_${ALUMET_VERSION}-${ALUMET_DISTRIBUTION}.deb
+    ...    alumet-agent_${ALUMET_VERSION}-1_${ALUMET_ARCHITECTURE}_${ALUMET_DISTRIBUTION}.deb
     IF    not ${exists}
         Fail    'Error downloading alumet package file. Test suite is stopped'
     END
@@ -49,14 +49,14 @@ Install Alumet
 
     # copy linux package on remote host
     Put File
-    ...    alumet-agent_${ALUMET_VERSION}-${ALUMET_DISTRIBUTION}.deb
-    ...    alumet-agent_${ALUMET_VERSION}-${ALUMET_DISTRIBUTION}.deb
+    ...    alumet-agent_${ALUMET_VERSION}-1_${ALUMET_ARCHITECTURE}_${ALUMET_DISTRIBUTION}.deb
+    ...    alumet-agent_${ALUMET_VERSION}-1_${ALUMET_ARCHITECTURE}_${ALUMET_DISTRIBUTION}.deb
 
     # copy tools files
     Put File    scenarios/tools/cpu_load.sh    cpu_load.sh
 
     VAR    ${command}=    sudo DEBIAN_FRONTEND=noninteractive apt install -y
-    ...    ./alumet-agent_${ALUMET_VERSION}-${ALUMET_DISTRIBUTION}.deb
+    ...    ./alumet-agent_${ALUMET_VERSION}-1_${ALUMET_ARCHITECTURE}_${ALUMET_DISTRIBUTION}.deb
     # install alumet package
     ${output}=    Execute Command Target Node    ${command}
     Log    result: ${output}
@@ -111,22 +111,22 @@ UnInstall Alumet
 
     # remove alumet package file on target node
     ${result}    ${stderr}=    Execute Command Target Node
-    ...    rm alumet-agent_${ALUMET_VERSION}-${ALUMET_DISTRIBUTION}.deb*
+    ...    rm alumet-agent_${ALUMET_VERSION}-1_${ALUMET_ARCHITECTURE}_${ALUMET_DISTRIBUTION}.deb*
     Log    result: ${result}
     Log    stderr: ${stderr}
 
     ${result}    ${stderr}=    Execute Command Target Node
-    ...    ls -l alumet-agent_${ALUMET_VERSION}-${ALUMET_DISTRIBUTION}.deb*
+    ...    ls -l alumet-agent_${ALUMET_VERSION}-1_${ALUMET_ARCHITECTURE}_${ALUMET_DISTRIBUTION}.deb*
     Log    result: ${result}
     Log    stderr: ${stderr}
 
     Should Not Contain    ${result}    alumet
 
     # remove alumet package file downloaded locally
-    ${result}=    Run    rm alumet-agent_${ALUMET_VERSION}-${ALUMET_DISTRIBUTION}.deb*
+    ${result}=    Run    rm alumet-agent_${ALUMET_VERSION}-1_${ALUMET_ARCHITECTURE}_${ALUMET_DISTRIBUTION}.deb*
     Log    result: ${result}
 
-    ${result}=    Run    ls -l alumet-agent_${ALUMET_VERSION}-${ALUMET_DISTRIBUTION}.deb*
+    ${result}=    Run    ls -l alumet-agent_${ALUMET_VERSION}-1_${ALUMET_ARCHITECTURE}_${ALUMET_DISTRIBUTION}.deb*
     Log    result: ${result}
 
     Should Contain    ${result}    cannot access

--- a/integration-tests/scenarios/baremetal/installation.robot
+++ b/integration-tests/scenarios/baremetal/installation.robot
@@ -8,7 +8,7 @@ Resource            ../resources/alumet_keywords.resource
 Suite Setup         Log    Test are running on cluster: ${NODE}    level=INFO
 Test Timeout        180 seconds
 
-Test Tags           installation
+Test Tags           baremetal    installation
 
 
 *** Test Cases ***

--- a/integration-tests/scenarios/baremetal/plugin-perf.robot
+++ b/integration-tests/scenarios/baremetal/plugin-perf.robot
@@ -2,12 +2,13 @@
 Documentation       Alumet test plugin perf
 
 Library             OperatingSystem
+Library             String
 Library             SSHLibrary
 Resource            ../resources/alumet_keywords.resource
 
 Test Timeout        60 seconds
 
-Test Tags           input_plugin    perf_plugin
+Test Tags           baremetal    input_plugin    perf_plugin
 
 
 *** Test Cases ***
@@ -39,9 +40,14 @@ Run plugin csv perf
     Log    Result stdout : ${output_alumet}
     Log    stderr Result : ${stderr}
 
-    Should Contain    ${output_alumet}    2 plugins started
-    Should Contain    ${output_alumet}    csv v0.2.0
-    Should Contain    ${output_alumet}    perf v0.1.0
+    # check that csv and perf plugins are started
+    ${started_section}=    Get Regexp Matches
+    ...    ${output_alumet}
+    ...    plugins started:(.*?)plugins disabled:
+    ...    1
+    ...    flags=DOTALL
+    Should Contain    ${started_section}[0]    csv
+    Should Contain    ${started_section}[0]    perf
 
 Check alumet running
     [Documentation]    Verify that alumet-agent is running with the correct plugins

--- a/integration-tests/scenarios/baremetal/plugin-rapl.robot
+++ b/integration-tests/scenarios/baremetal/plugin-rapl.robot
@@ -2,12 +2,13 @@
 Documentation       Alumet test plugin rapl
 
 Library             OperatingSystem
+Library             String
 Library             SSHLibrary
 Resource            ../resources/alumet_keywords.resource
 
 Test Timeout        60 seconds
 
-Test Tags           input_plugin    rapl_plugin
+Test Tags           baremetal    input_plugin    rapl_plugin
 
 
 *** Test Cases ***
@@ -40,9 +41,15 @@ Check plugins socket-control csv rapl
     Log    Result stdout : ${output_alumet}
     Log    stderr Result : ${stderr}
 
-    Should Contain    ${output_alumet}    csv v0.2.0
-    Should Contain    ${output_alumet}    socket-control v0.2.1
-    Should Contain    ${output_alumet}    rapl v0.3.1
+    # check that csv and perf plugins are started
+    ${started_section}=    Get Regexp Matches
+    ...    ${output_alumet}
+    ...    plugins started:(.*?)plugins disabled:
+    ...    1
+    ...    flags=DOTALL
+    Should Contain    ${started_section}[0]    csv
+    Should Contain    ${started_section}[0]    rapl
+    Should Contain    ${started_section}[0]    socket-control
 
 Check alumet running
     [Documentation]    Verify that alumet-agent is running with the correct plugins

--- a/integration-tests/scenarios/container/installation.robot
+++ b/integration-tests/scenarios/container/installation.robot
@@ -10,11 +10,8 @@ Test Timeout        180 seconds
 
 Test Tags           installation
 
-*** Variables ***
-${ALUMET_CONTAINER_NAME}    alumet_robot_fm
 
 *** Test Cases ***
-
 Launch Alumet Container
     [Documentation]    Launch Alumet as container
 
@@ -25,4 +22,3 @@ Stop Alumet Container
 
     UnInstall Alumet As Container
     Log    Hello
-    

--- a/integration-tests/scenarios/container/installation.robot
+++ b/integration-tests/scenarios/container/installation.robot
@@ -1,0 +1,28 @@
+*** Settings ***
+Documentation       Alumet installation / uninstallation
+
+Library             OperatingSystem
+Library             SSHLibrary
+Resource            ../resources/alumet_keywords.resource
+
+Suite Setup         Log    Test are running on cluster: ${NODE}    level=INFO
+Test Timeout        180 seconds
+
+Test Tags           installation
+
+*** Variables ***
+${ALUMET_CONTAINER_NAME}    alumet_robot_fm
+
+*** Test Cases ***
+
+Launch Alumet Container
+    [Documentation]    Launch Alumet as container
+
+    Install Alumet As Container    csv
+
+Stop Alumet Container
+    [Documentation]    Stop and delete Alumet Container
+
+    UnInstall Alumet As Container
+    Log    Hello
+    

--- a/integration-tests/scenarios/container/installation.robot
+++ b/integration-tests/scenarios/container/installation.robot
@@ -8,7 +8,7 @@ Resource            ../resources/alumet_keywords.resource
 Suite Setup         Log    Test are running on cluster: ${NODE}    level=INFO
 Test Timeout        180 seconds
 
-Test Tags           installation
+Test Tags           container    installation
 
 
 *** Test Cases ***

--- a/integration-tests/scenarios/container/plugin-perf.robot
+++ b/integration-tests/scenarios/container/plugin-perf.robot
@@ -1,0 +1,109 @@
+*** Settings ***
+Documentation       Alumet test plugin perf
+
+Library             OperatingSystem
+Library             SSHLibrary
+Library             Process
+Library             String
+
+Resource            ../resources/alumet_keywords.resource
+
+Test Timeout        60 seconds
+
+Test Tags           input_plugin    perf_plugin
+
+
+*** Test Cases ***
+Run cpu_load
+    [Documentation]    Execute cpu_load script in the background
+
+    Copy tools File
+    
+    VAR  ${command}=    nohup ./cpu_load.sh 20 > /dev/null 2>&1 &
+    ${output}   ${stderr}=    Execute Command Target Node     ${command}
+    Sleep    3s
+    Log    Output Result of SSH : ${output}
+    Log    stderr Result of SSH : ${stderr}
+
+Run plugin csv perf
+    [Documentation]    Run alumet-agent with csv and perf plugins
+
+    Install Alumet As Container    csv,perf
+    #watch "$(cat cpu_load.sh.pid)" 
+    
+    ${result}   ${stderr}=    Execute Command Target Node       sudo podman logs ${ALUMET_CONTAINER_NAME}
+    Log    result: ${result}
+    Log    stderr: ${stderr}
+
+    Should Contain    ${stderr}    Starting Alumet
+    Should Contain    ${stderr}    ${ALUMET_VERSION}
+
+    Should Contain    ${stderr}    4 metrics registered
+
+    # check that csv and perf plugins are started
+    ${started_section}=    Get Regexp Matches
+    ...    ${stderr}
+    ...    plugins started:(.*?)plugins disabled:
+    ...    1
+    ...    flags=DOTALL
+    Should Contain    ${started_section}[0]    csv
+    Should Contain    ${started_section}[0]    perf
+
+Check alumet running
+    [Documentation]    Verify that alumet-agent is running with the correct plugins
+
+    ${output}   ${stderr}=    Execute Command Target Node       sudo podman exec ${ALUMET_CONTAINER_NAME} ps -f
+    Log    Result stdout : ${output}
+    Log    stderr Result : ${stderr}
+
+    Should Contain    ${output}    /usr/bin/alumet-agent
+    Should Contain    ${output}    --plugins csv,perf
+
+Copy csv File
+    [Documentation]    Copy alumet csv file
+
+    # wait several seconds to get some metrics in csv file
+    sleep    10s
+    Copy csv File
+
+Check Perf Metric perf_hardware_REF_CPU_CYCLES
+    [Documentation]    Check perf_hardware_REF_CPU_CYCLES metric
+    [Template]    Check Metric
+    # ${metric}                   ${resource_kind}    ${domain}
+    perf_hardware_REF_CPU_CYCLES    local_machine      ${EMPTY}
+
+Check Perf Metric perf_hardware_CACHE_MISSES
+    [Documentation]    Check perf_hardware_CACHE_MISSES metric
+    [Template]    Check Metric
+
+    # ${metric}    ${resource_kind}    ${domain}
+    perf_hardware_CACHE_MISSES    local_machine
+
+Check Perf Metric perf_hardware_BRANCH_MISSES
+    [Documentation]    Check perf_hardware_BRANCH_MISSES metric
+    [Template]    Check Metric
+
+    # ${metric}    ${resource_kind}    ${domain}
+    perf_hardware_BRANCH_MISSES    local_machine
+
+Check Perf Metric perf_cache_LL_READ_MISS
+    [Documentation]    Check perf_cache_LL_READ_MISS metric
+    [Template]    Check Metric
+
+    # ${metric}    ${resource_kind}    ${domain}
+    perf_cache_LL_READ_MISS    local_machine
+
+Stop alumet
+    [Documentation]    Stop alumet-agent delete alumet container
+
+    UnInstall Alumet As Container
+    Log    Stop alumet
+
+Check alumet not running
+    [Documentation]    Verify that alumet-agent is not running
+
+    ${output}    ${stderr}=    Execute Command Target Node    ps -f -u ${USERNAME}
+    Log    Result stdout : ${output}
+    Log    stderr Result : ${stderr}
+
+    Should Not Contain    ${output}    alumet-agent

--- a/integration-tests/scenarios/container/plugin-perf.robot
+++ b/integration-tests/scenarios/container/plugin-perf.robot
@@ -2,10 +2,9 @@
 Documentation       Alumet test plugin perf
 
 Library             OperatingSystem
-Library             SSHLibrary
 Library             Process
 Library             String
-
+Library             SSHLibrary
 Resource            ../resources/alumet_keywords.resource
 
 Test Timeout        60 seconds
@@ -17,21 +16,19 @@ Test Tags           input_plugin    perf_plugin
 Run cpu_load
     [Documentation]    Execute cpu_load script in the background
 
-    Copy tools File
-    
-    VAR  ${command}=    nohup ./cpu_load.sh 20 > /dev/null 2>&1 &
-    ${output}   ${stderr}=    Execute Command Target Node     ${command}
+    Copy Tools File
+
+    VAR    ${command}=    nohup ./cpu_load.sh 20 > /dev/null 2>&1 &
+    ${output}    ${stderr}=    Execute Command Target Node    ${command}
     Sleep    3s
     Log    Output Result of SSH : ${output}
     Log    stderr Result of SSH : ${stderr}
 
-Run plugin csv perf
+Run plugins csv perf
     [Documentation]    Run alumet-agent with csv and perf plugins
 
     Install Alumet As Container    csv,perf
-    #watch "$(cat cpu_load.sh.pid)" 
-    
-    ${result}   ${stderr}=    Execute Command Target Node       sudo podman logs ${ALUMET_CONTAINER_NAME}
+    ${result}    ${stderr}=    Execute Command Target Node    sudo podman logs ${ALUMET_CONTAINER_NAME}
     Log    result: ${result}
     Log    stderr: ${stderr}
 
@@ -52,7 +49,7 @@ Run plugin csv perf
 Check alumet running
     [Documentation]    Verify that alumet-agent is running with the correct plugins
 
-    ${output}   ${stderr}=    Execute Command Target Node       sudo podman exec ${ALUMET_CONTAINER_NAME} ps -f
+    ${output}    ${stderr}=    Execute Command Target Node    sudo podman exec ${ALUMET_CONTAINER_NAME} ps -f
     Log    Result stdout : ${output}
     Log    stderr Result : ${stderr}
 
@@ -63,14 +60,14 @@ Copy csv File
     [Documentation]    Copy alumet csv file
 
     # wait several seconds to get some metrics in csv file
-    sleep    10s
-    Copy csv File
+    Sleep    10s
+    Copy Csv File
 
 Check Perf Metric perf_hardware_REF_CPU_CYCLES
     [Documentation]    Check perf_hardware_REF_CPU_CYCLES metric
     [Template]    Check Metric
-    # ${metric}                   ${resource_kind}    ${domain}
-    perf_hardware_REF_CPU_CYCLES    local_machine      ${EMPTY}
+    # ${metric}    ${resource_kind}    ${domain}
+    perf_hardware_REF_CPU_CYCLES    local_machine    ${EMPTY}
 
 Check Perf Metric perf_hardware_CACHE_MISSES
     [Documentation]    Check perf_hardware_CACHE_MISSES metric

--- a/integration-tests/scenarios/container/plugin-perf.robot
+++ b/integration-tests/scenarios/container/plugin-perf.robot
@@ -9,7 +9,7 @@ Resource            ../resources/alumet_keywords.resource
 
 Test Timeout        60 seconds
 
-Test Tags           input_plugin    perf_plugin
+Test Tags           container    input_plugin    perf_plugin
 
 
 *** Test Cases ***

--- a/integration-tests/scenarios/container/plugin-rapl.robot
+++ b/integration-tests/scenarios/container/plugin-rapl.robot
@@ -8,7 +8,7 @@ Resource            ../resources/alumet_keywords.resource
 
 Test Timeout        60 seconds
 
-Test Tags           input_plugin    rapl_plugin
+Test Tags           container    input_plugin    rapl_plugin
 
 
 *** Test Cases ***

--- a/integration-tests/scenarios/container/plugin-rapl.robot
+++ b/integration-tests/scenarios/container/plugin-rapl.robot
@@ -2,8 +2,8 @@
 Documentation       Alumet test plugin rapl
 
 Library             OperatingSystem
-Library             SSHLibrary
 Library             String
+Library             SSHLibrary
 Resource            ../resources/alumet_keywords.resource
 
 Test Timeout        60 seconds
@@ -19,14 +19,12 @@ Test connection on target node
     Log    Output Result of SSH : ${output}
     Log    stderr Result of SSH : ${stderr}
 
-Run plugin csv rapl
+Run plugins csv rapl
     [Documentation]    Run alumet-agent with csv and rapl plugins
 
     Install Alumet As Container    csv,rapl
-    
-    sleep   10s
 
-    ${result}   ${stderr}=    Execute Command Target Node    sudo podman logs ${ALUMET_CONTAINER_NAME}
+    ${result}    ${stderr}=    Execute Command Target Node    sudo podman logs ${ALUMET_CONTAINER_NAME}
     Log    result: ${result}
     Log    stderr: ${stderr}
 
@@ -41,12 +39,12 @@ Run plugin csv rapl
     ...    1
     ...    flags=DOTALL
     Should Contain    ${started_section}[0]    csv
-    Should Contain    ${started_section}[0]    rapl    
+    Should Contain    ${started_section}[0]    rapl
 
 Check alumet running
     [Documentation]    Verify that alumet-agent is running with the correct plugins
 
-    ${output}   ${stderr}=    Execute Command Target Node      sudo podman exec ${ALUMET_CONTAINER_NAME} ps -f
+    ${output}    ${stderr}=    Execute Command Target Node    sudo podman exec ${ALUMET_CONTAINER_NAME} ps -f
     Log    Result stdout : ${output}
     Log    Result stderr : ${stderr}
 
@@ -58,8 +56,8 @@ Copy csv File
     [Documentation]    Copy alumet csv file
 
     # wait several seconds to get some metrics in csv file
-    sleep    10s
-    Copy csv File
+    Sleep    10s
+    Copy Csv File
 
 Check Rapl Metric package
     [Documentation]    Check rapl_consumed_energy_J metric for cpu_package
@@ -86,11 +84,11 @@ Stop alumet
 
     UnInstall Alumet As Container
     Log    Stop alumet
-    
+
 Check alumet not running
     [Documentation]    Verify that alumet-agent is not running
-    
-   ${output}=    Execute Command Target Node    sudo podman exec ${ALUMET_CONTAINER_NAME} ps -f
-    Log    Result stdout : ${output}    
+
+    ${output}=    Execute Command Target Node    sudo podman exec ${ALUMET_CONTAINER_NAME} ps -f
+    Log    Result stdout : ${output}
 
     Should Not Contain    ${output}    alumet-agent

--- a/integration-tests/scenarios/container/plugin-rapl.robot
+++ b/integration-tests/scenarios/container/plugin-rapl.robot
@@ -1,0 +1,96 @@
+*** Settings ***
+Documentation       Alumet test plugin rapl
+
+Library             OperatingSystem
+Library             SSHLibrary
+Library             String
+Resource            ../resources/alumet_keywords.resource
+
+Test Timeout        60 seconds
+
+Test Tags           input_plugin    rapl_plugin
+
+
+*** Test Cases ***
+Test connection on target node
+    [Documentation]    Verify SSH connection to the target node
+
+    ${output}    ${stderr}=    Execute Command Target Node    hostname
+    Log    Output Result of SSH : ${output}
+    Log    stderr Result of SSH : ${stderr}
+
+Run plugin csv rapl
+    [Documentation]    Run alumet-agent with csv and rapl plugins
+
+    Install Alumet As Container    csv,rapl
+    
+    sleep   10s
+
+    ${result}   ${stderr}=    Execute Command Target Node    sudo podman logs ${ALUMET_CONTAINER_NAME}
+    Log    result: ${result}
+    Log    stderr: ${stderr}
+
+    # Note that the output of podman log command is redirected to stderr
+    Should Contain    ${stderr}    Starting Alumet
+    Should Contain    ${stderr}    ${ALUMET_VERSION}
+
+    # check that csv and perf plugins are started
+    ${started_section}=    Get Regexp Matches
+    ...    ${stderr}
+    ...    plugins started:(.*?)plugins disabled:
+    ...    1
+    ...    flags=DOTALL
+    Should Contain    ${started_section}[0]    csv
+    Should Contain    ${started_section}[0]    rapl    
+
+Check alumet running
+    [Documentation]    Verify that alumet-agent is running with the correct plugins
+
+    ${output}   ${stderr}=    Execute Command Target Node      sudo podman exec ${ALUMET_CONTAINER_NAME} ps -f
+    Log    Result stdout : ${output}
+    Log    Result stderr : ${stderr}
+
+    # Note that the output of podman log command is redirected to stderr
+    Should Contain    ${output}    /usr/bin/alumet-agent
+    Should Contain    ${output}    --plugins csv,rapl
+
+Copy csv File
+    [Documentation]    Copy alumet csv file
+
+    # wait several seconds to get some metrics in csv file
+    sleep    10s
+    Copy csv File
+
+Check Rapl Metric package
+    [Documentation]    Check rapl_consumed_energy_J metric for cpu_package
+    [Template]    Check Metric
+    rapl_consumed_energy_J    cpu_package    package
+
+Check Rapl Metric package_total
+    [Documentation]    Check rapl_consumed_energy_J metric for package_total
+    [Template]    Check Metric
+    rapl_consumed_energy_J    local_machine    package_total
+
+Check Rapl Metric dram
+    [Documentation]    Check rapl_consumed_energy_J metric for dram
+    [Template]    Check Metric
+    rapl_consumed_energy_J    dram    dram
+
+Check Rapl Metric dram_total
+    [Documentation]    Check rapl_consumed_energy_J metric for dram_total
+    [Template]    Check Metric
+    rapl_consumed_energy_J    local_machine    dram_total
+
+Stop alumet
+    [Documentation]    Stop alumet-agent delete alumet container
+
+    UnInstall Alumet As Container
+    Log    Stop alumet
+    
+Check alumet not running
+    [Documentation]    Verify that alumet-agent is not running
+    
+   ${output}=    Execute Command Target Node    sudo podman exec ${ALUMET_CONTAINER_NAME} ps -f
+    Log    Result stdout : ${output}    
+
+    Should Not Contain    ${output}    alumet-agent

--- a/integration-tests/scenarios/resources/alumet_keywords.resource
+++ b/integration-tests/scenarios/resources/alumet_keywords.resource
@@ -9,6 +9,9 @@ Documentation       This resource file contains reusable keywords for interactin
 Library             OperatingSystem
 Library             SSHLibrary
 
+*** Variables ***
+${ALUMET_CONTAINER_NAME}    alumet_robot_fm
+
 
 *** Keywords ***
 Compare Values Percent
@@ -137,3 +140,36 @@ Check Metric
 
     ${output}=    Read Value    ${metric}    ${resource_kind}    ${domain}
     Should Be True    ${output} !=0.0
+
+Install Alumet As Container
+    [Documentation]    Launch Alumet as container
+    ...     input parameters:
+    ...         list of input plugins 
+    ...     Return parameters:
+    ...         none
+    [Arguments]    ${list_plugins}=${EMPTY}
+
+    IF    '${list_plugins}' != ''
+        VAR    ${entryPoint}=    '["/usr/bin/alumet-agent",  "--config", "/etc/alumet/alumet-config.toml", "--plugins", "${list_plugins}"]'
+        ${result}=    Run    podman run -d --cap-add=PERFMON --cap-add=SYS_NICE --cap-add=SYS_PTRACE --entrypoint ${entryPoint} --replace --privileged --name ${ALUMET_CONTAINER_NAME} ghcr.io/alumet-dev/alumet-agent:${ALUMET_VERSION}-${ALUMET_DISTRIBUTION}
+    ELSE
+        ${result}=    Run    podman run -d --cap-add=PERFMON --cap-add=SYS_NICE --cap-add=SYS_PTRACE --name ${ALUMET_CONTAINER_NAME} ghcr.io/alumet-dev/alumet-agent:${ALUMET_VERSION}-${ALUMET_DISTRIBUTION}
+    END
+
+    ${result}=    Run    podman logs ${ALUMET_CONTAINER_NAME}
+    Log    result: ${result}
+
+    Should Contain    ${result}    Starting Alumet
+    Should Contain    ${result}    ${ALUMET_VERSION}
+
+UnInstall Alumet As Container
+    [Documentation]    Stop and delete Alumet Container
+
+    ${result}=    Run    podman rm -f ${ALUMET_CONTAINER_NAME}
+    Log    result: ${result}
+
+    ${result}=    Run    podman ps -a | grep ${ALUMET_CONTAINER_NAME}
+    Log    result: ${result}
+
+    Should Not Contain    ${result}    ${ALUMET_CONTAINER_NAME}
+

--- a/integration-tests/scenarios/resources/alumet_keywords.resource
+++ b/integration-tests/scenarios/resources/alumet_keywords.resource
@@ -102,17 +102,19 @@ Read Value
     ...         ${KEY}                      : ssh key to open the ssh connection
     [Arguments]    ${metric}    ${resource_kind}    ${domain}=${EMPTY}
 
+    # sed -n 'Np' command below means that we read the N first metric value found in the csv file
+    # it is better not to read the first value but second or higher
+    # the metric value is on 3rd column (print $3)
     IF    '${domain}' != ''
         VAR    ${command}=
         ...    grep ${metric} alumet-output.csv | awk -F ';' ' $8 == "${domain}" &&
-        ...    $4 == "${resource_kind}" { OFS="|"; print $3 }' | sed -n '1p'
+        ...    $4 == "${resource_kind}" { OFS="|"; print $3 }' | sed -n '2p'
     ELSE
         VAR    ${command}=
         ...    grep ${metric} alumet-output.csv | awk -F ';' '
-        ...    $4 == "${resource_kind}" { OFS="|"; print $3 }' | sed -n '1p'
+        ...    $4 == "${resource_kind}" { OFS="|"; print $3 }' | sed -n '2p'
     END
 
-    # the metric value is on 3rd column
     ${output}    ${stderr}=    Execute Command Target Node    ${command}
     Log    output: ${output}
     Log    stderr: ${stderr}
@@ -149,27 +151,87 @@ Install Alumet As Container
     ...         none
     [Arguments]    ${list_plugins}=${EMPTY}
 
+    Log    alumer version: ${ALUMET_VERSION}
+    Log    alumer distribution: ${ALUMET_DISTRIBUTION}
+
     IF    '${list_plugins}' != ''
-        VAR    ${entryPoint}=    '["/usr/bin/alumet-agent",  "--config", "/etc/alumet/alumet-config.toml", "--plugins", "${list_plugins}"]'
-        ${result}=    Run    podman run -d --cap-add=PERFMON --cap-add=SYS_NICE --cap-add=SYS_PTRACE --entrypoint ${entryPoint} --replace --privileged --name ${ALUMET_CONTAINER_NAME} ghcr.io/alumet-dev/alumet-agent:${ALUMET_VERSION}-${ALUMET_DISTRIBUTION}
+        VAR  ${entryPoint}=    '["/usr/bin/alumet-agent",  "--config", "/etc/alumet/alumet-config.toml", "--plugins", "${list_plugins}"]'
+
+        # test if perf plugin is present
+        ${perf_present}=    Evaluate    "perf" in """${list_plugins}"""
+
+        IF    ${perf_present}
+            Log    "perf" plugin is activated
+            VAR  ${command}=    sudo podman run -d --pid=host --cap-add=PERFMON --cap-add=SYS_NICE --cap-add=SYS_PTRACE --entrypoint ${entryPoint} --replace --privileged --name ${ALUMET_CONTAINER_NAME} ghcr.io/alumet-dev/alumet-agent:${ALUMET_VERSION}-${ALUMET_DISTRIBUTION} watch "$(cat cpu_load.sh.pid)"
+        ELSE
+            Log    "perf" plugin is not activated
+            VAR  ${command}=    sudo podman run -d --pid=host --cap-add=PERFMON --cap-add=SYS_NICE --cap-add=SYS_PTRACE --entrypoint ${entryPoint} --replace --privileged --name ${ALUMET_CONTAINER_NAME} ghcr.io/alumet-dev/alumet-agent:${ALUMET_VERSION}-${ALUMET_DISTRIBUTION}
+        END
+
     ELSE
-        ${result}=    Run    podman run -d --cap-add=PERFMON --cap-add=SYS_NICE --cap-add=SYS_PTRACE --name ${ALUMET_CONTAINER_NAME} ghcr.io/alumet-dev/alumet-agent:${ALUMET_VERSION}-${ALUMET_DISTRIBUTION}
+        VAR  ${command}=    sudo podman run -d --cap-add=PERFMON --cap-add=SYS_NICE --cap-add=SYS_PTRACE --name ${ALUMET_CONTAINER_NAME} ghcr.io/alumet-dev/alumet-agent:${ALUMET_VERSION}-${ALUMET_DISTRIBUTION}
     END
 
-    ${result}=    Run    podman logs ${ALUMET_CONTAINER_NAME}
-    Log    result: ${result}
+    #VAR    ${command}=    env | grep -i proxy
 
-    Should Contain    ${result}    Starting Alumet
-    Should Contain    ${result}    ${ALUMET_VERSION}
+    ${result}=    Execute Command Target Node    ${command}
+    Log    result: ${result}
 
 UnInstall Alumet As Container
-    [Documentation]    Stop and delete Alumet Container
+    [Documentation]    Stop and delete Alumet Container, remove temporary files used for testing
 
-    ${result}=    Run    podman rm -f ${ALUMET_CONTAINER_NAME}
+    ${result}=    Execute Command Target Node    sudo podman rm -f ${ALUMET_CONTAINER_NAME}
     Log    result: ${result}
 
-    ${result}=    Run    podman ps -a | grep ${ALUMET_CONTAINER_NAME}
+    ${result}=    Execute Command Target Node    sudo podman ps -a | grep ${ALUMET_CONTAINER_NAME}
     Log    result: ${result}
 
     Should Not Contain    ${result}    ${ALUMET_CONTAINER_NAME}
+
+    # remove alumet-output.csv file
+    ${result}    ${stderr}=    Execute Command Target Node    rm alumet-output.csv
+    Log    result: ${result}
+    Log    stderr: ${stderr}
+
+    ${result}    ${stderr}=    Execute Command Target Node    ls -l alumet-output.csv
+    Log    result: ${result}
+    Log    stderr: ${stderr}
+
+    Should Contain    ${stderr}    cannot access
+
+    # remove cpu_load.*
+    ${result}    ${stderr}=    Execute Command Target Node    rm cpu_load.*
+    Log    result: ${result}
+    Log    stderr: ${stderr}
+
+    ${result}    ${stderr}=    Execute Command Target Node    ls -l cpu_load.*
+    Log    result: ${result}
+    Log    stderr: ${stderr}
+
+    Should Contain    ${stderr}    cannot access
+
+Copy tools File
+    [Documentation]    Copy tools file from Alumet container to local directory
+
+    Open Connection    ${GATEWAY}    alias=jumphost
+    Login With Public Key    ${USERNAME}    ${KEY}
+
+    Open Connection    ${NODE}
+
+    Login With Public Key    ${USERNAME}    ${KEY}
+    ...    jumphost_index_or_alias=jumphost
+
+    # copy tools files
+    Put File    scenarios/tools/cpu_load.sh    cpu_load.sh
+
+    Close All Connections
+
+Copy csv File
+    [Documentation]    Copy csv file from Alumet container to local directory
+
+    ${result}=    Execute Command Target Node    sudo podman cp ${ALUMET_CONTAINER_NAME}:/app/alumet-output.csv alumet-output.csv
+    Log    result: ${result}
+
+    OperatingSystem.File Should Exist    alumet-output.csv    msg=the alumet-output.csv file does not exist
+    
 

--- a/integration-tests/scenarios/resources/alumet_keywords.resource
+++ b/integration-tests/scenarios/resources/alumet_keywords.resource
@@ -152,8 +152,9 @@ Install Alumet As Container
     ...         none
     [Arguments]    ${list_plugins}=${EMPTY}
 
-    Log    alumer version: ${ALUMET_VERSION}
-    Log    alumer distribution: ${ALUMET_DISTRIBUTION}
+    Log    alumet version: ${ALUMET_VERSION}
+    Log    alumet distribution: ${ALUMET_DISTRIBUTION}
+    Log    alumet architecture: ${ALUMET_ARCHITECTURE}
 
     IF    '${list_plugins}' != ''
         VAR    ${entryPoint}=    '["/usr/bin/alumet-agent",
@@ -169,7 +170,7 @@ Install Alumet As Container
             ...    --cap-add=PERFMON --cap-add=SYS_NICE --cap-add=SYS_PTRACE
             ...    --entrypoint ${entryPoint} --replace --privileged
             ...    --name ${ALUMET_CONTAINER_NAME}
-            ...    ghcr.io/alumet-dev/alumet-agent:${ALUMET_VERSION}-${ALUMET_DISTRIBUTION}
+            ...    ghcr.io/alumet-dev/alumet-agent:${ALUMET_VERSION}-1_${ALUMET_DISTRIBUTION}
             ...    watch "$(cat cpu_load.sh.pid)"
         ELSE
             Log    "perf" plugin is not activated
@@ -177,11 +178,13 @@ Install Alumet As Container
             ...    --cap-add=PERFMON --cap-add=SYS_NICE --cap-add=SYS_PTRACE
             ...    --entrypoint ${entryPoint} --replace --privileged
             ...    --name ${ALUMET_CONTAINER_NAME}
-            ...    ghcr.io/alumet-dev/alumet-agent:${ALUMET_VERSION}-${ALUMET_DISTRIBUTION}
+            ...    ghcr.io/alumet-dev/alumet-agent:${ALUMET_VERSION}-1_${ALUMET_DISTRIBUTION}
         END
     ELSE
-        VAR    ${command}=    sudo podman run -d --cap-add=PERFMON --cap-add=SYS_NICE --cap-add=SYS_PTRACE
-        ...    --name ${ALUMET_CONTAINER_NAME} ghcr.io/alumet-dev/alumet-agent:${ALUMET_VERSION}-${ALUMET_DISTRIBUTION}
+        VAR    ${command}=
+        ...    sudo podman run -d --cap-add=PERFMON --cap-add=SYS_NICE --cap-add=SYS_PTRACE
+        ...    --name ${ALUMET_CONTAINER_NAME}
+        ...    ghcr.io/alumet-dev/alumet-agent:${ALUMET_VERSION}-1_${ALUMET_DISTRIBUTION}
     END
 
     ${result}=    Execute Command Target Node    ${command}
@@ -240,7 +243,12 @@ Copy Csv File
     [Documentation]    Copy csv file from Alumet container to local directory
 
     VAR    ${command}=    sudo podman cp ${ALUMET_CONTAINER_NAME}:/app/alumet-output.csv alumet-output.csv
-    ${result}=    Execute Command Target Node    ${command}
+    ${result}    ${stderr}=    Execute Command Target Node    ${command}
     Log    result: ${result}
+    Log    stderr: ${stderr}
 
-    OperatingSystem.File Should Exist    alumet-output.csv    msg=the alumet-output.csv file does not exist
+    # check if alumet-output.csv file exists
+    ${result}    ${stderr}=    Execute Command Target Node    ls -l alumet-output.csv
+    Log    result: ${result}
+    Log    stderr: ${stderr}
+    Should Contain    ${result}    alumet-output.csv

--- a/integration-tests/scenarios/resources/alumet_keywords.resource
+++ b/integration-tests/scenarios/resources/alumet_keywords.resource
@@ -9,6 +9,7 @@ Documentation       This resource file contains reusable keywords for interactin
 Library             OperatingSystem
 Library             SSHLibrary
 
+
 *** Variables ***
 ${ALUMET_CONTAINER_NAME}    alumet_robot_fm
 
@@ -146,7 +147,7 @@ Check Metric
 Install Alumet As Container
     [Documentation]    Launch Alumet as container
     ...     input parameters:
-    ...         list of input plugins 
+    ...         list of input plugins
     ...     Return parameters:
     ...         none
     [Arguments]    ${list_plugins}=${EMPTY}
@@ -155,24 +156,33 @@ Install Alumet As Container
     Log    alumer distribution: ${ALUMET_DISTRIBUTION}
 
     IF    '${list_plugins}' != ''
-        VAR  ${entryPoint}=    '["/usr/bin/alumet-agent",  "--config", "/etc/alumet/alumet-config.toml", "--plugins", "${list_plugins}"]'
+        VAR    ${entryPoint}=    '["/usr/bin/alumet-agent",
+        ...    "--config", "/etc/alumet/alumet-config.toml",
+        ...    "--plugins", "${list_plugins}"]'
 
         # test if perf plugin is present
         ${perf_present}=    Evaluate    "perf" in """${list_plugins}"""
 
         IF    ${perf_present}
             Log    "perf" plugin is activated
-            VAR  ${command}=    sudo podman run -d --pid=host --cap-add=PERFMON --cap-add=SYS_NICE --cap-add=SYS_PTRACE --entrypoint ${entryPoint} --replace --privileged --name ${ALUMET_CONTAINER_NAME} ghcr.io/alumet-dev/alumet-agent:${ALUMET_VERSION}-${ALUMET_DISTRIBUTION} watch "$(cat cpu_load.sh.pid)"
+            VAR    ${command}=    sudo podman run -d --pid=host
+            ...    --cap-add=PERFMON --cap-add=SYS_NICE --cap-add=SYS_PTRACE
+            ...    --entrypoint ${entryPoint} --replace --privileged
+            ...    --name ${ALUMET_CONTAINER_NAME}
+            ...    ghcr.io/alumet-dev/alumet-agent:${ALUMET_VERSION}-${ALUMET_DISTRIBUTION}
+            ...    watch "$(cat cpu_load.sh.pid)"
         ELSE
             Log    "perf" plugin is not activated
-            VAR  ${command}=    sudo podman run -d --pid=host --cap-add=PERFMON --cap-add=SYS_NICE --cap-add=SYS_PTRACE --entrypoint ${entryPoint} --replace --privileged --name ${ALUMET_CONTAINER_NAME} ghcr.io/alumet-dev/alumet-agent:${ALUMET_VERSION}-${ALUMET_DISTRIBUTION}
+            VAR    ${command}=    sudo podman run -d --pid=host
+            ...    --cap-add=PERFMON --cap-add=SYS_NICE --cap-add=SYS_PTRACE
+            ...    --entrypoint ${entryPoint} --replace --privileged
+            ...    --name ${ALUMET_CONTAINER_NAME}
+            ...    ghcr.io/alumet-dev/alumet-agent:${ALUMET_VERSION}-${ALUMET_DISTRIBUTION}
         END
-
     ELSE
-        VAR  ${command}=    sudo podman run -d --cap-add=PERFMON --cap-add=SYS_NICE --cap-add=SYS_PTRACE --name ${ALUMET_CONTAINER_NAME} ghcr.io/alumet-dev/alumet-agent:${ALUMET_VERSION}-${ALUMET_DISTRIBUTION}
+        VAR    ${command}=    sudo podman run -d --cap-add=PERFMON --cap-add=SYS_NICE --cap-add=SYS_PTRACE
+        ...    --name ${ALUMET_CONTAINER_NAME} ghcr.io/alumet-dev/alumet-agent:${ALUMET_VERSION}-${ALUMET_DISTRIBUTION}
     END
-
-    #VAR    ${command}=    env | grep -i proxy
 
     ${result}=    Execute Command Target Node    ${command}
     Log    result: ${result}
@@ -210,7 +220,7 @@ UnInstall Alumet As Container
 
     Should Contain    ${stderr}    cannot access
 
-Copy tools File
+Copy Tools File
     [Documentation]    Copy tools file from Alumet container to local directory
 
     Open Connection    ${GATEWAY}    alias=jumphost
@@ -226,12 +236,11 @@ Copy tools File
 
     Close All Connections
 
-Copy csv File
+Copy Csv File
     [Documentation]    Copy csv file from Alumet container to local directory
 
-    ${result}=    Execute Command Target Node    sudo podman cp ${ALUMET_CONTAINER_NAME}:/app/alumet-output.csv alumet-output.csv
+    VAR    ${command}=    sudo podman cp ${ALUMET_CONTAINER_NAME}:/app/alumet-output.csv alumet-output.csv
+    ${result}=    Execute Command Target Node    ${command}
     Log    result: ${result}
 
     OperatingSystem.File Should Exist    alumet-output.csv    msg=the alumet-output.csv file does not exist
-    
-


### PR DESCRIPTION
I added robot framework test for Alumet container:
- created a sub folder container under scenarios folder
- added 2 examples test files (similar ti the baremetal tests): plugin-perf.robot and plugin-rapl.robot
- updated alumet_keywords.resource file to include alumet installation and uninstallation procedures for containers
- update README

Note that the current container tests only target Alumet OCI images.
Since OCI images are not available for all OS distributions and versions, running tests for all scenarios (baremetal and container), may fail due to the unavailibity of either Alumet Linux package or Alumet OCI images. For example Unbuntu 22.04 Linux Package exist but not the OCI image.  

These tets should be completed to add more plugins.