### PR TITLE
Feat/add some of missing memory metrics

### DIFF
--- a/plugins/cgroups/raw/README.md
+++ b/plugins/cgroups/raw/README.md
@@ -19,6 +19,9 @@ Here are the metrics collected by the plugin's sources.
 |`cgroup_memory_file`|Gauge|Bytes|memory used to cache filesystem data|`LocalMachine`|`Cgroup`|see below|
 |`cgroup_memory_kernel_stack`|Gauge|Bytes|memory allocated to kernel stacks|`LocalMachine`|`Cgroup`|see below|
 |`cgroup_memory_pagetables`|Gauge|Bytes|memory reserved for the page tables|`LocalMachine`|`Cgroup`|see below|
+|`cgroup_slab_reclaimable`|Gauge|Bytes|Amount of reclaimable kernel slab memory used by the cgroup.|`LocalMachine`|`Cgroup`|see below|
+|`cgroup_pswpin`|Counter|Pages|Total number of pages swapped into memory by the cgroup.|`LocalMachine`|`Cgroup`|see below|
+|`cgroup_pswpout`|Counter|Pages|Total number of pages swapped out of memory by the cgroup.|`LocalMachine`|`Cgroup`|see below|
 |`io_pressure_some_total`|CounterDiff|microseconds|IO pressure some total delta (at least one task stalled)|`LocalMachine`|`Cgroup`|none|
 |`io_pressure_full_total`|CounterDiff|microseconds|IO pressure full total delta (all tasks stalled)|`LocalMachine`|`Cgroup`|none|
 

--- a/plugins/cgroups/util-cgroups-plugins/src/metrics.rs
+++ b/plugins/cgroups/util-cgroups-plugins/src/metrics.rs
@@ -22,6 +22,12 @@ pub struct Metrics {
     pub memory_kernel_stack: TypedMetricId<u64>,
     /// Memory used to manage correspondence between virtual and physical addresses.
     pub memory_pagetables: TypedMetricId<u64>,
+    /// Reclaimable kernel slab memory used by the cgroup.
+    pub slab_reclaimable: TypedMetricId<u64>,
+    /// Number of pages swapped into memory by the cgroup.
+    pub pswpin: TypedMetricId<u64>,
+    /// Number of pages swapped out of memory by the cgroup.
+    pub pswpout: TypedMetricId<u64>,
     /// IO pressure: some total delta (at least one task stalled)
     pub io_pressure_some_total: TypedMetricId<u64>,
     /// IO pressure: full total delta (all tasks stalled)
@@ -65,6 +71,12 @@ pub struct AugmentedMetrics {
     pub memory_kernel_stack: AugmentedMetric<u64>,
     /// Memory used to manage correspondence between virtual and physical addresses.
     pub memory_pagetables: AugmentedMetric<u64>,
+    /// Reclaimable kernel slab memory used by the cgroup.
+    pub slab_reclaimable: AugmentedMetric<u64>,
+    /// Number of pages swapped into memory by the cgroup.
+    pub pswpin: AugmentedMetric<u64>,
+    /// Number of pages swapped out of memory by the cgroup.
+    pub pswpout: AugmentedMetric<u64>,
     /// IO pressure: some total delta (at least one task stalled)
     pub io_pressure_some_total: AugmentedMetric<u64>,
     /// IO pressure: full total delta (all tasks stalled)
@@ -112,6 +124,22 @@ impl Metrics {
             Unit::Byte,
             "Amount of memory allocated for page tables (which map virtual addresses to physical addresses).",
         )?;
+        let slab_reclaimable = alumet.create_metric::<u64>(
+            "cgroup_slab_reclaimable",
+            Unit::Byte,
+            "Amount of reclaimable kernel slab memory used by the cgroup.",
+        )?;
+        let pswpin = alumet.create_metric::<u64>(
+            "cgroup_pswpin",
+            Unit::Unity,
+            "Number of pages swapped into memory by the cgroup.",
+        )?;
+
+        let pswpout = alumet.create_metric::<u64>(
+            "cgroup_pswpout",
+            Unit::Unity,
+            "Number of pages swapped out of memory by the cgroup.",
+        )?;
         let io_pressure_some_total = alumet.create_metric::<u64>(
             "io_pressure_some_total",
             PrefixedUnit::micro(Unit::Second),
@@ -130,6 +158,9 @@ impl Metrics {
             memory_file,
             memory_kernel_stack,
             memory_pagetables,
+            slab_reclaimable,
+            pswpin,
+            pswpout,
             io_pressure_some_total,
             io_pressure_full_total,
         })
@@ -146,6 +177,9 @@ impl AugmentedMetrics {
             memory_file: AugmentedMetric::simple(metrics.memory_file),
             memory_kernel_stack: AugmentedMetric::simple(metrics.memory_kernel_stack),
             memory_pagetables: AugmentedMetric::simple(metrics.memory_pagetables),
+            slab_reclaimable: AugmentedMetric::simple(metrics.slab_reclaimable),
+            pswpin: AugmentedMetric::simple(metrics.pswpin),
+            pswpout: AugmentedMetric::simple(metrics.pswpout),
             io_pressure_full_total: AugmentedMetric::simple(metrics.io_pressure_full_total),
             io_pressure_some_total: AugmentedMetric::simple(metrics.io_pressure_some_total),
             common_attrs: Vec::new(),
@@ -174,6 +208,9 @@ impl AugmentedMetrics {
             memory_file: AugmentedMetric::simple(metrics.memory_file),
             memory_kernel_stack: AugmentedMetric::simple(metrics.memory_kernel_stack),
             memory_pagetables: AugmentedMetric::simple(metrics.memory_pagetables),
+            slab_reclaimable: AugmentedMetric::simple(metrics.slab_reclaimable),
+            pswpin: AugmentedMetric::simple(metrics.pswpin),
+            pswpout: AugmentedMetric::simple(metrics.pswpout),
             io_pressure_full_total: AugmentedMetric::simple(metrics.io_pressure_full_total),
             io_pressure_some_total: AugmentedMetric::simple(metrics.io_pressure_some_total),
             common_attrs,

--- a/plugins/cgroups/util-cgroups-plugins/src/v2.rs
+++ b/plugins/cgroups/util-cgroups-plugins/src/v2.rs
@@ -176,6 +176,15 @@ impl Source for CgroupV2Probe {
             if let Some(value) = mem_stat.page_tables {
                 measurements.push(self.new_point(&self.metrics.memory_pagetables, t, &resource, value));
             }
+            if let Some(value) = mem_stat.slab_reclaimable {
+                measurements.push(self.new_point(&self.metrics.slab_reclaimable, t, &resource, value));
+            }
+            if let Some(value) = mem_stat.pswpin {
+                measurements.push(self.new_point(&self.metrics.pswpin, t, &resource, value));
+            }
+            if let Some(value) = mem_stat.pswpout {
+                measurements.push(self.new_point(&self.metrics.pswpout, t, &resource, value));
+            }
         }
 
         // IO statistics

--- a/plugins/cgroups/util-cgroups/src/measure/v2/memory.rs
+++ b/plugins/cgroups/util-cgroups/src/measure/v2/memory.rs
@@ -33,6 +33,9 @@ pub struct MemoryStats {
     pub file: Option<u64>,
     pub kernel_stack: Option<u64>,
     pub page_tables: Option<u64>,
+    pub slab_reclaimable: Option<u64>,
+    pub pswpin: Option<u64>,
+    pub pswpout: Option<u64>,
     // could be extended to manage other memory.stat measurements
 }
 
@@ -42,6 +45,9 @@ struct MemoryStatMapping {
     file: LineIndex,
     kernel_stack: LineIndex,
     page_tables: LineIndex,
+    slab_reclaimable: LineIndex,
+    pswpin: LineIndex,
+    pswpout: LineIndex,
 }
 
 #[derive(Debug, Serialize)]
@@ -51,6 +57,9 @@ pub struct MemoryStatCollectorSettings {
     pub kernel_stack: bool,
     #[serde(rename = "pagetables")]
     pub page_tables: bool,
+    pub slab_reclaimable: bool,
+    pub pswpin: bool,
+    pub pswpout: bool,
 }
 
 impl EnabledKeys for MemoryStatCollectorSettings {}
@@ -62,6 +71,9 @@ impl Default for MemoryStatCollectorSettings {
             file: true,
             kernel_stack: true,
             page_tables: true,
+            slab_reclaimable: true,
+            pswpin: true,
+            pswpout: true,
         }
     }
 }
@@ -114,6 +126,15 @@ impl MemoryStatCollector {
         if let Some(i) = stat_mapping.line_index("pagetables") {
             mapping.page_tables = i.into();
         }
+        if let Some(i) = stat_mapping.line_index("slab_reclaimable") {
+            mapping.slab_reclaimable = i.into();
+        }
+        if let Some(i) = stat_mapping.line_index("pswpin") {
+            mapping.pswpin = i.into();
+        }
+        if let Some(i) = stat_mapping.line_index("pswpout") {
+            mapping.pswpout = i.into();
+        }
 
         if !stat_mapping.keys_not_found().is_empty() {
             log::warn!(
@@ -143,6 +164,15 @@ impl MemoryStatCollector {
                 i if i == self.mapping.page_tables.0 => {
                     res.page_tables = Some(v);
                 }
+                i if i == self.mapping.slab_reclaimable.0 => {
+                    res.slab_reclaimable = Some(v);
+                }
+                i if i == self.mapping.pswpin.0 => {
+                    res.pswpin = Some(v);
+                }
+                i if i == self.mapping.pswpout.0 => {
+                    res.pswpout = Some(v);
+                }
                 _ => (),
             })
         }?;
@@ -168,6 +198,9 @@ mod tests {
             file: 12,
             kernel_stack: 123,
             pagetables: 42,
+            slab_reclaimable: 77,
+            pswpin: 79,
+            pswpout: 81,
             ..Default::default()
         };
         mock.write_to_file(tmp.as_file_mut())?;
@@ -180,6 +213,9 @@ mod tests {
                 file: false,
                 kernel_stack: true,
                 page_tables: true,
+                slab_reclaimable: true,
+                pswpin: true,
+                pswpout: true,
             },
             io_buf.as_mut(),
         )?;
@@ -189,6 +225,9 @@ mod tests {
         assert_eq!(memory_stats.file, None);
         assert_eq!(memory_stats.kernel_stack, Some(123));
         assert_eq!(memory_stats.page_tables, Some(42));
+        assert_eq!(memory_stats.slab_reclaimable, Some(77));
+        assert_eq!(memory_stats.pswpin, Some(79));
+        assert_eq!(memory_stats.pswpout, Some(81));
         Ok(())
     }
 
@@ -206,6 +245,9 @@ mod tests {
                 file: true,
                 kernel_stack: true,
                 page_tables: true,
+                slab_reclaimable: true,
+                pswpin: true,
+                pswpout: true,
             },
             io_buf.as_mut(),
         )?;
@@ -215,6 +257,9 @@ mod tests {
         assert_eq!(memory_stats.file, None);
         assert_eq!(memory_stats.kernel_stack, None);
         assert_eq!(memory_stats.page_tables, None);
+        assert_eq!(memory_stats.slab_reclaimable, None);
+        assert_eq!(memory_stats.pswpin, None);
+        assert_eq!(memory_stats.pswpout, None);
 
         // empty lines
         std::fs::write(tmp.path(), "\n\n\n")?;
@@ -223,6 +268,9 @@ mod tests {
         assert_eq!(memory_stats.file, None);
         assert_eq!(memory_stats.kernel_stack, None);
         assert_eq!(memory_stats.page_tables, None);
+        assert_eq!(memory_stats.slab_reclaimable, None);
+        assert_eq!(memory_stats.pswpin, None);
+        assert_eq!(memory_stats.pswpout, None);
         Ok(())
     }
 

--- a/plugins/cgroups/util-cgroups/tests/measure_v2.rs
+++ b/plugins/cgroups/util-cgroups/tests/measure_v2.rs
@@ -29,7 +29,10 @@ pub fn test_new_and_measure() -> anyhow::Result<()> {
     let data_mem = "anon 321\n\
             file 654\n\
             kernel_stack 987\n\
-            pagetables 741\n";
+            pagetables 741\n\
+            slab_reclaimable 139419168\n\
+            pswpin 179988\n\
+            pswpout 549088\n";
     let mut file2 = File::create(file_path)?;
     file2.write_all(data_mem.as_bytes())?;
     // file 3
@@ -67,6 +70,9 @@ pub fn test_new_and_measure() -> anyhow::Result<()> {
     assert_eq!(mem_stat.file.unwrap_or(0), 654);
     assert_eq!(mem_stat.kernel_stack.unwrap_or(0), 987);
     assert_eq!(mem_stat.page_tables.unwrap_or(0), 741);
+    assert_eq!(mem_stat.slab_reclaimable.unwrap_or(0), 139419168);
+    assert_eq!(mem_stat.pswpin.unwrap_or(0), 179988);
+    assert_eq!(mem_stat.pswpout.unwrap_or(0), 549088);
 
     assert_eq!(mem_cur, 852);
 
@@ -224,7 +230,10 @@ pub fn test_new_and_measure_bad_file_content_value() -> anyhow::Result<()> {
     let data_mem = "anon ghj\n\
             file hh\n\
             kernel_stack rez\n\
-            pagetables 741\n";
+            pagetables 741\n\
+            slab_reclaimable 139419168\n\
+            pswpin 179988\n\
+            pswpout 549088\n";
     let mut file2 = File::create(file_path)?;
     file2.write_all(data_mem.as_bytes())?;
     // file 3


### PR DESCRIPTION
Add 3 metrics available in `memory.stat` file:

- `slab_reclaimable`
- `pswpin`
- `pswpout`

