### PR TITLE
feat(perf): introduce modifiers + new event syntax

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -40,6 +40,7 @@ jumphost
 kwollect
 libdrm
 libgflags
+libpfm
 libpowercap
 libusb
 miri

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3256,8 +3256,10 @@ dependencies = [
  "humantime-serde",
  "itertools 0.13.0",
  "log",
+ "perf-event-open-sys2",
  "perf-event2",
  "serde",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]

--- a/plugins/perf/Cargo.toml
+++ b/plugins/perf/Cargo.toml
@@ -13,7 +13,11 @@ humantime-serde.workspace = true
 itertools = "0.13.0"
 log.workspace = true
 perf-event2 = "0.7.4"
+perf-event-open-sys2 = "5.0.6"
 serde = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+toml = "0.9.5"
 
 [lints]
 workspace = true

--- a/plugins/perf/README.md
+++ b/plugins/perf/README.md
@@ -9,39 +9,87 @@ This plugin works in a similar way to the [`perf` command-line tool](https://man
 - Linux (`perf_events` is a kernel feature)
 - [Required capabilities](#perf_event_paranoid-and-capabilities).
 
-## Metrics
+## Events
 
-Here are the metrics collected by the plugin's source.
-All the metrics are counters.
+Events to measure are described with a single unified syntax, following the `perf stat -e`
+[event selection syntax](https://man7.org/linux/man-pages/man1/perf-stat.1.html). Each event is a
+string of the form `<event>[:<modifiers>]`
+
+### Event formats
+
+The `<event>` part can be, mirroring `perf stat -e`:
+
+- A **symbolic event name** (e.g. `INSTRUCTIONS`, `LL_READ_MISS`). The names
+  known to the plugin are listed in [Symbolic event names](#symbolic-event-names) below. (**Supported**)
+- A **raw PMU event** `rN`, where `N` is a hexadecimal value
+  that represents the raw register encoding with the layout described by
+  `/sys/bus/event_source/devices/cpu/format/*`. (**Not yet supported**)
+- A a **symbolically formed PMU event**
+  `pmu/config=M,config1=N,config2=K/`, where `M`, `N`, `K` are numbers (decimal, hex or octal) whose
+  acceptable values are defined by `/sys/bus/event_source/devices/<pmu>/format/*`. (**Not yet supported**)
+- The **named-parameter variant** `pmu/param1=0x3,param2/`,
+  where `param1`/`param2` are formats defined for the PMU in
+  `/sys/bus/event_source/devices/<pmu>/format/*`, and the uncore / `percore` qualifiers. (**Not yet supported**)
+
+Any event, symbolic or raw, may be followed by an optional colon and a list of
+[modifiers](#modifiers), e.g. `INSTRUCTIONS:u` or `CACHE_MISSES:u:k`.
+
+A form that is recognised but not yet supported is rejected with an explicit "planned for a future
+release" error, so the config surface stays stable: upcoming releases will encode these forms
+without changing the syntax.
+
+### Symbolic event names
+
+Currently the plugin resolves symbolic names against the **native** kernel tables. The name is one of:
+
+**Hardware events**:
+`CPU_CYCLES`, `INSTRUCTIONS`, `CACHE_REFERENCES`, `CACHE_MISSES`, `BRANCH_INSTRUCTIONS`, `BRANCH_MISSES`, `BUS_CYCLES`, `STALLED_CYCLES_FRONTEND`, `STALLED_CYCLES_BACKEND`, `REF_CPU_CYCLES`.
+
+**Software events**:
+`PAGE_FAULTS`, `CONTEXT_SWITCHES`, `CPU_MIGRATIONS`, `PAGE_FAULTS_MIN`, `PAGE_FAULTS_MAJ`, `ALIGNMENT_FAULTS`, `EMULATION_FAULTS`, `CGROUP_SWITCHES`.
+
+**Cache events** (`{cache-id}_{cache-op}_{cache-result}`), built from:
+- `cache-id`: one of `L1D`, `L1I`, `LL`, `DTLB`, `ITLB`, `BPU`, `NODE`
+- `cache-op`: one of `READ`, `WRITE`, `PREFETCH`
+- `cache-result`: one of `ACCESS`, `MISS`
+
+For example: `LL_READ_MISS`.
+
+(Resolving arbitrary symbolic names through libpfm, for names outside these native tables, is
+planned.)
 
 To learn more about the standard events, please refer to the [`perf_event_open` manual](https://man7.org/linux/man-pages/man2/perf_event_open.2.html).
 To list the events that are available on your machine, run the `perf list` command.
-
-**For hardware related metrics:**
-
-`perf_hardware_{hardware-event-name}` where `hardware-event-name` is one of:
-
-`CPU_CYCLES`, `INSTRUCTIONS`, `CACHE_REFERENCES`, `CACHE_MISSES`, `BRANCH_INSTRUCTIONS`, `BRANCH_MISSES`, `BUS_CYCLES`, `STALLED_CYCLES_FRONTEND`, `STALLED_CYCLES_BACKEND`, `REF_CPU_CYCLES`.
-
-**For software related metrics:**
-
-`perf_software_{software-event-name}` where `software-event-name` is one of:
-
-`PAGE_FAULTS`, `CONTEXT_SWITCHES`, `CPU_MIGRATIONS`, `PAGE_FAULTS_MIN`, `PAGE_FAULTS_MAJ`, `ALIGNMENT_FAULTS`, `EMULATION_FAULTS`, `CGROUP_SWITCHES`.
-
-**For cache related metrics:**
-
-`perf_cache_{cache-id}_{cache-op}_{cache-result}` where:
-
-`cache-id` is one of `L1D`, `L1I`, `LL`, `DTLB`, `ITLB`, `BPU`, `NODE`
-
-`cache-op` is one of `READ`, `WRITE` or `PREFETCH`.
-
-`cache-result` is one of `ACCESS` or `MISS`.
-
 Note that based on your kernel version, some events could be unavailable.
 
-### Attributes
+### Modifiers
+
+Modifiers restrict or refine an event; several can be chained. You can write them grouped after a
+single colon (`INSTRUCTIONS:uk`) or each after its own colon (`INSTRUCTIONS:u:k`) — both are
+equivalent.
+
+For now these modifiers are supported:
+
+| Modifier | Effect                              |
+| -------- | ----------------------------------- |
+| `u`      | user space only                     |
+| `k`      | kernel space only                   |
+| `h`      | hypervisor only                     |
+| `H`      | host only (exclude guest)           |
+| `G`      | guest only (exclude host)           |
+| `I`      | exclude idle                        |
+
+**Defaults.** With no modifier, an event is measured in **user space only**: kernel space and the
+hypervisor are excluded. The domain modifiers (`u`/`k`/`h`) work as a group: as soon as you specify
+at least one of them, the domains you *don't* list are excluded, so `:u` means "user space only" and
+`:u:k` means "user and kernel, but not hypervisor".
+
+### Metric naming
+
+By default the metric is named `perf_{name}` (e.g. `INSTRUCTIONS` → `perf_INSTRUCTIONS`). The
+modifiers do not change the metric name, so if you measure the same event with different modifiers,
+give at least one of them a `rename` to avoid a name clash. A `rename` replaces the whole suffix;
+the metric then becomes `perf_{rename}`.
 
 ## Configuration
 
@@ -52,20 +100,13 @@ Here is a configuration example of the plugin. It's part of the Alumet configura
 # Description.
 poll_interval = "1s"
 flush_interval = "1s"
-hardware_events = [
+events = [
     "REF_CPU_CYCLES",
     "CACHE_MISSES",
     "BRANCH_MISSES",
-#   // any {hardware-event-name} from the list previously mentionned
-]
-software_events = [
-    "PAGE_FAULTS",
-    "CONTEXT_SWITCHES",
-#   // any {software-event-name} from the list previously mentionned
-]
-cache_events = [
-    "LL_READ_MISS",
-#   // any combination of {cache-id}_{cache-op}_{cache-result} from the lists previously mentionned
+    "INSTRUCTIONS:u:k",                              # user-space and kernel instructions only
+    { event = "CONTEXT_SWITCHES", rename = "ctxsw" }, # -> metric perf_ctxsw
+    { event = "LL_READ_MISS:h", rename = "LL_READ_MISS_HYPERVISOR"}, # hypervisor instructions only
 ]
 ```
 

--- a/plugins/perf/src/lib.rs
+++ b/plugins/perf/src/lib.rs
@@ -14,9 +14,7 @@ use alumet::{
     units::Unit,
 };
 use anyhow::Context;
-use events::NamedPerfEvent;
 use itertools::Itertools;
-use perf_event::events::{Cache, Hardware, Software};
 use serde::{Deserialize, Serialize};
 
 use crate::source::{Observable, PerfEventSourceBuilder};
@@ -27,6 +25,7 @@ compile_error!("This plugin only works on Linux.");
 mod cpu;
 mod events;
 mod source;
+mod spec;
 
 pub struct PerfPlugin {
     config: Arc<Mutex<ParsedConfig>>,
@@ -51,29 +50,15 @@ impl AlumetPlugin for PerfPlugin {
             // Store the source settings.
             poll_interval: config.poll_interval,
             flush_interval: config.flush_interval,
-            // Parse the perf events.
-            hardware_events: config
-                .hardware_events
-                .into_iter()
-                .map(|e| events::parse_hardware(&e))
+            // Parse the perf events with the unified syntax.
+            events: config
+                .events
+                .iter()
+                .map(spec::parse)
                 .try_collect()
-                .context("invalid hardware event in config")?,
-            software_events: config
-                .software_events
-                .into_iter()
-                .map(|e| events::parse_software(&e))
-                .try_collect()
-                .context("invalid software event in config")?,
-            cache_events: config
-                .cache_events
-                .into_iter()
-                .map(|e| events::parse_cache(&e))
-                .try_collect()
-                .context("invalid cache event in config")?,
+                .context("invalid event in config")?,
             // The metrics are initialized in start()
-            hardware_metrics: Vec::new(),
-            software_metrics: Vec::new(),
-            cache_metrics: Vec::new(),
+            metrics: Vec::new(),
         };
         Ok(Box::new(PerfPlugin {
             config: Arc::new(Mutex::new(config)),
@@ -83,28 +68,13 @@ impl AlumetPlugin for PerfPlugin {
     fn start(&mut self, alumet: &mut alumet::plugin::AlumetPluginStart) -> anyhow::Result<()> {
         let mut config = self.config.lock().unwrap();
 
-        let mut hardware_metrics = Vec::with_capacity(config.hardware_events.len());
-        let mut software_metrics = Vec::with_capacity(config.software_events.len());
-        let mut cache_metrics = Vec::with_capacity(config.cache_events.len());
-
-        for e in &config.hardware_events {
-            let metric_name = format!("perf_hardware_{}", e.name);
+        let mut metrics = Vec::with_capacity(config.events.len());
+        for e in &config.events {
+            let metric_name = format!("perf_{}", e.metric_suffix);
             let metric = alumet.create_metric::<u64>(metric_name, Unit::Unity, e.description.clone())?;
-            hardware_metrics.push(metric);
+            metrics.push(metric);
         }
-        for e in &config.software_events {
-            let metric_name = format!("perf_software_{}", e.name);
-            let metric = alumet.create_metric::<u64>(metric_name, Unit::Unity, e.description.clone())?;
-            software_metrics.push(metric);
-        }
-        for e in &config.cache_events {
-            let metric_name = format!("perf_cache_{}", e.name);
-            let metric = alumet.create_metric::<u64>(metric_name, Unit::Unity, e.description.clone())?;
-            cache_metrics.push(metric);
-        }
-        config.hardware_metrics = hardware_metrics;
-        config.software_metrics = software_metrics;
-        config.cache_metrics = cache_metrics;
+        config.metrics = metrics;
         Ok(())
     }
 
@@ -137,26 +107,10 @@ impl AlumetPlugin for PerfPlugin {
                     log::info!("Starting to observe {o:?}...");
                     let config = config_cloned.lock().unwrap();
                     let mut builder = PerfEventSourceBuilder::observe(o)?;
-                    for (event, metric) in config.hardware_events.iter().zip(&config.hardware_metrics) {
-                        builder.add(event.event, *metric).with_context(|| {
-                            format!(
-                                "could not configure hardware event {} (code {})",
-                                event.name, event.event.0
-                            )
-                        })?;
-                    }
-                    for (event, metric) in config.software_events.iter().zip(&config.software_metrics) {
-                        builder.add(event.event, *metric).with_context(|| {
-                            format!(
-                                "could not configure software event {} (code {})",
-                                event.name, event.event.0
-                            )
-                        })?;
-                    }
-                    for (event, metric) in config.cache_events.iter().zip(&config.cache_metrics) {
+                    for (event, metric) in config.events.iter().zip(&config.metrics) {
                         builder
-                            .add(event.event.clone(), *metric)
-                            .with_context(|| format!("could not configure cache event {}", event.name))?;
+                            .add(&event.event, *metric)
+                            .with_context(|| format!("could not configure event {}", event.metric_suffix))?;
                     }
                     let poll_interval = config.poll_interval;
                     let flush_interval = config.flush_interval;
@@ -190,9 +144,11 @@ struct Config {
     #[serde(with = "humantime_serde")]
     flush_interval: Duration,
 
-    hardware_events: Vec<String>,
-    software_events: Vec<String>,
-    cache_events: Vec<String>,
+    /// The events to measure, described with the unified syntax (see [`spec`]).
+    ///
+    /// Each entry is either a bare string (`"REF_CPU_CYCLES"`, `"INSTRUCTIONS:u"`) or an inline
+    /// table with an optional metric `rename` (`{ event = "LL_READ_MISS", rename = "llc_miss" }`).
+    events: Vec<spec::EventEntry>,
 }
 
 impl Default for Config {
@@ -201,13 +157,12 @@ impl Default for Config {
             poll_interval: Duration::from_secs(1), // 1Hz
             flush_interval: Duration::from_secs(5),
 
-            hardware_events: vec![
-                "REF_CPU_CYCLES".to_owned(),
-                "CACHE_MISSES".to_owned(),
-                "BRANCH_MISSES".to_owned(),
+            events: vec![
+                spec::EventEntry::Simple("REF_CPU_CYCLES".to_owned()),
+                spec::EventEntry::Simple("CACHE_MISSES".to_owned()),
+                spec::EventEntry::Simple("BRANCH_MISSES".to_owned()),
+                spec::EventEntry::Simple("LL_READ_MISS".to_owned()),
             ],
-            software_events: vec![],
-            cache_events: vec!["LL_READ_MISS".to_owned()],
         }
     }
 }
@@ -217,10 +172,6 @@ struct ParsedConfig {
     poll_interval: Duration,
     flush_interval: Duration,
 
-    hardware_events: Vec<NamedPerfEvent<Hardware>>,
-    software_events: Vec<NamedPerfEvent<Software>>,
-    cache_events: Vec<NamedPerfEvent<Cache>>,
-    hardware_metrics: Vec<TypedMetricId<u64>>,
-    software_metrics: Vec<TypedMetricId<u64>>,
-    cache_metrics: Vec<TypedMetricId<u64>>,
+    events: Vec<spec::ParsedEvent>,
+    metrics: Vec<TypedMetricId<u64>>,
 }

--- a/plugins/perf/src/source.rs
+++ b/plugins/perf/src/source.rs
@@ -11,6 +11,7 @@ use anyhow::Context;
 use itertools::Itertools;
 
 use crate::cpu;
+use crate::spec::ConfiguredEvent;
 
 #[derive(Debug)]
 pub enum Observable {
@@ -89,11 +90,7 @@ impl PerfEventSourceBuilder {
         })
     }
 
-    pub fn add<E: perf_event::events::Event + Clone>(
-        &mut self,
-        event: E,
-        alumet_metric: TypedMetricId<u64>,
-    ) -> anyhow::Result<&mut Self> {
+    pub fn add(&mut self, event: &ConfiguredEvent, alumet_metric: TypedMetricId<u64>) -> anyhow::Result<&mut Self> {
         // Returns a new [`perf_event::Builder`] configured to build a group of perf events.
         fn new_group_builder<'a>() -> perf_event::Builder<'a> {
             use perf_event::ReadFormat;
@@ -120,8 +117,11 @@ impl PerfEventSourceBuilder {
                         .with_context(|| format!("build_group with observe_pid({pid}).any_cpu()"))?;
 
                     // add event (the params must be the same)
+                    let mut event_builder = perf_event::Builder::new(event.clone());
+                    event_builder.observe_pid(*pid).any_cpu();
+                    event.configure(&mut event_builder);
                     let counter = perf_group
-                        .add(perf_event::Builder::new(event).observe_pid(*pid).any_cpu())
+                        .add(&event_builder)
                         .with_context(|| format!("perf_group.add with observe_pid({pid}).any_cpu()"))?;
 
                     // add metadata
@@ -154,12 +154,11 @@ impl PerfEventSourceBuilder {
                             .with_context(|| format!("build_group with observe_cgroup({path}).one_cpu({cpu_id})"))?;
 
                         // add event (the params must be the same)
+                        let mut event_builder = perf_event::Builder::new(event.clone());
+                        event_builder.observe_cgroup(fd).one_cpu(cpu_id);
+                        event.configure(&mut event_builder);
                         let counter = perf_group
-                            .add(
-                                perf_event::Builder::new(event.clone())
-                                    .observe_cgroup(fd)
-                                    .one_cpu(cpu_id),
-                            )
+                            .add(&event_builder)
                             .with_context(|| format!("perf_group.add with observe_cgroup({path}).one_cpu({cpu_id})"))?;
 
                         let group_with_info = EventGroup {
@@ -190,6 +189,7 @@ impl PerfEventSourceBuilder {
                         event_builder.observe_cgroup(fd).one_cpu(group.cpu_id.unwrap() as usize);
                     }
                 }
+                event.configure(&mut event_builder);
 
                 let counter = group.perf_group.add(&event_builder).with_context(|| {
                     format!(

--- a/plugins/perf/src/spec.rs
+++ b/plugins/perf/src/spec.rs
@@ -1,0 +1,397 @@
+//! Unified perf event descriptor.
+//!
+//! An event is written `<event>[:<modifiers>]`, following the `perf stat -e` syntax. A single
+//! parser owns the syntax: it splits off the modifiers (`:u`, `:k`, …) and applies them itself,
+//! so a modifier behaves identically whatever the event's source.
+//!
+//! `<event>` can take several forms. We support a subset for now and *recognise* the rest so the
+//! syntax stays stable across releases:
+//!
+//! - a **symbolic event name**, e.g. `INSTRUCTIONS` or `LL_READ_MISS` **supported**, encoded from
+//!   the native kernel tables (hardware/software/cache). Encoding arbitrary names through libpfm is
+//!   planned.
+//! - a **raw PMU event** `rN`, where `N` is a hexadecimal value representing the raw register
+//!   encoding, with the layout described by `/sys/bus/event_source/devices/cpu/format/*`
+//!   **not yet supported** (planned).
+//! - a **symbolically formed PMU event** `pmu/config=M,config1=N,config2=K/`, where `M`, `N`, `K`
+//!   are numbers whose acceptable values are defined by
+//!   `/sys/bus/event_source/devices/<pmu>/format/*` **not yet supported** (planned).
+//! - the named-parameter variant `pmu/param1=0x3,param2/` and the uncore/`percore` qualifiers
+//!   **not yet supported** (planned).
+//!
+//! A not-yet-supported form is recognised by [`resolve_event`] and rejected with an explicit "planned for a
+//! future release" error.
+
+use anyhow::Context;
+use perf_event::events::{Cache, Event, Hardware, Software};
+use perf_event_open_sys::bindings::perf_event_attr;
+use serde::{Deserialize, Serialize};
+
+use crate::events;
+
+/// One entry of the `events` config list: a bare string, or a table with a metric `rename`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum EventEntry {
+    Simple(String),
+    Detailed {
+        event: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        rename: Option<String>,
+    },
+}
+
+impl EventEntry {
+    fn parts(&self) -> (&str, Option<&str>) {
+        match self {
+            EventEntry::Simple(s) => (s, None),
+            EventEntry::Detailed { event, rename } => (event, rename.as_deref()),
+        }
+    }
+}
+
+/// perf event domain modifiers, e.g. `INSTRUCTIONS:u:k`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Modifiers {
+    user: bool,
+    kernel: bool,
+    hv: bool,
+    host: bool,
+    guest: bool,
+    idle_only: bool,
+}
+
+impl Modifiers {
+    /// Parse the modifier characters that follow the first `:` (the group separators `:` in
+    /// `u:k` are ignored).
+    fn parse(s: &str) -> anyhow::Result<Self> {
+        let mut m = Modifiers::default();
+        for c in s.chars() {
+            match c {
+                ':' => {}
+                'u' => m.user = true,
+                'k' => m.kernel = true,
+                'h' => m.hv = true,
+                'H' => m.host = true,
+                'G' => m.guest = true,
+                'I' => m.idle_only = true,
+                other => anyhow::bail!("unknown modifier '{other}'"),
+            }
+        }
+        Ok(m)
+    }
+
+    /// The `exclude_*` bits these modifiers produce.
+    ///
+    /// With no domain modifier we keep the original plugin's default **user space only** (kernel
+    /// and hypervisor excluded). A domain modifier restricts to the listed domains by excluding the others.
+    fn excludes(&self) -> Excludes {
+        let (user, kernel, hv) = if self.user || self.kernel || self.hv {
+            (!self.user, !self.kernel, !self.hv)
+        } else {
+            (false, true, true)
+        };
+        Excludes {
+            user,
+            kernel,
+            hv,
+            host: self.guest && !self.host,  // guest-only excludes the host
+            guest: self.host && !self.guest, // host-only excludes the guest
+            idle: self.idle_only,
+        }
+    }
+
+    /// Apply the modifiers to a builder. This must run *after* [`perf_event::Builder::new`], which
+    /// forces its own `exclude_kernel`/`exclude_hv` defaults; we set every bit explicitly so the
+    /// result never depends on that ordering.
+    fn configure(&self, builder: &mut perf_event::Builder<'_>) {
+        let e = self.excludes();
+        builder
+            .exclude_user(e.user)
+            .exclude_kernel(e.kernel)
+            .exclude_hv(e.hv)
+            .exclude_host(e.host)
+            .exclude_guest(e.guest)
+            .exclude_idle(e.idle);
+    }
+}
+
+/// The `exclude_*` bits computed from a [`Modifiers`] set (`true` = the domain is *not* measured).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Excludes {
+    user: bool,
+    kernel: bool,
+    hv: bool,
+    host: bool,
+    guest: bool,
+    idle: bool,
+}
+
+/// An encoded event, whatever its source. Future sources (`Raw`, `Pfm`) are added as new variants.
+#[derive(Debug, Clone)]
+enum AnyEvent {
+    Hardware(Hardware),
+    Software(Software),
+    Cache(Cache),
+}
+
+impl AnyEvent {
+    fn update_attrs(self, attr: &mut perf_event_attr) {
+        match self {
+            AnyEvent::Hardware(e) => e.update_attrs(attr),
+            AnyEvent::Software(e) => e.update_attrs(attr),
+            AnyEvent::Cache(e) => e.update_attrs(attr),
+        }
+    }
+}
+
+/// A fully-configured event ready to be added to a perf group: an encoding plus its modifiers.
+#[derive(Debug, Clone)]
+pub struct ConfiguredEvent {
+    inner: AnyEvent,
+    modifiers: Modifiers,
+}
+
+impl Event for ConfiguredEvent {
+    fn update_attrs(self, attr: &mut perf_event_attr) {
+        // Only encode the event here. The modifiers are applied by [`Self::configure`] *after*
+        // `Builder::new`, otherwise its forced `exclude_kernel`/`exclude_hv` defaults would clobber
+        // them.
+        self.inner.update_attrs(attr);
+    }
+}
+
+impl ConfiguredEvent {
+    /// Apply this event's modifiers to a freshly-created builder. Required for the modifiers to
+    /// take effect.
+    pub fn configure(&self, builder: &mut perf_event::Builder<'_>) {
+        self.modifiers.configure(builder);
+    }
+}
+
+/// A parsed config event: the metric name suffix (after `perf_`), a description and the event.
+#[derive(Debug)]
+pub struct ParsedEvent {
+    pub metric_suffix: String,
+    pub description: String,
+    pub event: ConfiguredEvent,
+}
+
+/// Parse one config entry into a [`ParsedEvent`].
+pub fn parse(entry: &EventEntry) -> anyhow::Result<ParsedEvent> {
+    let (input, rename) = entry.parts();
+    let (name, mods_str) = input.split_once(':').unwrap_or((input, ""));
+    if name.is_empty() {
+        anyhow::bail!("empty event name in '{input}'");
+    }
+
+    let ctx = || format!("invalid event '{input}'");
+    let modifiers = Modifiers::parse(mods_str).with_context(ctx)?;
+    let (event, canonical_name, description) = resolve_event(name).with_context(ctx)?;
+
+    let metric_suffix = match rename {
+        Some(r) => sanitize(r),
+        None => canonical_name,
+    };
+
+    Ok(ParsedEvent {
+        metric_suffix,
+        description,
+        event: ConfiguredEvent {
+            inner: event,
+            modifiers,
+        },
+    })
+}
+
+/// Resolve an event (no modifiers) to its encoding, returning the event, its canonical name (used
+/// for the metric name) and a description. See the module docs for the recognised forms.
+fn resolve_event(name: &str) -> anyhow::Result<(AnyEvent, String, String)> {
+    // Forms we recognise but do not encode yet: reject them explicitly so the syntax stays stable
+    // and the error is actionable.
+
+    // Raw PMU event `rN` (hex register encoding).
+    let looks_raw = name
+        .strip_prefix('r')
+        .map(|d| d.trim_start_matches("0x").trim_start_matches("0X"))
+        .is_some_and(|d| !d.is_empty() && d.chars().all(|c| c.is_ascii_hexdigit()));
+    if looks_raw {
+        anyhow::bail!("raw PMU events (`{name}`) are not supported yet; this is planned for a future release");
+    }
+    // Symbolically formed PMU event `pmu/.../`.
+    if name.contains('/') {
+        anyhow::bail!("PMU-term events (`{name}`) are not supported yet; this is planned for a future release");
+    }
+
+    // Symbolic event name: encoded from the native kernel tables.
+    if let Ok(e) = events::parse_hardware(name) {
+        return Ok((AnyEvent::Hardware(e.event), e.name, e.description));
+    }
+    if let Ok(e) = events::parse_software(name) {
+        return Ok((AnyEvent::Software(e.event), e.name, e.description));
+    }
+    if let Ok(e) = events::parse_cache(name) {
+        return Ok((AnyEvent::Cache(e.event), e.name, e.description));
+    }
+    anyhow::bail!(
+        "Unknown event '{name}': not a native hardware/software/cache event. \
+         Encoding arbitrary event names through libpfm is planned for a future release."
+    )
+}
+
+/// Turn a string into a metric-name-safe suffix: non-alphanumeric characters become `_`, and
+/// leading/trailing `_` are trimmed.
+fn sanitize(s: &str) -> String {
+    let mapped: String = s
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    mapped.trim_matches('_').to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_simple(s: &str) -> ParsedEvent {
+        parse(&EventEntry::Simple(s.to_owned())).unwrap()
+    }
+
+    #[test]
+    fn native_hardware() {
+        let e = parse_simple("REF_CPU_CYCLES");
+        assert_eq!(e.metric_suffix, "REF_CPU_CYCLES");
+        assert!(matches!(e.event.inner, AnyEvent::Hardware(_)));
+    }
+
+    #[test]
+    fn native_software() {
+        let e = parse_simple("CONTEXT_SWITCHES");
+        assert_eq!(e.metric_suffix, "CONTEXT_SWITCHES");
+        assert!(matches!(e.event.inner, AnyEvent::Software(_)));
+    }
+
+    #[test]
+    fn native_cache() {
+        let e = parse_simple("LL_READ_MISS");
+        assert_eq!(e.metric_suffix, "LL_READ_MISS");
+        assert!(matches!(e.event.inner, AnyEvent::Cache(_)));
+    }
+
+    #[test]
+    fn no_modifier_is_user_space_only() {
+        // The default must match the original plugin: user space only (kernel + hv excluded).
+        let e = parse_simple("INSTRUCTIONS");
+        assert_eq!(e.metric_suffix, "INSTRUCTIONS");
+        assert_eq!(
+            e.event.modifiers.excludes(),
+            Excludes {
+                user: false,
+                kernel: true,
+                hv: true,
+                host: false,
+                guest: false,
+                idle: false
+            }
+        );
+    }
+
+    #[test]
+    fn user_modifier_matches_default() {
+        let x = parse_simple("INSTRUCTIONS:u").event.modifiers.excludes();
+        assert!(!x.user && x.kernel && x.hv);
+    }
+
+    #[test]
+    fn user_and_kernel_modifier() {
+        // `:u:k` measures user and kernel, but still excludes the hypervisor.
+        let x = parse_simple("INSTRUCTIONS:u:k").event.modifiers.excludes();
+        assert!(!x.user);
+        assert!(!x.kernel);
+        assert!(x.hv);
+    }
+
+    #[test]
+    fn grouped_and_chained_modifiers_are_equivalent() {
+        // `:uk` (grouped) and `:u:k` (each after its own colon) must mean the same thing.
+        let grouped = parse_simple("INSTRUCTIONS:uk").event.modifiers.excludes();
+        let chained = parse_simple("INSTRUCTIONS:u:k").event.modifiers.excludes();
+        assert_eq!(grouped, chained);
+    }
+
+    #[test]
+    fn kernel_only_modifier() {
+        // `:k` measures kernel only: user is excluded, kernel is counted.
+        let x = parse_simple("INSTRUCTIONS:k").event.modifiers.excludes();
+        assert!(x.user);
+        assert!(!x.kernel);
+        assert!(x.hv);
+    }
+
+    #[test]
+    fn host_and_idle_modifiers() {
+        let x = parse_simple("INSTRUCTIONS:H:I").event.modifiers.excludes();
+        assert!(x.guest); // host only -> exclude guest
+        assert!(!x.host);
+        assert!(x.idle); // exclude idle
+    }
+
+    #[test]
+    fn unknown_modifier_is_rejected() {
+        assert!(parse(&EventEntry::Simple("INSTRUCTIONS:z".to_owned())).is_err());
+    }
+
+    #[test]
+    fn rename_overrides_metric_name() {
+        let e = parse(&EventEntry::Detailed {
+            event: "LL_READ_MISS".to_owned(),
+            rename: Some("my llc miss".to_owned()),
+        })
+        .unwrap();
+        assert_eq!(e.metric_suffix, "my_llc_miss");
+    }
+
+    #[test]
+    fn raw_code_rejected_for_now() {
+        // `rNNNN` is recognised by the syntax but not encoded yet.
+        let err = parse(&EventEntry::Simple("r0x412e".to_owned())).unwrap_err();
+        assert!(format!("{err:#}").contains("future release"), "got: {err:#}");
+    }
+
+    #[test]
+    fn pmu_term_rejected_for_now() {
+        let err = parse(&EventEntry::Simple("cpu/event=0x2e,umask=0x41/".to_owned())).unwrap_err();
+        assert!(format!("{err:#}").contains("future release"), "got: {err:#}");
+    }
+
+    #[test]
+    fn unknown_name_mentions_libpfm() {
+        let err = parse(&EventEntry::Simple("RESOURCE_STALLS".to_owned())).unwrap_err();
+        assert!(format!("{err:#}").contains("libpfm"), "got: {err:#}");
+    }
+
+    #[test]
+    fn empty_is_rejected() {
+        assert!(parse(&EventEntry::Simple(":u".to_owned())).is_err());
+    }
+
+    #[test]
+    fn config_list_deserializes_mixed_entries() {
+        // TOML 1.0 allows mixed-type arrays: bare strings and inline tables in the same list.
+        #[derive(serde::Deserialize)]
+        struct Wrap {
+            events: Vec<EventEntry>,
+        }
+        let toml = r#"
+            events = [
+                "INSTRUCTIONS",
+                "LL_READ_MISS",
+                { event = "CACHE_MISSES", rename = "my_event" },
+            ]
+        "#;
+        let w: Wrap = toml::from_str(toml).unwrap();
+        assert_eq!(w.events.len(), 3);
+        assert!(matches!(w.events[0], EventEntry::Simple(_)));
+        assert!(matches!(w.events[2], EventEntry::Detailed { .. }));
+    }
+}


### PR DESCRIPTION
Introducing modifiers to make configurable domain-level granularity.

Following a similar syntax as "perf-stat" does, having in mind the future evolution of the plugin that will support libpfm and raw configs, keeping the same <event> syntax.

details from the README:


The `<event>` part can be, mirroring `perf stat -e`:

- A **symbolic event name** (e.g. `INSTRUCTIONS`, `LL_READ_MISS`). The names
  known to the plugin are listed in [Symbolic event names](#symbolic-event-names) below. (**Supported**)
- A **raw PMU event** `rN`, where `N` is a hexadecimal value
  that represents the raw register encoding with the layout described by
  `/sys/bus/event_source/devices/cpu/format/*`. (**Not yet supported**)
- A a **symbolically formed PMU event**
  `pmu/config=M,config1=N,config2=K/`, where `M`, `N`, `K` are numbers (decimal, hex or octal) whose
  acceptable values are defined by `/sys/bus/event_source/devices/<pmu>/format/*`. (**Not yet supported**)
- The **named-parameter variant** `pmu/param1=0x3,param2/`,
  where `param1`/`param2` are formats defined for the PMU in
  `/sys/bus/event_source/devices/<pmu>/format/*`, and the uncore / `percore` qualifiers. (**Not yet supported**)

Any event, symbolic or raw, may be followed by an optional colon and a list of
[modifiers](#modifiers), e.g. `INSTRUCTIONS:u` or `CACHE_MISSES:u:k`.

A form that is recognised but not yet supported is rejected with an explicit "planned for a future
release" error, so the config surface stays stable: upcoming releases will encode these forms
without changing the syntax.
