### PR TITLE
Perf raw hex

### DIFF
--- a/plugins/perf/README.md
+++ b/plugins/perf/README.md
@@ -30,12 +30,8 @@ The `<event>` part can be one of five forms:
 - **libpfm** : any other name, optionally with unit masks (e.g. `RESOURCE_STALLS:ANY`,
   `MEM_LOAD_RETIRED:L3_MISS`), resolved through [libpfm](#libpfm-events). (**Supported**, requires libpfm)
 - **raw-hex** : a raw code `rN`, where `N` is a hexadecimal value representing the raw register
-  encoding, with the layout described by `/sys/bus/event_source/devices/cpu/format/*`. (**Not yet supported**)
-- **pmu-named** : `pmu/event=M,umask=N,…/`, using named fields defined in
-  `/sys/bus/event_source/devices/<pmu>/format/*` (perf packs the bits for you); also the uncore /
-  `percore` qualifiers. (**Not yet supported**)
-- **pmu-raw** : `pmu/config=M,config1=N,config2=K/`, giving the raw config registers directly
-  (numbers in decimal, hex or octal). (**Not yet supported**)
+  encoding, with the layout described by `/sys/bus/event_source/devices/<pmu>/format/*`. It targets
+  the default raw PMU. (**Supported**, see [Raw events](#raw-events))
 
 Any event may be followed by `#` and a list of [modifiers](#modifiers), e.g.
 `INSTRUCTIONS#u` or `CACHE_MISSES#u:k`.
@@ -90,6 +86,20 @@ libpfm is **loaded at runtime** (via `dlopen`), not linked at build time:
   error . A configuration with no libpfm event starts fine.
 - Install it from your distribution (e.g. `libpfm4` on Debian/Ubuntu). By default the plugin looks
   for `libpfm.so.4` and `libpfm.so`. Set `ALUMET_LIBPFM_LIB` to a `.so` name or full path to override.
+
+### Raw events
+
+When a symbolic name is not enough, you can give the raw event code directly, just like `perf`:
+
+- **`rN`** — the hexadecimal code `N` goes into the counter's `config` on the default raw PMU
+  (`PERF_TYPE_RAW`). Both `r3c` and `r0x412e` are accepted (a `0x` prefix is optional).
+
+The meaning of the bits in `N` is CPU-specific; the layout is described by
+`/sys/bus/event_source/devices/<pmu>/format/*`. The plugin does not interpret it, it forwards the
+value as-is.
+
+Modifiers work here too: `r0x412e#u:k`. The metric is named after the sanitized event string, so
+`r0x412e` → `perf_r0x412e` (use a `rename` for something friendlier).
 
 ### Modifiers
 

--- a/plugins/perf/src/lib.rs
+++ b/plugins/perf/src/lib.rs
@@ -25,6 +25,7 @@ compile_error!("This plugin only works on Linux.");
 mod cpu;
 mod native;
 mod pfm;
+mod raw;
 mod source;
 mod spec;
 

--- a/plugins/perf/src/native.rs
+++ b/plugins/perf/src/native.rs
@@ -175,3 +175,20 @@ fn parse_cache(cache_spec: &str) -> anyhow::Result<NamedPerfEvent> {
         }),
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hardware_software_and_cache_parse() {
+        assert_eq!(parse("INSTRUCTIONS").unwrap().name, "INSTRUCTIONS");
+        assert_eq!(parse("CONTEXT_SWITCHES").unwrap().name, "CONTEXT_SWITCHES");
+        assert_eq!(parse("LL_READ_MISS").unwrap().name, "LL_READ_MISS");
+    }
+
+    #[test]
+    fn unknown_name_is_rejected() {
+        assert!(parse("DEFINITELY_NOT_A_REAL_EVENT_XYZ").is_err());
+    }
+}

--- a/plugins/perf/src/raw.rs
+++ b/plugins/perf/src/raw.rs
@@ -1,0 +1,84 @@
+//! Raw perf events, in the style of `perf stat -e`.
+//!
+//! One form is accepted:
+//! - **`rN`** — a raw event code `N` (hexadecimal) on the default raw PMU (`PERF_TYPE_RAW`), e.g.
+//!   `r3c` or `r0x412e`. `N` is written verbatim into `config`.
+
+use perf_event_open_sys::bindings::PERF_TYPE_RAW;
+
+use crate::spec::{EventEncoding, NamedPerfEvent, sanitize};
+
+/// Try to parse `name` as a raw-hex event.
+///
+/// Returns `None` if `name` is not the raw form.
+pub fn parse(name: &str) -> Option<anyhow::Result<NamedPerfEvent>> {
+    let config = raw_config(name)?;
+    Some(Ok(build(config, name)))
+}
+
+/// Parse a raw code token `r<hex>` (with an optional `0x` prefix) into its `config` value.
+/// e.g. `r3c` -> `0x3c`, `r0x412e` -> `0x412e`. Returns `None` if `token` is not that shape.
+fn raw_config(token: &str) -> Option<u64> {
+    let digits = token.strip_prefix('r')?;
+    let digits = digits.trim_start_matches("0x").trim_start_matches("0X");
+    if digits.is_empty() {
+        return None;
+    }
+    u64::from_str_radix(digits, 16).ok()
+}
+
+fn build(config: u64, original: &str) -> NamedPerfEvent {
+    NamedPerfEvent {
+        name: sanitize(original),
+        description: format!("raw event {config:#x}"),
+        encoding: EventEncoding {
+            type_: PERF_TYPE_RAW,
+            config,
+            config1: 0,
+            config2: 0,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_config_parses_hex() {
+        assert_eq!(raw_config("r3c"), Some(0x3c));
+        assert_eq!(raw_config("r0x412e"), Some(0x412e));
+        assert_eq!(raw_config("r0X412E"), Some(0x412e));
+        assert_eq!(raw_config("r0"), Some(0));
+    }
+
+    #[test]
+    fn raw_config_rejects_non_raw() {
+        assert_eq!(raw_config("INSTRUCTIONS"), None); // not r-prefixed
+        assert_eq!(raw_config("r"), None); // no digits
+        assert_eq!(raw_config("r0x"), None); // no digits after prefix
+        assert_eq!(raw_config("rZZ"), None); // not hex
+        assert_eq!(raw_config("r3c_extra"), None); // trailing junk
+    }
+
+    #[test]
+    fn plain_raw_encodes_to_perf_type_raw() {
+        let e = parse("r0x412e").expect("recognised as raw").expect("valid");
+        assert_eq!(e.name, "r0x412e");
+        assert_eq!(
+            e.encoding,
+            EventEncoding {
+                type_: PERF_TYPE_RAW,
+                config: 0x412e,
+                config1: 0,
+                config2: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn non_raw_name_is_not_recognised() {
+        assert!(parse("INSTRUCTIONS").is_none());
+        assert!(parse("cpu/config=0x3c/").is_none());
+    }
+}

--- a/plugins/perf/src/spec.rs
+++ b/plugins/perf/src/spec.rs
@@ -10,13 +10,8 @@
 //! - **libpfm** : any other name, optionally with unit masks (e.g. `RESOURCE_STALLS:ANY`), resolved
 //!   through libpfm (per-CPU encoding tables). This is the fallback when the native tables don't
 //!   know the name. **Supported**.
-//! - **raw-hex** : a raw code `rN`, where `N` is a hexadecimal register encoding (layout from
-//!   `/sys/bus/event_source/devices/cpu/format/*`). **Not yet supported** (planned).
-//! - **pmu-named** : `pmu/event=M,umask=N,…/`, using named fields from
-//!   `/sys/bus/event_source/devices/<pmu>/format/*` (also the uncore/`percore` qualifiers).
-//!   **Not yet supported** (planned).
-//! - **pmu-raw** : `pmu/config=M,config1=N,config2=K/`, the raw config registers given directly.
-//!   **Not yet supported** (planned).
+//! - **raw-hex** : a raw code `rN` (hex register encoding) on the default raw PMU. Layout from
+//!   `/sys/bus/event_source/devices/<pmu>/format/*`. **Supported**.
 //!
 //! A not-yet-supported form is rejected there with an explicit "planned for a future release" error.
 
@@ -27,6 +22,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::native;
 use crate::pfm;
+use crate::raw;
 
 /// One entry of the `events` config list: a bare string, or a table with a metric `rename`.
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -237,16 +233,12 @@ pub fn parse(entry: &EventEntry) -> anyhow::Result<ParsedEvent> {
 /// Resolve an event name (no modifiers) into a [`NamedPerfEvent`]. Each encoder builds the `NamedPerfEvent`
 /// in its own module; this only dispatches to them. See the module docs for the recognised forms.
 fn resolve_event(name: &str) -> anyhow::Result<NamedPerfEvent> {
-    // raw-hex route (`rN`, hex register encoding): recognised, but not encoded yet.
-    let looks_raw = name
-        .strip_prefix('r')
-        .map(|d| d.trim_start_matches("0x").trim_start_matches("0X"))
-        .is_some_and(|d| !d.is_empty() && d.chars().all(|c| c.is_ascii_hexdigit()));
-    if looks_raw {
-        anyhow::bail!("raw-hex events (`{name}`) are not supported yet; this is planned for a future release");
+    // raw-hex route: `rN`, a raw code on the default raw PMU.
+    if let Some(result) = raw::parse(name) {
+        return result;
     }
-    // pmu-named (`pmu/event=,umask=/`) and pmu-raw (`pmu/config=,config1=/`) routes: recognised,
-    // but not encoded yet.
+    // any `pmu/…/` form (native-on-PMU, raw-on-PMU, pmu-named, pmu-raw): recognised, but not
+    // encoded yet. The whole PMU machinery is planned for a future release.
     if name.contains('/') {
         anyhow::bail!(
             "pmu-named / pmu-raw events (`{name}`) are not supported yet; this is planned for a future release"
@@ -403,10 +395,21 @@ mod tests {
     }
 
     #[test]
-    fn raw_code_rejected_for_now() {
-        // `rNNNN` is recognised by the syntax but not encoded yet.
-        let err = parse(&EventEntry::Simple("r0x412e".to_owned())).unwrap_err();
-        assert!(format!("{err:#}").contains("future release"), "got: {err:#}");
+    fn raw_hex_event() {
+        use perf_event_open_sys::bindings::PERF_TYPE_RAW;
+        // `rN` encodes a raw code on the default raw PMU, and modifiers still apply.
+        let e = parse_simple("r0x412e#u:k");
+        assert_eq!(e.metric_suffix, "r0x412e");
+        assert_eq!(
+            e.event.encoding(),
+            EventEncoding {
+                type_: PERF_TYPE_RAW,
+                config: 0x412e,
+                config1: 0,
+                config2: 0,
+            }
+        );
+        assert!(!e.event.modifiers.excludes().kernel);
     }
 
     #[test]


### PR DESCRIPTION
Adding a new way to configure event using hexadecimal notation.

It's based on top of https://github.com/alumet-dev/alumet/pull/428 so need to be merged after