### PR TITLE
test(cgroup): add missing metric check in cgroup plugin

### DIFF
--- a/plugins/cgroups/util-cgroups-plugins/tests/tests_metrics.rs
+++ b/plugins/cgroups/util-cgroups-plugins/tests/tests_metrics.rs
@@ -72,6 +72,9 @@ fn test_metrics_sets() {
         .expect_metric::<u64>("cgroup_memory_file", Unit::Byte)
         .expect_metric::<u64>("cgroup_memory_kernel_stack", Unit::Byte)
         .expect_metric::<u64>("cgroup_memory_pagetables", Unit::Byte)
+        .expect_metric::<u64>("cgroup_slab_reclaimable", Unit::Byte)
+        .expect_metric::<u64>("cgroup_pswpin", Unit::Unity)
+        .expect_metric::<u64>("cgroup_pswpout", Unit::Unity)
         .expect_metric::<u64>("io_pressure_some_total", PrefixedUnit::micro(Unit::Second))
         .expect_metric::<u64>("io_pressure_full_total", PrefixedUnit::micro(Unit::Second))
         .expect_source(PLUGIN_NAME, SOURCE_NAME);
@@ -89,6 +92,9 @@ fn test_metrics_sets() {
             let cgroup_memory_file = ctx.metrics().by_name("cgroup_memory_file").unwrap().0;
             let cgroup_memory_kernel_stack = ctx.metrics().by_name("cgroup_memory_kernel_stack").unwrap().0;
             let cgroup_memory_pagetables = ctx.metrics().by_name("cgroup_memory_pagetables").unwrap().0;
+            let cgroup_slab_reclaimable = ctx.metrics().by_name("cgroup_slab_reclaimable").unwrap().0;
+            let cgroup_pswpin = ctx.metrics().by_name("cgroup_pswpin").unwrap().0;
+            let cgroup_pswpout = ctx.metrics().by_name("cgroup_pswpout").unwrap().0;
             let io_pressure_some_total = ctx.metrics().by_name("io_pressure_some_total").unwrap().0;
             let io_pressure_full_total = ctx.metrics().by_name("io_pressure_full_total").unwrap().0;
 
@@ -99,6 +105,9 @@ fn test_metrics_sets() {
             assert!(m.iter().any(|p| p.metric == cgroup_memory_file));
             assert!(m.iter().any(|p| p.metric == cgroup_memory_kernel_stack));
             assert!(m.iter().any(|p| p.metric == cgroup_memory_pagetables));
+            assert!(m.iter().any(|p| p.metric == cgroup_slab_reclaimable));
+            assert!(m.iter().any(|p| p.metric == cgroup_pswpin));
+            assert!(m.iter().any(|p| p.metric == cgroup_pswpout));
             assert!(m.iter().any(|p| p.metric == io_pressure_some_total));
             assert!(m.iter().any(|p| p.metric == io_pressure_full_total));
         },


### PR DESCRIPTION
In `startup_expectation` and `runtime_expectation`, three metrics were missing. 