### PR TITLE
feat(plugins/nvml): adds gpm metrics support

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -21,6 +21,7 @@ crio
 d'Ivoire
 Damerau
 desugars
+DFMA
 doctests
 DTLB
 evalexpr
@@ -28,9 +29,11 @@ Eviden
 FSCREDS
 giga
 hipcc
+HMMA
 humantime
 hwinfo
 hwmon
+IMMMA
 indice
 inotify
 ITLB
@@ -52,8 +55,12 @@ neowise
 niced
 nohup
 noninteractive
+NVDEC
+nvdec
 nvme
 NVML
+nvjpg
+nvofa
 oarstat
 oarsub
 Opensearch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,9 @@ name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bitvec"
@@ -2676,12 +2679,13 @@ dependencies = [
 [[package]]
 name = "nvml-wrapper"
 version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f049ae562349fefb8e837eb15443da1e7c6dcbd8a11f52a228f92220c2e5c85e"
+source = "git+https://github.com/TheElectronWill/nvml-wrapper.git?branch=feat%2Fgpm-sample-from-raw#9e90b1eac04d9f3b3d1e366ae6c1b6b6e8da5d1b"
 dependencies = [
  "bitflags 2.13.0",
  "libloading",
  "nvml-wrapper-sys",
+ "serde",
+ "serde_derive",
  "static_assertions",
  "thiserror 1.0.69",
  "wrapcenum-derive",
@@ -2690,8 +2694,7 @@ dependencies = [
 [[package]]
 name = "nvml-wrapper-sys"
 version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b4d594420fcda43b1c2c4bd44d48974aa3c7a9ab2cbf10dc18e35265767bf0b"
+source = "git+https://github.com/TheElectronWill/nvml-wrapper.git?branch=feat%2Fgpm-sample-from-raw#9e90b1eac04d9f3b3d1e366ae6c1b6b6e8da5d1b"
 dependencies = [
  "libloading",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2678,8 +2678,9 @@ dependencies = [
 
 [[package]]
 name = "nvml-wrapper"
-version = "0.12.1"
-source = "git+https://github.com/TheElectronWill/nvml-wrapper.git?branch=feat%2Fgpm-sample-from-raw#9e90b1eac04d9f3b3d1e366ae6c1b6b6e8da5d1b"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d164abbde0b3c03edb9edb9cb8d31a7f5b79015c692b7c771f6e0840e9106b9f"
 dependencies = [
  "bitflags 2.13.0",
  "libloading",
@@ -2693,8 +2694,9 @@ dependencies = [
 
 [[package]]
 name = "nvml-wrapper-sys"
-version = "0.9.1"
-source = "git+https://github.com/TheElectronWill/nvml-wrapper.git?branch=feat%2Fgpm-sample-from-raw#9e90b1eac04d9f3b3d1e366ae6c1b6b6e8da5d1b"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2079f4c9b6d2170bfb71c6355734ead6c47da75c179847395c31f9f2f66ede"
 dependencies = [
  "libloading",
 ]
@@ -3208,7 +3210,7 @@ dependencies = [
 
 [[package]]
 name = "plugin-nvidia-nvml"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "alumet",
  "anyhow",

--- a/plugins/nvidia-nvml/Cargo.toml
+++ b/plugins/nvidia-nvml/Cargo.toml
@@ -10,8 +10,8 @@ anyhow.workspace = true
 humantime-serde.workspace = true
 indexmap = "2.14.0"
 log.workspace = true
-nvml-wrapper = { version = "0.12.0", features = ["legacy-functions"] }
-nvml-wrapper-sys = { version = "0.9.0" }
+nvml-wrapper = { git = "https://github.com/TheElectronWill/nvml-wrapper.git", branch = "feat/gpm-sample-from-raw", version = "0.12.0", features = ["legacy-functions","serde"] }
+nvml-wrapper-sys = {git = "https://github.com/TheElectronWill/nvml-wrapper.git", branch = "feat/gpm-sample-from-raw", version = "0.9.0" }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/plugins/nvidia-nvml/Cargo.toml
+++ b/plugins/nvidia-nvml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plugin-nvidia-nvml"
-version = "0.6.2"
+version = "0.7.0"
 edition.workspace = true
 repository.workspace = true
 
@@ -10,8 +10,8 @@ anyhow.workspace = true
 humantime-serde.workspace = true
 indexmap = "2.14.0"
 log.workspace = true
-nvml-wrapper = { git = "https://github.com/TheElectronWill/nvml-wrapper.git", branch = "feat/gpm-sample-from-raw", version = "0.12.0", features = ["legacy-functions","serde"] }
-nvml-wrapper-sys = {git = "https://github.com/TheElectronWill/nvml-wrapper.git", branch = "feat/gpm-sample-from-raw", version = "0.9.0" }
+nvml-wrapper = {version = "0.13.0", features = ["legacy-functions","serde"] }
+nvml-wrapper-sys = {version = "0.10.0" }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/plugins/nvidia-nvml/README.md
+++ b/plugins/nvidia-nvml/README.md
@@ -38,7 +38,7 @@ One source will be created per GPU device.
 |`nvml_gpm_dram_utilization`|Gauge|Percentage|Percentage of DRAM bandwidth used|GPU|LocalMachine||
 |`nvml_gpm_pcie_throughput`|Gauge|byte|PCIe bytes transmitted or received per second|GPU|LocalMachine|[Direction](#direction)|
 |`nvml_gpm_nvdec_utilization`|Gauge|Percent|NVDEC utilization|GPU|LocalMachine|[Instance](#instance)|
-|`nvml_gpm_nvjpg_utilization`|Gauge|Percent|NGJPG utilization|GPU|LocalMachine|[Instance](#instance)|
+|`nvml_gpm_nvjpg_utilization`|Gauge|Percent|NVJPG utilization|GPU|LocalMachine|[Instance](#instance)|
 |`nvml_gpm_nvofa_utilization`|Gauge|Percent|NVOFA utilization|GPU|LocalMachine|[Instance](#instance)|
 |`nvml_gpm_nvlink_throughput`|Gauge|bytes|NVLink received and transmitted bytes per second across all links.|GPU|LocalMachine|[Instance](#instance), [Direction](#direction)|
 

--- a/plugins/nvidia-nvml/README.md
+++ b/plugins/nvidia-nvml/README.md
@@ -30,6 +30,17 @@ One source will be created per GPU device.
 |`nvml_sm_utilization`|Gauge|Percentage|Utilization of the GPU streaming multiprocessors by a process (3D task and rendering, etc...)|GPU|Process||
 |`nvml_clock_info`|Gauge|Hertz|GPU clock frequency|GPU|LocalMachine|[Clock_type](#clock_type)|
 |`nvml_used_gpu_memory`|Gauge|bytes|Amount of used GPU memory|GPU or GPUPartition|Process|[Context](#context), [Compute_instance_ID](#compute_instance_id)|
+|`nvml_gpm_graphics_util`|Gauge|Percentage|Percentage of time any warp was active on a multiprocessor|GPU|LocalMachine||
+|`nvml_gpm_sm_util`|Gauge|Percentage|Percentage of time each multiprocessor had at least 1 warp assigned|GPU|LocalMachine||
+|`nvml_gpm_sm_occupancy`|Gauge|Percentage|Percentage of warps that were active vs theoretical maximum|GPU|LocalMachine||
+|`nvml_gpm_tensor_utilization`|Gauge|Percentage|Percentage of time the GPU's SMs were doing (any, DFMA, HMMA or IMMMA) tensor operations|GPU|LocalMachine|[Operation type](#operation_type)|
+|`nvml_gpm_precision_utilization`|Gauge|Percentage|Percentage of time the GPU's SMs were doing integer, FP64, FP32 or FP16 operations|GPU|LocalMachine|[Precision](#precision)|
+|`nvml_gpm_dram_utilization`|Gauge|Percentage|Percentage of DRAM bandwidth used|GPU|LocalMachine||
+|`nvml_gpm_pcie_throughput`|Gauge|byte|PCIe bytes transmitted or received per second|GPU|LocalMachine|[Direction](#direction)|
+|`nvml_gpm_nvdec_utilization`|Gauge|Percent|NVDEC utilization|GPU|LocalMachine|[Instance](#instance)|
+|`nvml_gpm_nvjpg_utilization`|Gauge|Percent|NGJPG utilization|GPU|LocalMachine|[Instance](#instance)|
+|`nvml_gpm_nvofa_utilization`|Gauge|Percent|NVOFA utilization|GPU|LocalMachine|[Instance](#instance)|
+|`nvml_gpm_nvlink_throughput`|Gauge|bytes|NVLink received and transmitted bytes per second across all links.|GPU|LocalMachine|[Instance](#instance), [Direction](#direction)|
 
 Some metrics can be disabled, see the `mode` configuration option.
 
@@ -70,6 +81,46 @@ There are two possible contexts for processes:
 
 Attribute containing the compute instance ID of the process. Only available when MIG (Multi Instance GPU) is enabled.
 
+#### operation_type
+
+The type of operation done by the tensor cores :
+
+|Value|Description|
+|-----|-----------|
+|`dfma`|DFMA operations (Dynamic Fused Multiply-Accumulate)|
+|`hmma`|HMMA operations (Half-precision Matrix Multiply-Accumulate)|
+|`imma`|HMMA operations (Integer Matrix Multiply-Accumulate)|
+|`any`|All of the above|
+
+#### precision
+
+The precision of the input of the operations done :
+
+|Value|Description|
+|-----|-----------|
+|`integer`|Integer (of any size)|
+|`fp64`|Floating point 64 bits|
+|`fp32`|Floating point 32 bits|
+|`fp16`|Floating point 16 bits|
+
+#### direction
+
+The direction of the bytes throughput :
+
+|Value|Description|
+|-----|-----------|
+|`transmitted`|Bytes are sent through the link|
+|`received`|Bytes are received through through the link|
+
+#### instance
+
+The identifier of the component, used when there are multiple ones :
+
+|Value|Description|
+|-----|-----------|
+|`0 (...) 17`|The number of the component|
+|`total`|The total value averaged on every components of that type|
+
 ## Configuration
 
 Here is an example of how to configure this plugin.
@@ -90,6 +141,8 @@ skip_failed_devices = true
 
 # See below
 mode = "full"
+
+gpm_metrics = []
 ```
 
 ### Choosing the Right Mode
@@ -103,6 +156,46 @@ If you want to make the GPU measurement faster, you can use the `minimal` mode.
 In `minimal` mode, only `nvml_energy_consumption` and `nvml_instant_power` are provided.
 The only measured value is `nvml_instant_power`. It is used to estimate `nvml_energy_consumption`.
 The `minimal` mode only works on GPU that support the `nvmlDeviceGetPowerUsage` device query (the plugin detects if this is the case on startup).
+
+### GPM metrics
+
+GPM metrics are more precise metrics only available on recent GPUs (Hopper and forward). You have to enable `full` mode to enable them. For more details on what each metric mean, please refer to the [NVML API documentation](https://docs.nvidia.com/deploy/nvml-api/group__nvmlGpmEnums.html#group__nvmlGpmEnums). You can choose which GPM metrics to monitor by filling the array `gpm_metrics`. Here are the available metrics :
+
+**Tensor operations related metrics:**
+
+`AnyTensorUtil`, `DfmaTensorUtil`, `HmmaTensorUtil`, `ImmaTensorUtil`
+
+**DRAM related metrics:**
+
+`DramBwUtil`
+
+**Generic computation related metrics:**
+
+`GraphicsUtil`, `SmUtil`, `SmOccupancy`
+
+Or by precision: `Fp64Util`, `Fp32Util`, `Fp16Util`, `IntegerUtil`
+
+**PCIE throughput:**
+
+`PcieTxPerSec`, `PcieRxPerSec`
+
+**NVDEC utilization:**
+
+`Nvdec0Util` [...] `Nvdec7Util`
+
+**NVJPG utilization:**
+
+`Nvjpg0Util` [...] `Nvjpg7Util`
+
+**NVOFA utilization:**
+
+`Nvofa0Util`, `Nvofa1Util`
+
+**NVLink throughput:**
+
+Received: `NvlinkTotalRxPerSec`, `NvlinkL0RxPerSec` [...] `NvlinkL17RxPerSec`
+
+Transmitted:  `NvlinkTotalTxPerSec`, `NvlinkL0TxPerSec` [...] `NvlinkL17TxPerSec`
 
 ## More information
 

--- a/plugins/nvidia-nvml/README.md
+++ b/plugins/nvidia-nvml/README.md
@@ -142,14 +142,17 @@ skip_failed_devices = true
 # See below
 mode = "full"
 
-gpm_metrics = []
+# Only available on Hopper and newer architectures
+# This requires the "full" mode
+# A list of the available metrics is on the README (section 'GPM metrics')
+gpm_metrics = ["DramBwUtil", "Nvdec0Util"]
 ```
 
 ### Choosing the Right Mode
 
 The NVML plugin offers two modes: `full` and `minimal`.
 
-In `full` mode, all the metrics listed in the table above are provided (if they are available on the GPU).
+In `full` mode, all the metrics listed  and the required GPM metrics in the table above are provided (if they are available on the GPU).
 
 If you want to make the GPU measurement faster, you can use the `minimal` mode.
 

--- a/plugins/nvidia-nvml/src/lib.rs
+++ b/plugins/nvidia-nvml/src/lib.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, anyhow};
+use nvml_wrapper::enums::gpm::GpmMetricId;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
@@ -83,7 +84,7 @@ impl<P: NvmlProvider + 'static> AlumetPlugin for NvmlPlugin<P> {
             );
         }
         let source_provider = match self.config.mode {
-            Mode::Full => SourceProvider::Full(FullMetrics::new(alumet)?),
+            Mode::Full => SourceProvider::Full(FullMetrics::new(alumet, &self.config.gpm_metrics)?),
             Mode::Minimal => SourceProvider::Minimal(MinimalMetrics::new(alumet)?),
         };
 
@@ -136,6 +137,8 @@ struct Config {
     ///
     /// On some GPUs, the "full" mode is too slow for high frequencies (100 Hz can be hard to reach in full mode).
     mode: Mode,
+
+    gpm_metrics: Vec<GpmMetricId>,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -158,6 +161,7 @@ impl Default for Config {
             flush_interval: Duration::from_secs(5),
             skip_failed_devices: true,
             mode: Mode::Full,
+            gpm_metrics: vec![],
         }
     }
 }
@@ -183,10 +187,14 @@ mod tests {
     use indexmap::IndexMap;
     use nvml_wrapper::{
         enum_wrappers::device::Clock,
-        enums::device::UsedGpuMemory,
-        struct_wrappers::device::{MemoryInfo, ProcessInfo, ProcessUtilizationSample, Utilization},
+        enums::{device::UsedGpuMemory, gpm::GpmMetricId},
+        struct_wrappers::{
+            device::{MemoryInfo, ProcessInfo, ProcessUtilizationSample, Utilization},
+            gpm::{GpmMetricInfo, GpmMetricResult},
+        },
         structs::device::UtilizationInfo,
     };
+    use nvml_wrapper_sys::bindings::nvmlGpmSample_t;
 
     use crate::nvml::{MockNvmlDevice, MockNvmlLib};
 
@@ -433,6 +441,32 @@ mod tests {
                 Clock::Memory => Ok(3),
                 Clock::Graphics => Ok(4),
             });
+            device.expect_gpm_support().returning(|| Ok(true));
+            device
+                .expect_gpm_handle()
+                .returning(|| std::ptr::null::<()>() as nvmlGpmSample_t);
+            device.expect_gpm_metrics_get().returning(|_, _, _| {
+                Ok(vec![
+                    Ok(GpmMetricResult {
+                        metric_id: GpmMetricId::SmOccupancy,
+                        value: 60.0,
+                        metric_info: GpmMetricInfo {
+                            short_name: "".to_string(),
+                            long_name: "".to_string(),
+                            unit: "".to_string(),
+                        },
+                    }),
+                    Ok(GpmMetricResult {
+                        metric_id: GpmMetricId::NvlinkL1TxPerSec,
+                        value: 32_000.0,
+                        metric_info: GpmMetricInfo {
+                            short_name: "".to_string(),
+                            long_name: "".to_string(),
+                            unit: "".to_string(),
+                        },
+                    }),
+                ])
+            });
             Ok(device)
         });
         ret
@@ -540,6 +574,7 @@ mod tests {
 
         let config = serialize_config(super::Config {
             mode: Mode::Full,
+            gpm_metrics: vec![GpmMetricId::SmOccupancy, GpmMetricId::NvlinkL1TxPerSec],
             ..Default::default()
         })
         .unwrap();
@@ -567,7 +602,9 @@ mod tests {
             .expect_metric::<u64>("nvml_decoder_utilization", Unit::Percent)
             .expect_metric::<u64>("nvml_encoder_utilization", Unit::Percent)
             .expect_metric::<u64>("nvml_sm_utilization", Unit::Percent)
-            .expect_metric::<u64>("nvml_clock_info", Unit::Hertz);
+            .expect_metric::<u64>("nvml_clock_info", Unit::Hertz)
+            .expect_metric::<u64>("nvml_gpm_sm_occupancy", Unit::Percent)
+            .expect_metric::<u64>("nvml_gpm_nvlink_throughput", Unit::Byte);
 
         let source_name = SourceName::from_str("nvml", &format!("device_{MOCK_BUS_ID}"));
         let runtime_checks = RuntimeExpectations::new()
@@ -584,9 +621,18 @@ mod tests {
                     // two attributes are fetched:
                     //  - kind for "memory_info"
                     //  - clock_type for "clock_info"
-                    let points =
-                        points_by_metric_and_consumer(out, &["kind", "clock_type", "context", "compute_instance_id"]);
-                    assert_eq!(points.len(), 20, "wrong number of points, got {points:?}");
+                    let points = points_by_metric_and_consumer(
+                        out,
+                        &[
+                            "kind",
+                            "clock_type",
+                            "context",
+                            "compute_instance_id",
+                            "direction",
+                            "instance",
+                        ],
+                    );
+                    assert_eq!(points.len(), 22, "wrong number of points, got {points:?}");
 
                     assert_eq!(
                         points[&("nvml_encoder_utilization", ResourceConsumer::LocalMachine, vec![])]
@@ -779,6 +825,25 @@ mod tests {
                             .as_u64(),
                         4_000_000
                     );
+                    assert_eq!(
+                        points[&("nvml_gpm_sm_occupancy", ResourceConsumer::LocalMachine, vec![])]
+                            .value
+                            .as_u64(),
+                        60
+                    );
+                    assert_eq!(
+                        points[&(
+                            "nvml_gpm_nvlink_throughput",
+                            ResourceConsumer::LocalMachine,
+                            vec![
+                                ("direction", &AttributeValue::Str("transmitted")),
+                                ("instance", &AttributeValue::Str("1")),
+                            ]
+                        )]
+                            .value
+                            .as_u64(),
+                        32_000
+                    );
                 },
             )
             .test_source(
@@ -787,7 +852,7 @@ mod tests {
                 |out| {
                     // second trigger
                     let points = points_by_metric_and_consumer(out, &["kind", "clock_type"]);
-                    assert_eq!(points.len(), 25, "wrong number of points, got {points:?}");
+                    assert_eq!(points.len(), 27, "wrong number of points, got {points:?}");
 
                     // new power value
                     assert_eq!(
@@ -877,7 +942,7 @@ mod tests {
                 let points = points_by_metric_and_consumer(out, &[]);
 
                 // metrics with attributes only appear once
-                assert_eq!(points.len(), 12, "wrong number of points, got {points:?}");
+                assert_eq!(points.len(), 14, "wrong number of points, got {points:?}");
 
                 let expected_key_clock = ("nvml_clock_info", ResourceConsumer::LocalMachine, vec![]);
                 let expected_key_memory = ("nvml_gpu_memory_info", ResourceConsumer::LocalMachine, vec![]);

--- a/plugins/nvidia-nvml/src/metrics.rs
+++ b/plugins/nvidia-nvml/src/metrics.rs
@@ -1,8 +1,12 @@
+use std::collections::HashMap;
+
 use alumet::{
+    measurement::AttributeValue,
     metrics::{TypedMetricId, error::MetricCreationError},
     plugin::AlumetPluginStart,
     units::{PrefixedUnit, Unit},
 };
+use nvml_wrapper::enums::gpm::GpmMetricId::{self};
 
 /// Contains the ids of the measured metrics.
 #[derive(Clone)]
@@ -37,6 +41,8 @@ pub struct FullMetrics {
     pub used_gpu_memory: TypedMetricId<u64>,
     /// Get the current clock frequency in Hertz
     pub clock_info: TypedMetricId<u64>,
+
+    pub gpm_metrics: HashMap<GpmMetricId, TypedMetricId<u64>>,
 }
 
 #[derive(Clone)]
@@ -49,7 +55,10 @@ pub struct MinimalMetrics {
 
 impl FullMetrics {
     /// Creates new Alumet metrics for NVML measurements and stores their ids in a `Metrics` structure.
-    pub fn new(alumet: &mut AlumetPluginStart) -> Result<Self, MetricCreationError> {
+    pub fn new(
+        alumet: &mut AlumetPluginStart,
+        gpm_metrics_requested: &Vec<GpmMetricId>,
+    ) -> Result<Self, MetricCreationError> {
         Ok(Self {
             total_energy_consumption: alumet.create_metric(
                 "nvml_energy_consumption",
@@ -120,7 +129,13 @@ impl FullMetrics {
                 "Utilization of the GPU streaming multiprocessors by the process",
             )?,
             clock_info: alumet.create_metric("nvml_clock_info", Unit::Hertz, "Current clock speed for the device")?,
+            gpm_metrics: add_gpm_metrics(gpm_metrics_requested, alumet),
         })
+    }
+
+    /// Returns the list of keys in `gpm_metrics` corresponding to the list of GPM metrics requested.
+    pub fn gpm_metrics_ids(&self) -> Vec<GpmMetricId> {
+        self.gpm_metrics.keys().map(|key| key.to_owned()).collect()
     }
 }
 
@@ -138,5 +153,353 @@ impl MinimalMetrics {
                 "Instantaneous power of the GPU at the time of the measurement",
             )?,
         })
+    }
+}
+
+/// Adds every GPM metric requested to [AlumetPluginStart].
+fn add_gpm_metrics(
+    gpm_metrics_requested: &Vec<GpmMetricId>,
+    alumet: &mut AlumetPluginStart,
+) -> HashMap<GpmMetricId, TypedMetricId<u64>> {
+    let mut hash_map = HashMap::new();
+    for gpm_metric in gpm_metrics_requested {
+        match create_gpm_metrics(gpm_metric, alumet) {
+            Ok(result) => {
+                hash_map.insert(*gpm_metric, result);
+            }
+            _ => continue,
+        }
+    }
+    hash_map
+}
+
+/// Create a metric from the the corresponding [GpmMetricId], with the right unit, name, and description.
+///
+/// Multiple [GpmMetricId] may map to the same metric (for example : [GpmMetricId::Nvdec0Util] [...] [GpmMetricId::Nvdec7Util] map to
+/// metric `nvml_gpm_nvdec_utilization`)  
+fn create_gpm_metrics(
+    gpm_metric: &GpmMetricId,
+    alumet: &mut AlumetPluginStart,
+) -> Result<TypedMetricId<u64>, MetricCreationError> {
+    Ok(match gpm_metric {
+        // Percentage of time any warp was active on a multiprocessor, averaged over all multiprocessors.
+        GpmMetricId::GraphicsUtil => alumet.create_metric(
+            "nvml_gpm_graphics_util",
+            Unit::Percent,
+            "Percentage of time any warp was active on a multiprocessor, averaged over all multiprocessors.",
+        )?,
+
+        // Percentage of time each multiprocessor had at least 1 warp assigned, averaged over all multiprocessors.
+        GpmMetricId::SmUtil => alumet.create_metric(
+            "nvml_gpm_sm_util",
+            Unit::Percent,
+            "Percentage of time each multiprocessor had at least 1 warp assigned, averaged over all multiprocessors.",
+        )?,
+
+        // Percentage of warps that were active vs theoretical maximum, averaged over all multiprocessors.
+        GpmMetricId::SmOccupancy => alumet.create_metric(
+            "nvml_gpm_sm_occupancy",
+            Unit::Percent,
+            "Percentage of warps that were active vs theoretical maximum, averaged over all multiprocessors",
+        )?,
+
+        // Percentage of time the GPU's SMs were doing (any, DFMA, HMMA or IMMMA) tensor operations.
+        GpmMetricId::AnyTensorUtil
+        | GpmMetricId::DfmaTensorUtil
+        | GpmMetricId::HmmaTensorUtil
+        | GpmMetricId::ImmaTensorUtil => alumet.create_metric(
+            "nvml_gpm_tensor_utilization",
+            Unit::Percent,
+            "Percentage of time the GPU's SMs were doing tensor operations.",
+        )?,
+
+        // Percentage of time the GPU's SMs were doing integer, FP64, FP32 or FP16 operations.
+        GpmMetricId::IntegerUtil | GpmMetricId::Fp64Util | GpmMetricId::Fp32Util | GpmMetricId::Fp16Util => alumet
+            .create_metric(
+                "nvml_gpm_precision_utilization",
+                Unit::Percent,
+                "Percentage of time the GPU's SMs were doing operations in a specific precision.",
+            )?,
+
+        // Percentage of DRAM bandwidth used.
+        GpmMetricId::DramBwUtil => alumet.create_metric(
+            "nvml_gpm_dram_utilization",
+            Unit::Percent,
+            "Percentage of DRAM bandwidth used.",
+        )?,
+
+        // PCIe bytes transmitted or received per second.
+        GpmMetricId::PcieTxPerSec | GpmMetricId::PcieRxPerSec => alumet.create_metric(
+            "nvml_gpm_pcie_throughput",
+            Unit::Byte,
+            "PCIe bytes transmitted or received per second.",
+        )?,
+
+        // NVDEC instance (0..7) utilization.
+        GpmMetricId::Nvdec0Util
+        | GpmMetricId::Nvdec1Util
+        | GpmMetricId::Nvdec2Util
+        | GpmMetricId::Nvdec3Util
+        | GpmMetricId::Nvdec4Util
+        | GpmMetricId::Nvdec5Util
+        | GpmMetricId::Nvdec6Util
+        | GpmMetricId::Nvdec7Util => {
+            alumet.create_metric("nvml_gpm_nvdec_utilization", Unit::Percent, "NVDEC utilization.")?
+        }
+
+        // NVJPG instance (0..7) utilization.
+        GpmMetricId::Nvjpg0Util
+        | GpmMetricId::Nvjpg1Util
+        | GpmMetricId::Nvjpg2Util
+        | GpmMetricId::Nvjpg3Util
+        | GpmMetricId::Nvjpg4Util
+        | GpmMetricId::Nvjpg5Util
+        | GpmMetricId::Nvjpg6Util
+        | GpmMetricId::Nvjpg7Util => {
+            alumet.create_metric("nvml_gpm_nvjpg_utilization", Unit::Percent, "NVJPG utilization.")?
+        }
+
+        // NVOFA instance (0..1) utilization.
+        GpmMetricId::Nvofa0Util | GpmMetricId::Nvofa1Util => {
+            alumet.create_metric("nvml_gpm_nvofa_utilization", Unit::Percent, "NVOFA utilization.")?
+        }
+
+        // Total and instance (0..17) NVLink receive, transmit bytes per second across all links.
+        GpmMetricId::NvlinkTotalRxPerSec
+        | GpmMetricId::NvlinkTotalTxPerSec
+        | GpmMetricId::NvlinkL0RxPerSec
+        | GpmMetricId::NvlinkL0TxPerSec
+        | GpmMetricId::NvlinkL1RxPerSec
+        | GpmMetricId::NvlinkL1TxPerSec
+        | GpmMetricId::NvlinkL2RxPerSec
+        | GpmMetricId::NvlinkL2TxPerSec
+        | GpmMetricId::NvlinkL3RxPerSec
+        | GpmMetricId::NvlinkL3TxPerSec
+        | GpmMetricId::NvlinkL4RxPerSec
+        | GpmMetricId::NvlinkL4TxPerSec
+        | GpmMetricId::NvlinkL5RxPerSec
+        | GpmMetricId::NvlinkL5TxPerSec
+        | GpmMetricId::NvlinkL6RxPerSec
+        | GpmMetricId::NvlinkL6TxPerSec
+        | GpmMetricId::NvlinkL7RxPerSec
+        | GpmMetricId::NvlinkL7TxPerSec
+        | GpmMetricId::NvlinkL8RxPerSec
+        | GpmMetricId::NvlinkL8TxPerSec
+        | GpmMetricId::NvlinkL9RxPerSec
+        | GpmMetricId::NvlinkL9TxPerSec
+        | GpmMetricId::NvlinkL10RxPerSec
+        | GpmMetricId::NvlinkL10TxPerSec
+        | GpmMetricId::NvlinkL11RxPerSec
+        | GpmMetricId::NvlinkL11TxPerSec
+        | GpmMetricId::NvlinkL12RxPerSec
+        | GpmMetricId::NvlinkL12TxPerSec
+        | GpmMetricId::NvlinkL13RxPerSec
+        | GpmMetricId::NvlinkL13TxPerSec
+        | GpmMetricId::NvlinkL14RxPerSec
+        | GpmMetricId::NvlinkL14TxPerSec
+        | GpmMetricId::NvlinkL15RxPerSec
+        | GpmMetricId::NvlinkL15TxPerSec
+        | GpmMetricId::NvlinkL16RxPerSec
+        | GpmMetricId::NvlinkL16TxPerSec
+        | GpmMetricId::NvlinkL17RxPerSec
+        | GpmMetricId::NvlinkL17TxPerSec => alumet.create_metric(
+            "nvml_gpm_nvlink_throughput",
+            Unit::Byte,
+            "NVLink bytes transmitted or received per second.",
+        )?,
+    })
+}
+
+/// Maps a [GpmMetricId] to a vector of attribtues that should be added to the corresponding MeasurementPoint
+pub fn match_gpm_id_to_attributes(gpm_metric: &GpmMetricId) -> Vec<(&'static str, AttributeValue)> {
+    match gpm_metric {
+        GpmMetricId::AnyTensorUtil => vec![("operation_type", AttributeValue::Str("any"))],
+        GpmMetricId::DfmaTensorUtil => vec![("operation_type", AttributeValue::Str("dfma"))],
+        GpmMetricId::HmmaTensorUtil => vec![("operation_type", AttributeValue::Str("hmma"))],
+        GpmMetricId::ImmaTensorUtil => vec![("operation_type", AttributeValue::Str("imma"))],
+
+        GpmMetricId::IntegerUtil => vec![("precision", AttributeValue::Str("integer"))],
+        GpmMetricId::Fp64Util => vec![("precision", AttributeValue::Str("fp64"))],
+        GpmMetricId::Fp32Util => vec![("precision", AttributeValue::Str("fp32"))],
+        GpmMetricId::Fp16Util => vec![("precision", AttributeValue::Str("fp16"))],
+
+        GpmMetricId::PcieTxPerSec => vec![("direction", AttributeValue::Str("transmitted"))],
+        GpmMetricId::PcieRxPerSec => vec![("direction", AttributeValue::Str("received"))],
+
+        GpmMetricId::Nvdec0Util => vec![("instance", AttributeValue::U64(0))],
+        GpmMetricId::Nvdec1Util => vec![("instance", AttributeValue::U64(1))],
+        GpmMetricId::Nvdec2Util => vec![("instance", AttributeValue::U64(2))],
+        GpmMetricId::Nvdec3Util => vec![("instance", AttributeValue::U64(3))],
+        GpmMetricId::Nvdec4Util => vec![("instance", AttributeValue::U64(4))],
+        GpmMetricId::Nvdec5Util => vec![("instance", AttributeValue::U64(5))],
+        GpmMetricId::Nvdec6Util => vec![("instance", AttributeValue::U64(6))],
+        GpmMetricId::Nvdec7Util => vec![("instance", AttributeValue::U64(7))],
+
+        GpmMetricId::Nvjpg0Util => vec![("instance", AttributeValue::U64(0))],
+        GpmMetricId::Nvjpg1Util => vec![("instance", AttributeValue::U64(1))],
+        GpmMetricId::Nvjpg2Util => vec![("instance", AttributeValue::U64(2))],
+        GpmMetricId::Nvjpg3Util => vec![("instance", AttributeValue::U64(3))],
+        GpmMetricId::Nvjpg4Util => vec![("instance", AttributeValue::U64(4))],
+        GpmMetricId::Nvjpg5Util => vec![("instance", AttributeValue::U64(5))],
+        GpmMetricId::Nvjpg6Util => vec![("instance", AttributeValue::U64(6))],
+        GpmMetricId::Nvjpg7Util => vec![("instance", AttributeValue::U64(7))],
+
+        GpmMetricId::Nvofa0Util => vec![("instance", AttributeValue::U64(0))],
+        GpmMetricId::Nvofa1Util => vec![("instance", AttributeValue::U64(1))],
+
+        GpmMetricId::NvlinkTotalRxPerSec => vec![
+            ("direction", AttributeValue::Str("received")),
+            ("instance", AttributeValue::Str("total")),
+        ],
+        GpmMetricId::NvlinkTotalTxPerSec => vec![
+            ("direction", AttributeValue::Str("transmitted")),
+            ("instance", AttributeValue::Str("total")),
+        ],
+
+        GpmMetricId::NvlinkL0RxPerSec => vec![
+            ("direction", AttributeValue::Str("received")),
+            ("instance", AttributeValue::Str("0")),
+        ],
+        GpmMetricId::NvlinkL0TxPerSec => vec![
+            ("direction", AttributeValue::Str("transmitted")),
+            ("instance", AttributeValue::Str("0")),
+        ],
+        GpmMetricId::NvlinkL1RxPerSec => vec![
+            ("direction", AttributeValue::Str("received")),
+            ("instance", AttributeValue::Str("1")),
+        ],
+        GpmMetricId::NvlinkL1TxPerSec => vec![
+            ("direction", AttributeValue::Str("transmitted")),
+            ("instance", AttributeValue::Str("1")),
+        ],
+        GpmMetricId::NvlinkL2RxPerSec => vec![
+            ("direction", AttributeValue::Str("received")),
+            ("instance", AttributeValue::Str("2")),
+        ],
+        GpmMetricId::NvlinkL2TxPerSec => vec![
+            ("direction", AttributeValue::Str("transmitted")),
+            ("instance", AttributeValue::Str("2")),
+        ],
+        GpmMetricId::NvlinkL3RxPerSec => vec![
+            ("direction", AttributeValue::Str("received")),
+            ("instance", AttributeValue::Str("3")),
+        ],
+        GpmMetricId::NvlinkL3TxPerSec => vec![
+            ("direction", AttributeValue::Str("transmitted")),
+            ("instance", AttributeValue::Str("3")),
+        ],
+        GpmMetricId::NvlinkL4RxPerSec => vec![
+            ("direction", AttributeValue::Str("received")),
+            ("instance", AttributeValue::Str("4")),
+        ],
+        GpmMetricId::NvlinkL4TxPerSec => vec![
+            ("direction", AttributeValue::Str("transmitted")),
+            ("instance", AttributeValue::Str("4")),
+        ],
+        GpmMetricId::NvlinkL5RxPerSec => vec![
+            ("direction", AttributeValue::Str("received")),
+            ("instance", AttributeValue::Str("5")),
+        ],
+        GpmMetricId::NvlinkL5TxPerSec => vec![
+            ("direction", AttributeValue::Str("transmitted")),
+            ("instance", AttributeValue::Str("5")),
+        ],
+        GpmMetricId::NvlinkL6RxPerSec => vec![
+            ("direction", AttributeValue::Str("received")),
+            ("instance", AttributeValue::Str("6")),
+        ],
+        GpmMetricId::NvlinkL6TxPerSec => vec![
+            ("direction", AttributeValue::Str("transmitted")),
+            ("instance", AttributeValue::Str("6")),
+        ],
+        GpmMetricId::NvlinkL7RxPerSec => vec![
+            ("direction", AttributeValue::Str("received")),
+            ("instance", AttributeValue::Str("7")),
+        ],
+        GpmMetricId::NvlinkL7TxPerSec => vec![
+            ("direction", AttributeValue::Str("transmitted")),
+            ("instance", AttributeValue::Str("7")),
+        ],
+        GpmMetricId::NvlinkL8RxPerSec => vec![
+            ("direction", AttributeValue::Str("received")),
+            ("instance", AttributeValue::Str("8")),
+        ],
+        GpmMetricId::NvlinkL8TxPerSec => vec![
+            ("direction", AttributeValue::Str("transmitted")),
+            ("instance", AttributeValue::Str("8")),
+        ],
+        GpmMetricId::NvlinkL9RxPerSec => vec![
+            ("direction", AttributeValue::Str("received")),
+            ("instance", AttributeValue::Str("9")),
+        ],
+        GpmMetricId::NvlinkL9TxPerSec => vec![
+            ("direction", AttributeValue::Str("transmitted")),
+            ("instance", AttributeValue::Str("9")),
+        ],
+        GpmMetricId::NvlinkL10RxPerSec => vec![
+            ("direction", AttributeValue::Str("received")),
+            ("instance", AttributeValue::Str("10")),
+        ],
+        GpmMetricId::NvlinkL10TxPerSec => vec![
+            ("direction", AttributeValue::Str("transmitted")),
+            ("instance", AttributeValue::Str("10")),
+        ],
+        GpmMetricId::NvlinkL11RxPerSec => vec![
+            ("direction", AttributeValue::Str("received")),
+            ("instance", AttributeValue::Str("11")),
+        ],
+        GpmMetricId::NvlinkL11TxPerSec => vec![
+            ("direction", AttributeValue::Str("transmitted")),
+            ("instance", AttributeValue::Str("11")),
+        ],
+        GpmMetricId::NvlinkL12RxPerSec => vec![
+            ("direction", AttributeValue::Str("received")),
+            ("instance", AttributeValue::Str("12")),
+        ],
+        GpmMetricId::NvlinkL12TxPerSec => vec![
+            ("direction", AttributeValue::Str("transmitted")),
+            ("instance", AttributeValue::Str("12")),
+        ],
+        GpmMetricId::NvlinkL13RxPerSec => vec![
+            ("direction", AttributeValue::Str("received")),
+            ("instance", AttributeValue::Str("13")),
+        ],
+        GpmMetricId::NvlinkL13TxPerSec => vec![
+            ("direction", AttributeValue::Str("transmitted")),
+            ("instance", AttributeValue::Str("13")),
+        ],
+        GpmMetricId::NvlinkL14RxPerSec => vec![
+            ("direction", AttributeValue::Str("received")),
+            ("instance", AttributeValue::Str("14")),
+        ],
+        GpmMetricId::NvlinkL14TxPerSec => vec![
+            ("direction", AttributeValue::Str("transmitted")),
+            ("instance", AttributeValue::Str("14")),
+        ],
+        GpmMetricId::NvlinkL15RxPerSec => vec![
+            ("direction", AttributeValue::Str("received")),
+            ("instance", AttributeValue::Str("15")),
+        ],
+        GpmMetricId::NvlinkL15TxPerSec => vec![
+            ("direction", AttributeValue::Str("transmitted")),
+            ("instance", AttributeValue::Str("15")),
+        ],
+        GpmMetricId::NvlinkL16RxPerSec => vec![
+            ("direction", AttributeValue::Str("received")),
+            ("instance", AttributeValue::Str("16")),
+        ],
+        GpmMetricId::NvlinkL16TxPerSec => vec![
+            ("direction", AttributeValue::Str("transmitted")),
+            ("instance", AttributeValue::Str("16")),
+        ],
+        GpmMetricId::NvlinkL17RxPerSec => vec![
+            ("direction", AttributeValue::Str("received")),
+            ("instance", AttributeValue::Str("17")),
+        ],
+        GpmMetricId::NvlinkL17TxPerSec => vec![
+            ("direction", AttributeValue::Str("transmitted")),
+            ("instance", AttributeValue::Str("17")),
+        ],
+        _ => vec![],
     }
 }

--- a/plugins/nvidia-nvml/src/metrics.rs
+++ b/plugins/nvidia-nvml/src/metrics.rs
@@ -310,7 +310,7 @@ fn create_gpm_metrics(
     })
 }
 
-/// Maps a [GpmMetricId] to a vector of attribtues that should be added to the corresponding MeasurementPoint
+/// Maps a [GpmMetricId] to a vector of attributes that should be added to the corresponding MeasurementPoint
 pub fn match_gpm_id_to_attributes(gpm_metric: &GpmMetricId) -> Vec<(&'static str, AttributeValue)> {
     match gpm_metric {
         GpmMetricId::AnyTensorUtil => vec![("operation_type", AttributeValue::Str("any"))],

--- a/plugins/nvidia-nvml/src/nvml/detect.rs
+++ b/plugins/nvidia-nvml/src/nvml/detect.rs
@@ -156,6 +156,10 @@ mod tests {
                 .expect_clock_info()
                 .returning(|_| Err(NvmlError::NotSupported))
                 .times(1);
+            device
+                .expect_gpm_support()
+                .returning(|| Err(NvmlError::NotSupported))
+                .times(1);
             Ok(device)
         });
 

--- a/plugins/nvidia-nvml/src/nvml/features.rs
+++ b/plugins/nvidia-nvml/src/nvml/features.rs
@@ -50,6 +50,8 @@ pub struct OptionalFeatures {
     pub clock_info: bool,
     // Amount of used GPU memory.
     pub used_gpu_memory: bool,
+
+    pub gpm_metrics: bool,
 }
 
 impl OptionalFeatures {
@@ -69,6 +71,7 @@ impl OptionalFeatures {
             clock_info: check_clock_info(device)?,
             used_gpu_memory: check_running_compute_processes(device)? != AvailableVersion::None
                 || check_running_graphics_processes(device)? != AvailableVersion::None,
+            gpm_metrics: is_supported(device.gpm_support())?,
         })
     }
 
@@ -84,6 +87,7 @@ impl OptionalFeatures {
             || self.running_graphics_processes != AvailableVersion::None
             || self.clock_info
             || self.used_gpu_memory
+            || self.gpm_metrics
     }
 }
 
@@ -214,6 +218,7 @@ mod tests {
             running_graphics_processes: AvailableVersion::Latest,
             clock_info: true,
             used_gpu_memory: true,
+            gpm_metrics: true,
         };
         assert_eq!(
             format!("{}", features),
@@ -236,6 +241,7 @@ mod tests {
             running_graphics_processes: AvailableVersion::None,
             clock_info: false,
             used_gpu_memory: true,
+            gpm_metrics: true,
         };
         assert_eq!(
             format!("{}", features),
@@ -259,6 +265,7 @@ mod tests {
             running_graphics_processes: AvailableVersion::None,
             clock_info: false,
             used_gpu_memory: false,
+            gpm_metrics: false,
         };
         assert!(!features.has_any());
     }
@@ -311,6 +318,7 @@ mod tests {
             })
             .times(1);
         device.expect_clock_info().returning(|_| Err(NvmlError::NotSupported));
+        device.expect_gpm_support().returning(|| Err(NvmlError::NotSupported));
 
         let features = OptionalFeatures::detect_on(&device).expect("detection failed");
         assert_eq!(
@@ -328,6 +336,7 @@ mod tests {
                 running_graphics_processes: AvailableVersion::None,
                 clock_info: false,
                 used_gpu_memory: true,
+                gpm_metrics: false
             }
         );
 
@@ -353,6 +362,7 @@ mod tests {
                 running_graphics_processes: AvailableVersion::Latest,
                 clock_info: false,
                 used_gpu_memory: true,
+                gpm_metrics: false
             }
         );
 

--- a/plugins/nvidia-nvml/src/nvml/mod.rs
+++ b/plugins/nvidia-nvml/src/nvml/mod.rs
@@ -1,6 +1,9 @@
 use std::fmt::Display;
 
-use nvml_wrapper::enum_wrappers::device::Clock;
+use nvml_wrapper::{
+    enum_wrappers::device::Clock, enums::gpm::GpmMetricId, error::NvmlError, struct_wrappers::gpm::GpmMetricResult,
+};
+use nvml_wrapper_sys::bindings::nvmlGpmSample_t;
 
 pub mod detect;
 pub mod features;
@@ -106,6 +109,23 @@ pub trait NvmlDevice: Display + Send {
     /// Current clock frequency.
     /// See [`nvml_wrapper::Device::clock_info`].
     fn clock_info(&self, clock_type: Clock) -> NvmlResult<u32>;
+
+    /// Checks whether the device supports GPM metrics.
+    /// See [`nvml_wrapper::Device::gpm_support`]
+    fn gpm_support(&self) -> Result<bool, nvml_wrapper::error::NvmlError>;
+
+    /// Returns a raw GPM sample handle, which can be stored between calls.
+    /// See [`nvml_wrapper::Device::from_handle`]
+    fn gpm_handle(&self) -> nvmlGpmSample_t;
+
+    /// Returns GPM metrics between two timestamps, defined by [previous_handle] and [current_handle].
+    /// The metrics requested are given by [metric_ids].
+    fn gpm_metrics_get(
+        &self,
+        previous_handle: nvmlGpmSample_t,
+        current_handle: nvmlGpmSample_t,
+        metric_ids: &[GpmMetricId],
+    ) -> Result<Vec<Result<GpmMetricResult, NvmlError>>, NvmlError>;
 }
 
 #[cfg(test)]

--- a/plugins/nvidia-nvml/src/nvml/objects.rs
+++ b/plugins/nvidia-nvml/src/nvml/objects.rs
@@ -5,11 +5,13 @@ use crate::nvml::NvmlProvider;
 use super::{NvmlDevice, NvmlLib, NvmlResult};
 use anyhow::Context;
 use nvml_wrapper::{
-    Device, Nvml,
+    Device, GpmSample, Nvml,
     enum_wrappers::device::{Clock, TemperatureSensor},
-    struct_wrappers::device::ProcessInfo,
+    enums::gpm::GpmMetricId,
+    error::NvmlError,
+    struct_wrappers::{device::ProcessInfo, gpm::GpmMetricResult},
 };
-use nvml_wrapper_sys::bindings::nvmlDevice_t;
+use nvml_wrapper_sys::bindings::{nvmlDevice_t, nvmlGpmSample_t};
 use std::{fmt::Display, sync::Arc};
 
 pub struct NvmlLoader;
@@ -202,6 +204,32 @@ impl NvmlDevice for ManagedDevice {
     /// See [`nvml_wrapper::Device::clock_info`].
     fn clock_info(&self, clock_type: Clock) -> NvmlResult<u32> {
         self.as_underlying_device().clock_info(clock_type)
+    }
+
+    /// Checks whether the device supports GPM metrics.
+    /// See [`nvml_wrapper::Device::gpm_support`]
+    fn gpm_support(&self) -> Result<bool, nvml_wrapper::error::NvmlError> {
+        self.as_underlying_device().gpm_support()
+    }
+
+    /// Returns a raw GPM sample handle, which can be stored between calls.
+    /// See [`nvml_wrapper::Device::from_handle`]
+    fn gpm_handle(&self) -> nvmlGpmSample_t {
+        unsafe { self.as_underlying_device().gpm_sample().unwrap().handle() }
+    }
+
+    /// Returns GPM metrics between two timestamps, defined by [previous_handle] and [current_handle].
+    /// The metrics requested are given by [metric_ids].
+    fn gpm_metrics_get<'nvml>(
+        &self,
+        previous_handle: nvmlGpmSample_t,
+        current_handle: nvmlGpmSample_t,
+        metric_ids: &[GpmMetricId],
+    ) -> Result<Vec<Result<GpmMetricResult, NvmlError>>, NvmlError> {
+        let previous_sample = unsafe { GpmSample::<'_>::from_handle(&self.lib.0, previous_handle) };
+        let current_sample = unsafe { GpmSample::<'_>::from_handle(&self.lib.0, current_handle) };
+
+        nvml_wrapper::gpm::gpm_metrics_get(&self.lib.0, &previous_sample, &current_sample, metric_ids)
     }
 }
 

--- a/plugins/nvidia-nvml/src/probe.rs
+++ b/plugins/nvidia-nvml/src/probe.rs
@@ -1,10 +1,11 @@
 use anyhow::{Context, anyhow};
 use nvml_wrapper::{
     enum_wrappers::device::{Clock, TemperatureSensor},
-    enums::device::UsedGpuMemory,
+    enums::{device::UsedGpuMemory, gpm::GpmMetricId},
     error::NvmlError,
     struct_wrappers::device::ProcessInfo,
 };
+use nvml_wrapper_sys::bindings::nvmlGpmSample_t;
 use std::{borrow::Cow, time::SystemTime};
 
 use alumet::{
@@ -15,7 +16,7 @@ use alumet::{
 };
 
 use crate::{
-    metrics::{FullMetrics, MinimalMetrics},
+    metrics::{FullMetrics, MinimalMetrics, match_gpm_id_to_attributes},
     nvml::{
         NvmlDevice,
         features::{AvailableVersion, DetectedDevice},
@@ -37,6 +38,11 @@ pub struct FullSource<D: NvmlDevice> {
     metrics: FullMetrics,
     /// Alumet resource ID.
     resource: Resource,
+
+    /// Last GPM sample handle.
+    previous_gpm_handle: nvmlGpmSample_t,
+    /// List of GPM metrics to monitor.
+    gpm_keys: Vec<GpmMetricId>,
 
     /// Last poll timestamp
     last_poll_timestamp: Option<Timestamp>,
@@ -111,12 +117,16 @@ fn push_mem_usage_per_process<D: NvmlDevice>(
 impl<D: NvmlDevice> FullSource<D> {
     pub fn new(device: DetectedDevice<D>, metrics: FullMetrics) -> Result<Self, NvmlError> {
         let bus_id = Cow::Owned(device.inner.bus_id().to_owned());
+        let gpm_handle = device.inner.gpm_handle();
+        let gpm_keys = metrics.gpm_metrics_ids();
         Ok(FullSource {
             energy_counter: CounterDiff::with_max_value(u64::MAX),
             device,
             metrics,
             resource: Resource::Gpu { bus_id },
             last_poll_timestamp: None,
+            previous_gpm_handle: gpm_handle,
+            gpm_keys,
         })
     }
 }
@@ -399,6 +409,40 @@ impl<D: NvmlDevice> Source for FullSource<D> {
                     .with_attr("clock_type", clock_type_to_str(clock_type)?),
                 );
             }
+        }
+
+        // Push requested GPM metrics
+        if features.gpm_metrics {
+            // getting a handle to a new sample
+            let new_handle = device.gpm_handle();
+            // computing metrics between previous and current sample
+            let gpm_metrics = device.gpm_metrics_get(self.previous_gpm_handle, new_handle, self.gpm_keys.as_slice())?;
+
+            for gpm_metric in gpm_metrics {
+                let Ok(gpm_metric_result) = gpm_metric else { continue };
+                let gpm_id = gpm_metric_result.clone().metric_id;
+                let gpm_value = gpm_metric_result.value;
+
+                if let Some(&alumet_metric) = {
+                    let metrics = &self.metrics;
+                    metrics.gpm_metrics.get(&gpm_id)
+                } {
+                    // pushing the gpm metric, with the corresponding alumet metric id and attributes
+                    measurements.push(
+                        MeasurementPoint::new(
+                            timestamp,
+                            alumet_metric,
+                            self.resource.clone(),
+                            consumer.clone(),
+                            gpm_value as u64,
+                        )
+                        .with_attr_vec(match_gpm_id_to_attributes(&gpm_id)),
+                    )
+                }
+            }
+
+            // replacing previous sample handle by the new one
+            self.previous_gpm_handle = new_handle;
         }
 
         Ok(())

--- a/plugins/nvidia-nvml/src/probe.rs
+++ b/plugins/nvidia-nvml/src/probe.rs
@@ -98,7 +98,7 @@ fn push_mem_usage_per_process<D: NvmlDevice>(
                 };
 
                 let mut measurement =
-                    MeasurementPoint::new(timestamp, source.metrics.used_gpu_memory, resource, consumer, n as u64)
+                    MeasurementPoint::new(timestamp, source.metrics.used_gpu_memory, resource, consumer, n)
                         .with_attr("context", context);
 
                 match process_info.compute_instance_id {


### PR DESCRIPTION
Adds more precise metrics to NVML using GPM metrics, including SM occupancy, Tensor Core usage, links throughput in bytes/s ...

~~Currently using @TheElectronWill's fork of nvml-wrapper as his modifications haven't been merged into the main branch yet.~~ Modifications have been merged as of v 0.13.0 of nvml-wrapper.