### PR TITLE
feat(cgroups): add io pressure in cgroups

### DIFF
--- a/plugins/cgroups/raw/README.md
+++ b/plugins/cgroups/raw/README.md
@@ -19,6 +19,8 @@ Here are the metrics collected by the plugin's sources.
 |`cgroup_memory_file`|Gauge|Bytes|memory used to cache filesystem data|`LocalMachine`|`Cgroup`|see below|
 |`cgroup_memory_kernel_stack`|Gauge|Bytes|memory allocated to kernel stacks|`LocalMachine`|`Cgroup`|see below|
 |`cgroup_memory_pagetables`|Gauge|Bytes|memory reserved for the page tables|`LocalMachine`|`Cgroup`|see below|
+|`io_pressure_some_total`|CounterDiff|microseconds|IO pressure some total delta (at least one task stalled)|`LocalMachine`|`Cgroup`|none|
+|`io_pressure_full_total`|CounterDiff|microseconds|IO pressure full total delta (all tasks stalled)|`LocalMachine`|`Cgroup`|none|
 
 ### Attributes
 

--- a/plugins/cgroups/util-cgroups-plugins/src/delta.rs
+++ b/plugins/cgroups/util-cgroups-plugins/src/delta.rs
@@ -7,11 +7,24 @@ pub struct CpuDeltaCounters {
     pub system: CounterDiff,
 }
 
+/// CounterDiff to compute the delta when it makes sense.
+pub struct IoDeltaCounters {
+    pub some: CounterDiff,
+    pub full: CounterDiff,
+}
+
 impl CpuDeltaCounters {
     pub fn reset(&mut self) {
         self.usage.reset();
         self.user.reset();
         self.system.reset();
+    }
+}
+
+impl IoDeltaCounters {
+    pub fn reset(&mut self) {
+        self.some.reset();
+        self.full.reset();
     }
 }
 
@@ -21,6 +34,15 @@ impl Default for CpuDeltaCounters {
             usage: CounterDiff::with_max_value(u64::MAX),
             user: CounterDiff::with_max_value(u64::MAX),
             system: CounterDiff::with_max_value(u64::MAX),
+        }
+    }
+}
+
+impl Default for IoDeltaCounters {
+    fn default() -> Self {
+        Self {
+            some: CounterDiff::with_max_value(u64::MAX),
+            full: CounterDiff::with_max_value(u64::MAX),
         }
     }
 }
@@ -47,5 +69,21 @@ mod tests {
         assert_eq!(cpu_delta_counters.usage.update(90), CounterDiffUpdate::FirstTime);
         assert_eq!(cpu_delta_counters.user.update(80), CounterDiffUpdate::FirstTime);
         assert_eq!(cpu_delta_counters.system.update(70), CounterDiffUpdate::FirstTime);
+    }
+
+    #[test]
+    fn test_io_delta_counters() {
+        let mut io_delta_counters = IoDeltaCounters::default();
+
+        assert_eq!(io_delta_counters.full.update(800), CounterDiffUpdate::FirstTime);
+        assert_eq!(io_delta_counters.some.update(75), CounterDiffUpdate::FirstTime);
+
+        assert_eq!(io_delta_counters.full.update(860), CounterDiffUpdate::Difference(60));
+        assert_eq!(io_delta_counters.some.update(75), CounterDiffUpdate::Difference(0));
+
+        io_delta_counters.reset();
+
+        assert_eq!(io_delta_counters.full.update(20), CounterDiffUpdate::FirstTime);
+        assert_eq!(io_delta_counters.some.update(80), CounterDiffUpdate::FirstTime);
     }
 }

--- a/plugins/cgroups/util-cgroups-plugins/src/metrics.rs
+++ b/plugins/cgroups/util-cgroups-plugins/src/metrics.rs
@@ -22,6 +22,10 @@ pub struct Metrics {
     pub memory_kernel_stack: TypedMetricId<u64>,
     /// Memory used to manage correspondence between virtual and physical addresses.
     pub memory_pagetables: TypedMetricId<u64>,
+    /// IO pressure: some total delta (at least one task stalled)
+    pub io_pressure_some_total: TypedMetricId<u64>,
+    /// IO pressure: full total delta (all tasks stalled)
+    pub io_pressure_full_total: TypedMetricId<u64>,
 }
 
 /// Used by probes to configure how cgroup measurements will be mapped to Alumet measurement points.
@@ -61,6 +65,10 @@ pub struct AugmentedMetrics {
     pub memory_kernel_stack: AugmentedMetric<u64>,
     /// Memory used to manage correspondence between virtual and physical addresses.
     pub memory_pagetables: AugmentedMetric<u64>,
+    /// IO pressure: some total delta (at least one task stalled)
+    pub io_pressure_some_total: AugmentedMetric<u64>,
+    /// IO pressure: full total delta (all tasks stalled)
+    pub io_pressure_full_total: AugmentedMetric<u64>,
 
     /// Common attributes, added to the points of all metrics.
     pub common_attrs: Vec<(String, AttributeValue)>,
@@ -104,6 +112,16 @@ impl Metrics {
             Unit::Byte,
             "Amount of memory allocated for page tables (which map virtual addresses to physical addresses).",
         )?;
+        let io_pressure_some_total = alumet.create_metric::<u64>(
+            "io_pressure_some_total",
+            PrefixedUnit::micro(Unit::Second),
+            "IO pressure some total delta: time with at least one task stalled since previous measurement",
+        )?;
+        let io_pressure_full_total = alumet.create_metric::<u64>(
+            "io_pressure_full_total",
+            PrefixedUnit::micro(Unit::Second),
+            "IO pressure full total delta: time with all tasks stalled since previous measurement",
+        )?;
         Ok(Self {
             cpu_time_delta,
             cpu_percent,
@@ -112,6 +130,8 @@ impl Metrics {
             memory_file,
             memory_kernel_stack,
             memory_pagetables,
+            io_pressure_some_total,
+            io_pressure_full_total,
         })
     }
 }
@@ -126,6 +146,8 @@ impl AugmentedMetrics {
             memory_file: AugmentedMetric::simple(metrics.memory_file),
             memory_kernel_stack: AugmentedMetric::simple(metrics.memory_kernel_stack),
             memory_pagetables: AugmentedMetric::simple(metrics.memory_pagetables),
+            io_pressure_full_total: AugmentedMetric::simple(metrics.io_pressure_full_total),
+            io_pressure_some_total: AugmentedMetric::simple(metrics.io_pressure_some_total),
             common_attrs: Vec::new(),
         }
     }
@@ -152,6 +174,8 @@ impl AugmentedMetrics {
             memory_file: AugmentedMetric::simple(metrics.memory_file),
             memory_kernel_stack: AugmentedMetric::simple(metrics.memory_kernel_stack),
             memory_pagetables: AugmentedMetric::simple(metrics.memory_pagetables),
+            io_pressure_full_total: AugmentedMetric::simple(metrics.io_pressure_full_total),
+            io_pressure_some_total: AugmentedMetric::simple(metrics.io_pressure_some_total),
             common_attrs,
         }
     }

--- a/plugins/cgroups/util-cgroups-plugins/src/v2.rs
+++ b/plugins/cgroups/util-cgroups-plugins/src/v2.rs
@@ -5,8 +5,15 @@ use alumet::{
 };
 use util_cgroups::{
     Cgroup,
-    measure::v2::{V2Collector, cpu::CpuStatCollectorSettings, memory::MemoryStatCollectorSettings},
+    measure::v2::{
+        V2Collector,
+        cpu::CpuStatCollectorSettings,
+        io::{IoPressureCollectorSettings, IoPressureStats},
+        memory::MemoryStatCollectorSettings,
+    },
 };
+
+use crate::delta::IoDeltaCounters;
 
 use super::{
     delta::CpuDeltaCounters, metrics::AugmentedMetric, metrics::AugmentedMetrics, self_stop::analyze_io_result,
@@ -14,7 +21,8 @@ use super::{
 
 pub struct CgroupV2Probe {
     consumer: ResourceConsumer,
-    delta_counters: CpuDeltaCounters,
+    cpu_delta_counters: CpuDeltaCounters,
+    io_delta_counters: IoDeltaCounters,
     metrics: AugmentedMetrics,
     collector: V2Collector,
     io_buf: Vec<u8>,
@@ -32,6 +40,7 @@ impl CgroupV2Probe {
             cgroup,
             MemoryStatCollectorSettings::default(),
             CpuStatCollectorSettings::default(),
+            IoPressureCollectorSettings::default(),
             &mut io_buf,
         )?;
 
@@ -41,7 +50,8 @@ impl CgroupV2Probe {
 
         Ok(Self {
             consumer,
-            delta_counters: Default::default(),
+            cpu_delta_counters: Default::default(),
+            io_delta_counters: Default::default(),
             metrics,
             collector,
             io_buf,
@@ -84,7 +94,7 @@ impl Source for CgroupV2Probe {
         if let Some(cpu_stat) = data.cpu_stat {
             if let Some(value) = cpu_stat
                 .usage
-                .map(|v| self.delta_counters.usage.update(v).difference())
+                .map(|v| self.cpu_delta_counters.usage.update(v).difference())
                 .flatten()
             {
                 measurements.push(
@@ -106,7 +116,7 @@ impl Source for CgroupV2Probe {
 
             if let Some(value) = cpu_stat
                 .system
-                .map(|v| self.delta_counters.system.update(v).difference())
+                .map(|v| self.cpu_delta_counters.system.update(v).difference())
                 .flatten()
             {
                 measurements.push(
@@ -128,7 +138,7 @@ impl Source for CgroupV2Probe {
 
             if let Some(value) = cpu_stat
                 .user
-                .map(|v| self.delta_counters.user.update(v).difference())
+                .map(|v| self.cpu_delta_counters.user.update(v).difference())
                 .flatten()
             {
                 measurements.push(
@@ -167,11 +177,32 @@ impl Source for CgroupV2Probe {
                 measurements.push(self.new_point(&self.metrics.memory_pagetables, t, &resource, value));
             }
         }
+
+        // IO statistics
+        if let Some(io_pressure) = data.io_pressure {
+            if let Some(value) = io_pressure
+                .some_total
+                .map(|v| self.io_delta_counters.some.update(v).difference())
+                .flatten()
+            {
+                measurements.push(self.new_point(&self.metrics.io_pressure_some_total, t, &resource, value));
+            }
+
+            if let Some(value) = io_pressure
+                .full_total
+                .map(|v| self.io_delta_counters.full.update(v).difference())
+                .flatten()
+            {
+                measurements.push(self.new_point(&self.metrics.io_pressure_full_total, t, &resource, value));
+            }
+        }
+
         Ok(())
     }
 
     fn reset(&mut self) -> anyhow::Result<()> {
-        self.delta_counters.reset();
+        self.cpu_delta_counters.reset();
+        self.io_delta_counters.reset();
         self.last_timestamp = None;
         Ok(())
     }

--- a/plugins/cgroups/util-cgroups-plugins/tests/tests_metrics.rs
+++ b/plugins/cgroups/util-cgroups-plugins/tests/tests_metrics.rs
@@ -72,6 +72,8 @@ fn test_metrics_sets() {
         .expect_metric::<u64>("cgroup_memory_file", Unit::Byte)
         .expect_metric::<u64>("cgroup_memory_kernel_stack", Unit::Byte)
         .expect_metric::<u64>("cgroup_memory_pagetables", Unit::Byte)
+        .expect_metric::<u64>("io_pressure_some_total", PrefixedUnit::micro(Unit::Second))
+        .expect_metric::<u64>("io_pressure_full_total", PrefixedUnit::micro(Unit::Second))
         .expect_source(PLUGIN_NAME, SOURCE_NAME);
 
     let runtime = RuntimeExpectations::new().test_source(
@@ -87,6 +89,8 @@ fn test_metrics_sets() {
             let cgroup_memory_file = ctx.metrics().by_name("cgroup_memory_file").unwrap().0;
             let cgroup_memory_kernel_stack = ctx.metrics().by_name("cgroup_memory_kernel_stack").unwrap().0;
             let cgroup_memory_pagetables = ctx.metrics().by_name("cgroup_memory_pagetables").unwrap().0;
+            let io_pressure_some_total = ctx.metrics().by_name("io_pressure_some_total").unwrap().0;
+            let io_pressure_full_total = ctx.metrics().by_name("io_pressure_full_total").unwrap().0;
 
             assert!(m.iter().any(|p| p.metric == cpu_time_delta));
             assert!(m.iter().any(|p| p.metric == cpu_percent));
@@ -95,6 +99,8 @@ fn test_metrics_sets() {
             assert!(m.iter().any(|p| p.metric == cgroup_memory_file));
             assert!(m.iter().any(|p| p.metric == cgroup_memory_kernel_stack));
             assert!(m.iter().any(|p| p.metric == cgroup_memory_pagetables));
+            assert!(m.iter().any(|p| p.metric == io_pressure_some_total));
+            assert!(m.iter().any(|p| p.metric == io_pressure_full_total));
         },
     );
 

--- a/plugins/cgroups/util-cgroups/src/measure/parse.rs
+++ b/plugins/cgroups/util-cgroups/src/measure/parse.rs
@@ -6,7 +6,10 @@ use std::{
 
 use rustc_hash::{FxBuildHasher, FxHashMap};
 
-use crate::measure::bitset::BitSet128;
+use crate::measure::{
+    bitset::BitSet128,
+    v2::io::{IoPressureCollectorSettings, IoPressureStats},
+};
 
 /// Reads `file` from the beginning to the end into `io_buf`.
 ///
@@ -246,6 +249,75 @@ impl SelectiveStatMapping {
     }
 }
 
+/// Parser for io.pressure files, which use a different format than standard stat files.
+///
+/// io.pressure format:
+/// ```text
+/// some avg10=0.00 avg60=0.00 avg300=0.00 total=91487491
+/// full avg10=0.00 avg60=0.00 avg300=0.00 total=84675542
+/// ```
+///
+/// Unlike standard stat files (space-separated key-value pairs),
+/// io.pressure uses lines containing multiple space-separated key=value pairs,
+/// and the line prefix (some/full) indicates the pressure type.
+
+pub struct IoPressureFile {
+    file: File,
+    settings: IoPressureCollectorSettings,
+}
+
+impl IoPressureFile {
+    pub fn new(file: File, settings: IoPressureCollectorSettings) -> Self {
+        Self { file, settings }
+    }
+    // pub fn open(path: impl AsRef<Path>) -> io::Result<Self> {
+    //     let f = File::open(path)?;
+    //     Ok(Self::new(f))
+    // }
+
+    /// Reads the io.pressure file and extracts the total values ​​for 'some' and 'full'
+    pub unsafe fn read(&mut self, io_buf: &mut Vec<u8>) -> io::Result<IoPressureStats> {
+        read_fully(&mut self.file, io_buf)?;
+        unsafe { parse_io_pressure(io_buf, self.settings) }
+    }
+}
+
+unsafe fn parse_io_pressure(io_buf: &[u8], settings: IoPressureCollectorSettings) -> io::Result<IoPressureStats> {
+    let mut res = IoPressureStats::default();
+    let content = unsafe { std::str::from_utf8_unchecked(io_buf) };
+
+    for line in content.lines() {
+        let mut fields = line.split_whitespace();
+
+        let pressure_type = match fields.next() {
+            Some(kind) => kind,
+            None => continue,
+        };
+
+        if (pressure_type == "some" && !settings.some_total) || (pressure_type == "full" && !settings.full_total) {
+            continue;
+        }
+
+        for field in fields {
+            if let Some(("total", value)) = field.split_once('=') {
+                let total = value
+                    .parse::<u64>()
+                    .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid total value"))?;
+
+                match pressure_type {
+                    "some" => res.some_total = Some(total),
+                    "full" => res.full_total = Some(total),
+                    _ => {}
+                }
+
+                break;
+            }
+        }
+    }
+
+    Ok(res)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -343,5 +415,119 @@ burst_usec 0
             })
         }?;
         Ok(())
+    }
+
+    mod io_pressure {
+        use super::*;
+        use pretty_assertions::assert_eq;
+
+        fn settings() -> IoPressureCollectorSettings {
+            IoPressureCollectorSettings::default()
+        }
+
+        #[test]
+        fn parses_some_and_full_totals() {
+            let input = br#"some avg10=0.00 avg60=0.00 avg300=0.00 total=91487491
+            full avg10=0.00 avg60=0.00 avg300=0.00 total=84675542"#;
+
+            let stats = unsafe { parse_io_pressure(input, settings()).unwrap() };
+
+            assert_eq!(stats.some_total, Some(91_487_491));
+            assert_eq!(stats.full_total, Some(84_675_542));
+        }
+
+        #[test]
+        fn parses_only_some() {
+            let input = br#"some avg10=0.00 avg60=0.00 avg300=0.00 total=12345"#;
+
+            let stats = unsafe { parse_io_pressure(input, settings()).unwrap() };
+
+            assert_eq!(stats.some_total, Some(12_345));
+            assert_eq!(stats.full_total, None);
+        }
+
+        #[test]
+        fn parses_only_full() {
+            let input = br#"full avg10=0.00 avg60=0.00 avg300=0.00 total=67890"#;
+
+            let stats = unsafe { parse_io_pressure(input, settings()).unwrap() };
+            assert_eq!(stats.some_total, None);
+            assert_eq!(stats.full_total, Some(67_890));
+        }
+
+        #[test]
+        fn parses_only_some_configured() {
+            let input = br#"some avg10=0.00 avg60=0.00 avg300=0.00 total=12345
+            full avg10=0.00 avg60=0.00 avg300=0.00 total=84675542"#;
+
+            let conf = IoPressureCollectorSettings {
+                some_total: true,
+                full_total: false,
+            };
+            let stats = unsafe { parse_io_pressure(input, conf).unwrap() };
+            assert_eq!(stats.some_total, Some(12_345));
+            assert_eq!(stats.full_total, None);
+        }
+
+        #[test]
+        fn parses_only_full_configured() {
+            let input = br#"full avg10=0.00 avg60=0.00 avg300=0.00 total=67890
+            some avg10=0.00 avg60=0.00 avg300=0.00 total=12345"#;
+
+            let conf = IoPressureCollectorSettings {
+                some_total: false,
+                full_total: true,
+            };
+            let stats = unsafe { parse_io_pressure(input, conf).unwrap() };
+            assert_eq!(stats.some_total, None);
+            assert_eq!(stats.full_total, Some(67_890));
+        }
+
+        #[test]
+        fn parses_only_full_configured_messy() {
+            let input = br#"full avg10=0.00 avg60=0.00 total=67890 avg300=0.00
+            some total=12345 avg10=0.00 avg60=0.00 avg300=0.00"#;
+
+            let conf = IoPressureCollectorSettings {
+                some_total: false,
+                full_total: true,
+            };
+            let stats = unsafe { parse_io_pressure(input, conf).unwrap() };
+            assert_eq!(stats.some_total, None);
+        }
+
+        #[test]
+        fn ignores_unknown_pressure_type() {
+            let input = br#"invalid avg10=0.00 avg60=0.00 avg300=0.00 total=999"#;
+
+            let stats = unsafe { parse_io_pressure(input, settings()).unwrap() };
+            assert_eq!(stats.some_total, None);
+            assert_eq!(stats.full_total, None);
+        }
+
+        #[test]
+        fn returns_error_on_invalid_total() {
+            let input = br#"some avg10=0.00 avg60=0.00 avg300=0.00 total=not_a_number"#;
+
+            assert!(unsafe { parse_io_pressure(input, settings()) }.is_err());
+        }
+
+        #[test]
+        fn handles_empty_input() {
+            let stats = unsafe { parse_io_pressure(b"", settings()).unwrap() };
+
+            assert_eq!(stats.some_total, None);
+            assert_eq!(stats.full_total, None);
+        }
+
+        #[test]
+        fn ignores_lines_without_total() {
+            let input = br#"some avg10=0.00 avg60=0.00 avg300=0.00
+            full avg10=0.00 avg60=0.00 avg300=0.00"#;
+
+            let stats = unsafe { parse_io_pressure(input, settings()).unwrap() };
+            assert_eq!(stats.some_total, None);
+            assert_eq!(stats.full_total, None);
+        }
     }
 }

--- a/plugins/cgroups/util-cgroups/src/measure/v2.rs
+++ b/plugins/cgroups/util-cgroups/src/measure/v2.rs
@@ -6,6 +6,9 @@ pub mod cpu;
 /// Memory statistics for cgroup v2.
 pub mod memory;
 
+/// IO statistics for cgroup v2.
+pub mod io;
+
 /// Small zero-cost wrapper around line index.
 mod line_index;
 
@@ -30,12 +33,14 @@ mod common {
         Cgroup,
         measure::v2::{
             cpu::{self, CpuStatCollectorSettings},
+            io::{IoPressureCollector, IoPressureCollectorSettings},
             memory::{self, MemoryStatCollectorSettings},
         },
     };
 
     use super::{
         cpu::{CpuStatCollector, CpuStats},
+        io::IoPressureStats,
         memory::{MemoryCurrentCollector, MemoryStatCollector, MemoryStats},
     };
 
@@ -44,12 +49,14 @@ mod common {
         memory_current: Option<MemoryCurrentCollector>,
         memory_stat: Option<MemoryStatCollector>,
         cpu_stat: Option<CpuStatCollector>,
+        io_pressure: Option<IoPressureCollector>,
     }
 
     pub struct V2Stats {
         pub memory_current: Option<u64>,
         pub memory_stat: Option<MemoryStats>,
         pub cpu_stat: Option<CpuStats>,
+        pub io_pressure: Option<IoPressureStats>,
     }
 
     impl V2Collector {
@@ -65,12 +72,14 @@ mod common {
             cgroup: Cgroup<'_>,
             memory_stat_settings: MemoryStatCollectorSettings,
             cpu_stat_settings: CpuStatCollectorSettings,
+            io_pressure_settings: IoPressureCollectorSettings,
             io_buf: &mut Vec<u8>,
         ) -> anyhow::Result<Self> {
             let cgroup_path = cgroup.fs_path();
             let memory_current_file = cgroup_path.join("memory.current");
             let memory_stat_file = cgroup_path.join("memory.stat");
             let cpu_stat_file = cgroup_path.join("cpu.stat");
+            let io_pressure_file = cgroup_path.join("io.pressure");
 
             let prepare_memory_current = || -> anyhow::Result<Option<MemoryCurrentCollector>> {
                 match MemoryCurrentCollector::new(&memory_current_file) {
@@ -117,12 +126,28 @@ mod common {
                 }
             };
 
+            let prepare_io_pressure = |io_buf: &mut Vec<u8>| -> anyhow::Result<Option<IoPressureCollector>> {
+                match IoPressureCollector::new(&io_pressure_file, io_pressure_settings, io_buf) {
+                    Ok(res) => Ok(Some(res)),
+                    Err(super::io::CollectorCreationError::Io(e, _)) if e.kind() == ErrorKind::NotFound => {
+                        // the file does not exist, ignore
+                        log::warn!(
+                            "{} does not exist, some metrics will not be available",
+                            cpu_stat_file.display()
+                        );
+                        Ok(None)
+                    }
+                    Err(e) => Err(e.into()),
+                }
+            };
+
             let error_msg = || format!("collector creation failed for cgroup {}", cgroup.unique_name());
 
             Ok(Self {
                 memory_current: prepare_memory_current().with_context(error_msg)?,
                 memory_stat: prepare_memory_stat(io_buf).with_context(error_msg)?,
                 cpu_stat: prepare_cpu_stat(io_buf).with_context(error_msg)?,
+                io_pressure: prepare_io_pressure(io_buf).with_context(error_msg)?,
             })
         }
 
@@ -133,11 +158,13 @@ mod common {
             let memory_current = self.memory_current.as_mut().map(|c| c.measure(io_buf)).transpose()?;
             let memory_stat = self.memory_stat.as_mut().map(|c| c.measure(io_buf)).transpose()?;
             let cpu_stat = self.cpu_stat.as_mut().map(|c| c.measure(io_buf)).transpose()?;
+            let io_pressure = self.io_pressure.as_mut().map(|c| c.measure(io_buf)).transpose()?;
 
             Ok(V2Stats {
                 memory_current,
                 memory_stat,
                 cpu_stat,
+                io_pressure,
             })
         }
     }

--- a/plugins/cgroups/util-cgroups/src/measure/v2/io.rs
+++ b/plugins/cgroups/util-cgroups/src/measure/v2/io.rs
@@ -1,0 +1,394 @@
+use serde::Serialize;
+use std::{fs::File, io, path::Path};
+
+use crate::measure::parse::IoPressureFile;
+
+/// Collects measurements from `io.pressure`.
+///
+/// The io.pressure file format is different from cpu.stat:
+/// ```text
+/// some avg10=0.00 avg60=0.00 avg300=0.00 total=91487491
+/// full avg10=0.00 avg60=0.00 avg300=0.00 total=84675542
+/// ```
+///
+/// Uses the dedicated IoPressureFile parser which handles the equals-separated
+/// key-value format and the line-based structure (some/full prefixes).
+pub struct IoPressureCollector {
+    file: IoPressureFile,
+}
+
+#[derive(Debug, Serialize, Clone, Copy)]
+pub struct IoPressureCollectorSettings {
+    pub some_total: bool,
+    pub full_total: bool,
+}
+
+impl Default for IoPressureCollectorSettings {
+    fn default() -> Self {
+        Self {
+            some_total: true,
+            full_total: true,
+        }
+    }
+}
+
+/// Represents the measurements extracted from the `io.pressure` file.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct IoPressureStats {
+    pub some_total: Option<u64>,
+    pub full_total: Option<u64>,
+}
+
+pub type CollectorCreationError = super::memory::CollectorCreationError;
+
+impl IoPressureCollector {
+    pub fn new<P: AsRef<Path>>(
+        path: P,
+        settings: IoPressureCollectorSettings,
+        _io_buf: &mut Vec<u8>,
+    ) -> Result<Self, CollectorCreationError> {
+        let path = path.as_ref();
+        let file = File::open(path).map_err(|e| CollectorCreationError::Io(e, path.into()))?;
+
+        Ok(Self {
+            file: IoPressureFile::new(file, settings),
+        })
+    }
+
+    /// Collects measurements from the io.pressure file and computes the delta values.
+    ///
+    /// Uses the IoPressureFile parser to read the current values, then computes
+    /// the delta since the last measurement.
+    pub fn measure(&mut self, io_buf: &mut Vec<u8>) -> io::Result<IoPressureStats> {
+        let current_stats = unsafe { self.file.read(io_buf) }?;
+        Ok(current_stats)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    /// Creates a temporary io.pressure file with the given content.
+    fn create_temp_io_pressure_file(content: &str) -> NamedTempFile {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+        file.flush().unwrap();
+        file
+    }
+
+    mod io_pressure_settings {
+        use super::*;
+
+        #[test]
+        fn test_io_pressure_collector_settings_default() {
+            let settings = IoPressureCollectorSettings::default();
+            assert!(settings.some_total);
+            assert!(settings.full_total);
+        }
+
+        #[test]
+        fn test_io_pressure_collector_settings_custom() {
+            let settings = IoPressureCollectorSettings {
+                some_total: false,
+                full_total: true,
+            };
+            assert!(!settings.some_total);
+            assert!(settings.full_total);
+        }
+    }
+
+    mod io_pressure_stats {
+        use super::*;
+
+        #[test]
+        fn test_io_pressure_stats_default() {
+            let stats = IoPressureStats::default();
+            assert_eq!(stats.some_total, None);
+            assert_eq!(stats.full_total, None);
+        }
+
+        #[test]
+        fn test_io_pressure_stats_equality() {
+            let stats1 = IoPressureStats {
+                some_total: Some(100),
+                full_total: Some(200),
+            };
+            let stats2 = IoPressureStats {
+                some_total: Some(100),
+                full_total: Some(200),
+            };
+            assert_eq!(stats1, stats2);
+        }
+
+        #[test]
+        fn test_io_pressure_stats_inequality() {
+            let stats1 = IoPressureStats {
+                some_total: Some(100),
+                full_total: Some(200),
+            };
+            let stats2 = IoPressureStats {
+                some_total: Some(100),
+                full_total: Some(300),
+            };
+            assert_ne!(stats1, stats2);
+        }
+    }
+
+    mod io_pressure_collector {
+        use super::*;
+
+        #[test]
+        fn test_io_pressure_collector_new_valid_file() {
+            let content = "some avg10=0.00 avg60=0.00 avg300=0.00 total=91487491\n\
+                           full avg10=0.00 avg60=0.00 avg300=0.00 total=84675542\n";
+            let temp_file = create_temp_io_pressure_file(content);
+            let mut io_buf = Vec::new();
+            let settings = IoPressureCollectorSettings::default();
+
+            let result = IoPressureCollector::new(temp_file.path(), settings, &mut io_buf);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_io_pressure_collector_new_nonexistent_file() {
+            let mut io_buf = Vec::new();
+            let settings = IoPressureCollectorSettings::default();
+
+            let result = IoPressureCollector::new("/nonexistent/path/io.pressure", settings, &mut io_buf);
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn test_io_pressure_collector_measure_full_content() {
+            let content = "some avg10=0.00 avg60=0.00 avg300=0.00 total=91487491\n\
+                           full avg10=0.00 avg60=0.00 avg300=0.00 total=84675542\n";
+            let temp_file = create_temp_io_pressure_file(content);
+            let mut io_buf = Vec::new();
+            let settings = IoPressureCollectorSettings::default();
+            let mut collector = IoPressureCollector::new(temp_file.path(), settings, &mut io_buf).unwrap();
+
+            let result = collector.measure(&mut io_buf);
+            assert!(result.is_ok());
+
+            let stats = result.unwrap();
+            assert_eq!(stats.some_total, Some(91487491));
+            assert_eq!(stats.full_total, Some(84675542));
+        }
+
+        #[test]
+        fn test_io_pressure_collector_measure_only_some() {
+            let content = "some avg10=0.00 avg60=0.00 avg300=0.00 total=12345678\n\
+            full avg10=0.00 avg60=0.00 avg300=0.00 total=84675542\n";
+            let temp_file = create_temp_io_pressure_file(content);
+            let mut io_buf = Vec::new();
+            let settings = IoPressureCollectorSettings {
+                some_total: true,
+                full_total: false,
+            };
+            let mut collector = IoPressureCollector::new(temp_file.path(), settings, &mut io_buf).unwrap();
+
+            let result = collector.measure(&mut io_buf);
+            assert!(result.is_ok());
+
+            let stats = result.unwrap();
+            assert_eq!(stats.some_total, Some(12345678));
+            assert_eq!(stats.full_total, None);
+        }
+
+        #[test]
+        fn test_io_pressure_collector_measure_only_full() {
+            let content = "full avg10=0.00 avg60=0.00 avg300=0.00 total=98765432\n";
+            let temp_file = create_temp_io_pressure_file(content);
+            let mut io_buf = Vec::new();
+            let settings = IoPressureCollectorSettings::default();
+            let mut collector = IoPressureCollector::new(temp_file.path(), settings, &mut io_buf).unwrap();
+
+            let result = collector.measure(&mut io_buf);
+            assert!(result.is_ok());
+
+            let stats = result.unwrap();
+            assert_eq!(stats.some_total, None);
+            assert_eq!(stats.full_total, Some(98765432));
+        }
+
+        #[test]
+        fn test_io_pressure_collector_measure_empty_file() {
+            let content = "";
+            let temp_file = create_temp_io_pressure_file(content);
+            let mut io_buf = Vec::new();
+            let settings = IoPressureCollectorSettings::default();
+            let mut collector = IoPressureCollector::new(temp_file.path(), settings, &mut io_buf).unwrap();
+
+            let result = collector.measure(&mut io_buf);
+            assert!(result.is_ok());
+
+            let stats = result.unwrap();
+            assert_eq!(stats.some_total, None);
+            assert_eq!(stats.full_total, None);
+        }
+
+        #[test]
+        fn test_io_pressure_collector_measure_with_zero_values() {
+            let content = "some avg10=0.00 avg60=0.00 avg300=0.00 total=0\n\
+                           full avg10=0.00 avg60=0.00 avg300=0.00 total=0\n";
+            let temp_file = create_temp_io_pressure_file(content);
+            let mut io_buf = Vec::new();
+            let settings = IoPressureCollectorSettings::default();
+            let mut collector = IoPressureCollector::new(temp_file.path(), settings, &mut io_buf).unwrap();
+
+            let result = collector.measure(&mut io_buf);
+            assert!(result.is_ok());
+
+            let stats = result.unwrap();
+            assert_eq!(stats.some_total, Some(0));
+            assert_eq!(stats.full_total, Some(0));
+        }
+
+        #[test]
+        fn test_io_pressure_collector_measure_with_large_values() {
+            let content = "some avg10=0.00 avg60=0.00 avg300=0.00 total=18446744073709551615\n\
+                           full avg10=0.00 avg60=0.00 avg300=0.00 total=18446744073709551614\n";
+            let temp_file = create_temp_io_pressure_file(content);
+            let mut io_buf = Vec::new();
+            let settings = IoPressureCollectorSettings::default();
+            let mut collector = IoPressureCollector::new(temp_file.path(), settings, &mut io_buf).unwrap();
+
+            let result = collector.measure(&mut io_buf);
+            assert!(result.is_ok());
+
+            let stats = result.unwrap();
+            assert_eq!(stats.some_total, Some(u64::MAX));
+            assert_eq!(stats.full_total, Some(u64::MAX - 1));
+        }
+
+        #[test]
+        fn test_io_pressure_collector_measure_with_extra_whitespace() {
+            let content = "some avg10=0.00 avg60=0.00 avg300=0.00 total=100  \n\
+                           full avg10=0.00 avg60=0.00 avg300=0.00 total=200  \n";
+            let temp_file = create_temp_io_pressure_file(content);
+            let mut io_buf = Vec::new();
+            let settings = IoPressureCollectorSettings::default();
+            let mut collector = IoPressureCollector::new(temp_file.path(), settings, &mut io_buf).unwrap();
+
+            let result = collector.measure(&mut io_buf);
+            assert!(result.is_ok());
+
+            let stats = result.unwrap();
+            assert_eq!(stats.some_total, Some(100));
+            assert_eq!(stats.full_total, Some(200));
+        }
+
+        #[test]
+        fn test_io_pressure_collector_measure_with_mixed_line_endings() {
+            let content = "some avg10=0.00 avg60=0.00 avg300=0.00 total=150\r\n\
+                           full avg10=0.00 avg60=0.00 avg300=0.00 total=250\r\n";
+            let temp_file = create_temp_io_pressure_file(content);
+            let mut io_buf = Vec::new();
+            let settings = IoPressureCollectorSettings::default();
+            let mut collector = IoPressureCollector::new(temp_file.path(), settings, &mut io_buf).unwrap();
+
+            let result = collector.measure(&mut io_buf);
+            assert!(result.is_ok());
+
+            let stats = result.unwrap();
+            assert_eq!(stats.some_total, Some(150));
+            assert_eq!(stats.full_total, Some(250));
+        }
+
+        #[test]
+        fn test_io_pressure_collector_measure_multiple_calls() {
+            let content = "some avg10=0.00 avg60=0.00 avg300=0.00 total=100\n\
+                           full avg10=0.00 avg60=0.00 avg300=0.00 total=200\n";
+            let temp_file = create_temp_io_pressure_file(content);
+            let mut io_buf = Vec::new();
+            let settings = IoPressureCollectorSettings::default();
+            let mut collector = IoPressureCollector::new(temp_file.path(), settings, &mut io_buf).unwrap();
+
+            // First measurement
+            let result1 = collector.measure(&mut io_buf);
+            assert!(result1.is_ok());
+            let stats1 = result1.unwrap();
+            assert_eq!(stats1.some_total, Some(100));
+            assert_eq!(stats1.full_total, Some(200));
+
+            // Second measurement (should read the same values again)
+            let result2 = collector.measure(&mut io_buf);
+            assert!(result2.is_ok());
+            let stats2 = result2.unwrap();
+            assert_eq!(stats2.some_total, Some(100));
+            assert_eq!(stats2.full_total, Some(200));
+        }
+
+        #[test]
+        fn test_io_pressure_collector_measure_buffer_reuse() {
+            let content = "some avg10=0.00 avg60=0.00 avg300=0.00 total=300\n\
+                           full avg10=0.00 avg60=0.00 avg300=0.00 total=400\n";
+            let temp_file = create_temp_io_pressure_file(content);
+            let mut io_buf = Vec::new();
+            let settings = IoPressureCollectorSettings::default();
+            let mut collector = IoPressureCollector::new(temp_file.path(), settings, &mut io_buf).unwrap();
+
+            // First call with empty buffer
+            let result1 = collector.measure(&mut io_buf);
+            assert!(result1.is_ok());
+
+            // Second call with non-empty buffer (should still work)
+            let result2 = collector.measure(&mut io_buf);
+            assert!(result2.is_ok());
+
+            let stats = result2.unwrap();
+            assert_eq!(stats.some_total, Some(300));
+            assert_eq!(stats.full_total, Some(400));
+        }
+    }
+
+    mod io_pressure_collector_settings {
+        use super::*;
+
+        #[test]
+        fn test_io_pressure_collector_with_path_str() {
+            let content = "some avg10=0.00 avg60=0.00 avg300=0.00 total=500\n\
+                           full avg10=0.00 avg60=0.00 avg300=0.00 total=600\n";
+            let temp_file = create_temp_io_pressure_file(content);
+            let mut io_buf = Vec::new();
+            let settings = IoPressureCollectorSettings::default();
+
+            // Test with &str path
+            let result = IoPressureCollector::new(temp_file.path().to_str().unwrap(), settings, &mut io_buf);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_io_pressure_collector_with_path_buf() {
+            let content = "some avg10=0.00 avg60=0.00 avg300=0.00 total=700\n\
+                           full avg10=0.00 avg60=0.00 avg300=0.00 total=800\n";
+            let temp_file = create_temp_io_pressure_file(content);
+            let mut io_buf = Vec::new();
+            let settings = IoPressureCollectorSettings::default();
+
+            // Test with PathBuf
+            let result = IoPressureCollector::new(temp_file.path().to_path_buf(), settings, &mut io_buf);
+            assert!(result.is_ok());
+        }
+    }
+
+    #[test]
+    fn test_io_pressure_full() {
+        let content = "some avg10=0.00 avg60=0.00 avg300=0.00 total=91487491\n\
+                        full avg10=0.00 avg60=0.00 avg300=0.00 total=84675542\n";
+        let temp_file = create_temp_io_pressure_file(content);
+        let mut io_buf = Vec::new();
+        let settings = IoPressureCollectorSettings::default();
+
+        let result = IoPressureCollector::new(temp_file.path(), settings, &mut io_buf.clone());
+        assert!(result.is_ok());
+        let read_pressure_values = unsafe { result.unwrap().file.read(&mut io_buf) }.unwrap();
+        assert!(read_pressure_values.full_total.is_some());
+        assert!(read_pressure_values.some_total.is_some());
+        assert_eq!(read_pressure_values.some_total, Some(91487491));
+        assert_eq!(read_pressure_values.full_total, Some(84675542));
+    }
+}

--- a/plugins/cgroups/util-cgroups/tests/measure_v2.rs
+++ b/plugins/cgroups/util-cgroups/tests/measure_v2.rs
@@ -3,7 +3,10 @@ use std::{fs::File, io::Write};
 use tempfile::tempdir;
 use util_cgroups::{
     Cgroup, CgroupHierarchy, CgroupVersion,
-    measure::v2::{V2Collector, cpu::CpuStatCollectorSettings, memory::MemoryStatCollectorSettings},
+    measure::v2::{
+        V2Collector, cpu::CpuStatCollectorSettings, io::IoPressureCollectorSettings,
+        memory::MemoryStatCollectorSettings,
+    },
 };
 
 #[test]
@@ -43,6 +46,7 @@ pub fn test_new_and_measure() -> anyhow::Result<()> {
         cgroup,
         MemoryStatCollectorSettings::default(),
         CpuStatCollectorSettings::default(),
+        IoPressureCollectorSettings::default(),
         &mut io_buf,
     )?;
     let v2stat_res = collector.measure(&mut io_buf);
@@ -98,6 +102,7 @@ pub fn test_new_and_measure_bad_file_content_key() -> anyhow::Result<()> {
         cgroup,
         MemoryStatCollectorSettings::default(),
         CpuStatCollectorSettings::default(),
+        IoPressureCollectorSettings::default(),
         &mut io_buf,
     )?;
     let v2stat_res = collector.measure(&mut io_buf);
@@ -129,6 +134,7 @@ pub fn test_new_files_dont_exist() -> anyhow::Result<()> {
         cgroup,
         MemoryStatCollectorSettings::default(),
         CpuStatCollectorSettings::default(),
+        IoPressureCollectorSettings::default(),
         &mut io_buf,
     )?;
 
@@ -171,6 +177,7 @@ pub fn test_new_missing_lines() -> anyhow::Result<()> {
         cgroup,
         MemoryStatCollectorSettings::default(),
         CpuStatCollectorSettings::default(),
+        IoPressureCollectorSettings::default(),
         &mut io_buf,
     )?;
     let v2stat_res = collector.measure(&mut io_buf);
@@ -234,6 +241,7 @@ pub fn test_new_and_measure_bad_file_content_value() -> anyhow::Result<()> {
         cgroup,
         MemoryStatCollectorSettings::default(),
         CpuStatCollectorSettings::default(),
+        IoPressureCollectorSettings::default(),
         &mut io_buf,
     );
 


### PR DESCRIPTION
Add a new metric about io pressure. (how much time processes are delayed because they are waiting for disk or other IO resources to become available)
Read the file: `io.pressure` on cgroup.

2 new metrics:

- `io_pressure_full_total`
- `io_pressure_some_total`

Also add tests
