### PR TITLE
feat(plugins/perf): support of system-wide counters

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -116,3 +116,7 @@ VERGEN
 wattmeters
 wattmetre
 zcat
+cpumask
+cstate
+imc
+pmu

--- a/plugins/perf/README.md
+++ b/plugins/perf/README.md
@@ -25,10 +25,16 @@ suffix (and is normalized the same way); the metric then becomes `perf_{rename}`
 
 ### Attributes
 
+A native hardware/cache measurement carries a `pmu` attribute naming the core PMU it was counted on
+(`cpu_core`, `cpu_atom`, or `cpu`).
+
 Every measurement carries an `accuracy` attribute describing how faithful its value is (see
 [Counter multiplexing](#counter-multiplexing) below):
 
 - `exact`: an exact count.
+- `partial` (**only for hybrid CPU**): a per-PMU count on a hybrid CPU (see [Native events on hybrid CPUs](#native-events-on-hybrid-cpus)).
+  The event is pinned to one PMU while the process also runs on the others, so the counter was on
+  the PMU only part of the time. The value is **not** scaled.
 - `extrapolated`: the value includes at least one multiplexed interval that was extrapolated (only
   happens when `multiplexing_auto_scale` is on). It is an estimate, which may be slightly above or
   below the truth.
@@ -36,9 +42,10 @@ Every measurement carries an `accuracy` attribute describing how faithful its va
   reported raw (`multiplexing_auto_scale` off) or because the counter was starved for some intervals
   (the events could not be counted at all).
 
-Because the reported values are cumulative counters, the accuracy only ever degrades from `exact` to
-`extrapolated` to `underestimated`, and never improves: a single imperfect interval affects every
-value reported afterwards.
+Because the reported values are cumulative counters, the accuracy only ever degrades and never
+improves: a single imperfect interval affects every value reported afterwards. `partial` applies only
+to PMU-pinned events (a hybrid-CPU artifact) and is never scaled; `extrapolated`/`underestimated`
+describe genuine multiplexing on a single-PMU event.
 
 ## Configuration
 
@@ -122,18 +129,25 @@ Each event is a string of the form:
 
 #### Event formats
 
-The `<event>` part can be one of three forms:
+The `<event>` part can be one of these forms:
 
 - **native** : a symbolic event name (e.g. `INSTRUCTIONS`, `LL_READ_MISS`), resolved against the
-  built-in kernel tables listed in [Native event names](#native-event-names). (**Supported**)
+  built-in kernel tables listed in [Native event names](#native-event-names).
+- **native on a PMU** : a native name pinned to a specific PMU, `pmu/NAME` (e.g.
+  `cpu_core/INSTRUCTIONS`, `cpu_atom/CACHE_MISSES`).
 - **libpfm** : any other name, optionally with unit masks (e.g. `RESOURCE_STALLS:ANY`,
-  `MEM_LOAD_RETIRED:L3_MISS`), resolved through [libpfm](#libpfm-events). (**Supported**, requires libpfm)
+  `MEM_LOAD_RETIRED:L3_MISS`), resolved through [libpfm](#libpfm-events). (requires libpfm)
 - **raw-hex** : a raw code `rN`, where `N` is a hexadecimal value representing the raw register
   encoding, with the layout described by `/sys/bus/event_source/devices/<pmu>/format/*`. It targets
-  the default raw PMU. (**Supported**, see [Raw events](#raw-events))
+  the default raw PMU. (see [Raw events](#raw-events))
+- **raw on a PMU** : `pmu/rN`, the same raw code but on a named PMU (addressed by its sysfs `type`),
+  e.g. `uncore_imc_0/r0x1`. This is the only way to reach a PMU that has no generic namespace, such
+  as the uncore, `power` (RAPL), or `cstate_*` PMUs. (see [Raw events](#raw-events)
+  and [System-wide events](#system-wide-events-uncore-rapl-cstate))
 
 Any event may be followed by `#` and a list of [modifiers](#modifiers), e.g.
-`INSTRUCTIONS#u` or `CACHE_MISSES#u:k`.
+`INSTRUCTIONS#u` or `CACHE_MISSES#u:k`. Modifiers do not apply to
+[system-wide events](#system-wide-events-uncore-rapl-cstate) and are rejected on them.
 
 #### Native event names
 
@@ -155,6 +169,20 @@ For example: `LL_READ_MISS`.
 To learn more about the standard events, please refer to the [`perf_event_open` manual](https://man7.org/linux/man-pages/man2/perf_event_open.2.html).
 To list the events that are available on your machine, run the `perf list` command.
 Note that based on your kernel version, some events could be unavailable.
+
+#### Native events on hybrid CPUs
+
+On hybrid CPUs (e.g. Intel P-core/E-core, exposed as the `cpu_core` and `cpu_atom` PMUs), a plain
+generic hardware/cache event is counted on **every** PMU automatically.
+They share the metric name (`perf_instructions`) and are told apart by their `pmu` attribute (`cpu_core` / `cpu_atom`);
+
+To measure one PMU only, qualify the name with the PMU: `cpu_core/INSTRUCTIONS` or
+`cpu_atom/INSTRUCTIONS`. This works for hardware and cache events; **software** events (e.g.
+`CONTEXT_SWITCHES`) are CPU-wide and have no PMU, so pinning them is rejected.
+
+These are per-process/cgroup events (the core PMUs are task-attachable), so they follow the observed
+entity like any native event. Their `resource` is the CPU package the PMU sits in
+(`cpu_package`), and the `pmu` attribute is added.
 
 #### Libpfm events
 
@@ -190,20 +218,69 @@ libpfm is **loaded at runtime** (via `dlopen`), not linked at build time:
 
 When a symbolic name is not enough, you can give the raw event code directly, just like `perf`:
 
-- **`rN`** — the hexadecimal code `N` goes into the counter's `config` on the default raw PMU
+- **`rN`**: the hexadecimal code `N` goes into the counter's `config` on the default raw PMU
   (`PERF_TYPE_RAW`). Both `r3c` and `r0x412e` are accepted (a `0x` prefix is optional).
+- **`pmu/rN`**: the same code, but on a named PMU. The PMU's numeric `type` is read from
+  `/sys/bus/event_source/devices/<pmu>/type`, so e.g. `uncore_imc_0/r0x1` counts on that memory
+  controller. The trailing slash is optional (`uncore_imc_0/r0x1/` also works). This is required to
+  reach PMUs that have no generic namespace (uncore, `power`, `cstate_*`).
 
 The meaning of the bits in `N` is CPU-specific; the layout is described by
 `/sys/bus/event_source/devices/<pmu>/format/*`. The plugin does not interpret it, it forwards the
 value as-is.
 
-Modifiers work here too: `r0x412e#u:k`. The metric is named after the sanitized event string, so
-`r0x412e` → `perf_r0x412e` (use a `rename` for something friendlier).
+Modifiers work on the default raw PMU (`r0x412e#u:k`), but **not** on a `pmu/rN` that lands on a
+system-wide PMU. The metric is named after the sanitized event string, so `r0x412e` →
+`perf_r0x412e` and `uncore_imc_0/r0x1` → `perf_uncore_imc_0_r0x1` (use a `rename` for something
+friendlier).
+
+#### System-wide events (uncore, RAPL, cstate)
+
+Some PMUs do not measure a single CPU core but a shared domain: the memory controllers
+(`uncore_imc_*`), package energy (`power`, i.e. RAPL), C-state residency (`cstate_*`), and so on.
+Their events cannot be attached to a process or cgroup, they count the whole domain regardless of
+what runs.
+
+The plugin detects this automatically: **if the event's PMU has a `cpumask`, the event is
+system-wide**. Instead of following the observed process/cgroup, it is opened once for the whole
+machine, on each CPU of that `cpumask`, and reported under the hardware resource of the domain (see
+below).
+
+```toml
+events = [
+    "INSTRUCTIONS",        # per-process/cgroup, follows the observed entity
+    "power/r0x2",          # system-wide: RAPL package energy, opened machine-wide
+    "uncore_imc_0/r0x1",   # system-wide: a memory-controller counter
+]
+```
+
+Two consequences:
+
+- **Modifiers are rejected** on system-wide events (`power/r0x2#u` is an error): the domain concepts
+  they express (user/kernel/hypervisor) do not exist for these PMUs, which also reject the underlying
+  `exclude_*` bits.
+- **They need more privilege**: opening an event with no target process requires
+  `perf_event_paranoid < 1` (`0` or `-1`) or `CAP_PERFMON`, which per-process events do not. If that
+  is missing, the plugin logs a warning and keeps working *without* the system-wide events.
+
+The **resource** of a system-wide measurement is derived from the PMU name and the
+reader CPU's package (`/sys/devices/system/cpu/cpuN/topology/physical_package_id`):
+
+| PMU | Resource |
+| --- | --- |
+| `uncore_imc*` (memory controllers) | `Dram` of the reader's package |
+| `cstate_core` (per physical core) | `CpuCore` (the reader CPU) |
+| `power` (RAPL), `cstate_pkg*` | `CpuPackage` (the reader's package) |
+| anything else (other `uncore_*`, unknown) | `Custom { kind = PMU, id = reader CPU }` |
+
+A PMU that is not specifically known maps to an explicit `Custom` resource rather than a guessed
+package, which is also collision-free since the reader CPU is unique.
 
 #### Modifiers
 
 Modifiers are attached after a `#`, one per `:`-separated token (e.g. `INSTRUCTIONS#u:k`).
-An unknown token (e.g. `INSTRUCTIONS#z`) is rejected.
+An unknown token (e.g. `INSTRUCTIONS#z`) is rejected. They do not apply to
+[system-wide events](#system-wide-events-uncore-rapl-cstate), which reject them.
 
 For now these modifiers are supported:
 
@@ -251,6 +328,11 @@ Below is a summary of how different perf_event_paranoid values affect perf plugi
 | 1                               | Allows user-space and kernel-space measurements        | `cap_perfmon` *(or `cap_sys_admin` for Linux < 5.8)* | ✅ Supported                       |
 | 0                               | Allows user-space, kernel-space, and CPU-specific data | `cap_perfmon` *(or `cap_sys_admin` for Linux < 5.8)* | ✅ Supported                       |
 | -1                              | Full access, including raw tracepoints                 | −                                                    | ✅ Supported                       |
+
+The table above is for per-process/cgroup events. [System-wide events](#system-wide-events-uncore-rapl-cstate)
+(uncore, RAPL, cstate) are stricter: they need `perf_event_paranoid < 1` (so `0` or `-1`) or
+`CAP_PERFMON`. At `paranoid = 1` the per-process events still work, but the system-wide ones are
+skipped (with a warning).
 
 Example for setting `perf_event_paranoid`: `sudo sysctl -w kernel.perf_event_paranoid=2` will set the value to **2**.
 

--- a/plugins/perf/src/cpu.rs
+++ b/plugins/perf/src/cpu.rs
@@ -3,7 +3,7 @@ use std::num::ParseIntError;
 
 use anyhow::Context;
 
-fn parse_cpu_list(cpulist: &str) -> anyhow::Result<Vec<u32>> {
+pub(crate) fn parse_cpu_list(cpulist: &str) -> anyhow::Result<Vec<u32>> {
     // handles "n" or "start-end"
     fn parse_cpulist_item(item: &str) -> anyhow::Result<Vec<u32>> {
         let bounds: Vec<u32> = item
@@ -29,6 +29,15 @@ fn parse_cpu_list(cpulist: &str) -> anyhow::Result<Vec<u32>> {
         .collect();
 
     Ok(cpus)
+}
+
+/// Read the physical package (socket) id a CPU belongs to, from sysfs topology.
+pub(crate) fn package_of(cpu: u32) -> anyhow::Result<u32> {
+    let path = format!("/sys/devices/system/cpu/cpu{cpu}/topology/physical_package_id");
+    let raw = std::fs::read_to_string(&path).with_context(|| format!("cannot read {path}"))?;
+    raw.trim()
+        .parse::<u32>()
+        .with_context(|| format!("invalid package id in {path}: {:?}", raw.trim()))
 }
 
 pub fn online_cpus() -> anyhow::Result<Vec<u32>> {

--- a/plugins/perf/src/lib.rs
+++ b/plugins/perf/src/lib.rs
@@ -19,10 +19,9 @@ use alumet::{
     units::Unit,
 };
 use anyhow::Context;
-use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
-use crate::source::{Observable, PerfEventSourceBuilder};
+use crate::source::{Observable, PerfEventSource, PerfEventSourceBuilder};
 
 #[cfg(not(target_os = "linux"))]
 compile_error!("This plugin only works on Linux.");
@@ -31,6 +30,7 @@ mod cpu;
 mod multiplexing;
 mod native;
 mod pfm;
+mod pmu;
 mod raw;
 mod source;
 mod spec;
@@ -54,17 +54,17 @@ impl AlumetPlugin for PerfPlugin {
 
     fn init(config: alumet::plugin::ConfigTable) -> anyhow::Result<Box<Self>> {
         let config: Config = deserialize_config(config)?;
+        // Parse the perf events with the unified syntax. One entry may expand to several events (a
+        // generic event fanned onto every core PMU of a hybrid CPU).
+        let mut events = Vec::with_capacity(config.events.len());
+        for entry in &config.events {
+            events.extend(spec::parse(entry).context("invalid event in config")?);
+        }
         let config = ParsedConfig {
             // Store the source settings.
             poll_interval: config.poll_interval,
             flush_interval: config.flush_interval,
-            // Parse the perf events with the unified syntax.
-            events: config
-                .events
-                .iter()
-                .map(spec::parse)
-                .try_collect()
-                .context("invalid event in config")?,
+            events,
             multiplexing_auto_scale: config.multiplexing_auto_scale,
             // The metrics are initialized in start()
             metrics: Vec::new(),
@@ -80,10 +80,20 @@ impl AlumetPlugin for PerfPlugin {
 
         let mut config = self.config.lock().unwrap();
 
+        // Events fanned onto several core PMUs share one metric (same name, told apart by their
+        // `pmu` attribute), so a metric is created once per distinct name and reused.
         let mut metrics = Vec::with_capacity(config.events.len());
+        let mut by_name: std::collections::HashMap<String, TypedMetricId<u64>> = std::collections::HashMap::new();
         for e in &config.events {
             let metric_name = format!("perf_{}", e.metric_suffix);
-            let metric = alumet.create_metric::<u64>(metric_name, Unit::Unity, e.description.clone())?;
+            let metric = match by_name.get(&metric_name) {
+                Some(metric) => *metric,
+                None => {
+                    let metric = alumet.create_metric::<u64>(&metric_name, Unit::Unity, e.description.clone())?;
+                    by_name.insert(metric_name, metric);
+                    metric
+                }
+            };
             metrics.push(metric);
         }
         config.metrics = metrics;
@@ -96,6 +106,58 @@ impl AlumetPlugin for PerfPlugin {
         let pipeline_control_end = alumet.pipeline_control();
         let runtime_start = alumet.async_runtime().clone();
         let runtime_end = alumet.async_runtime().clone();
+
+        // Start the machine-wide source for system-wide events (uncore, power, cstate…). Unlike the
+        // per-process/cgroup sources below, it is not reactive: it exists for the whole machine, so
+        // it is created once, here, rather than when a consumer appears.
+        {
+            let config = self.config.lock().unwrap();
+            let system_events: Vec<_> = config
+                .events
+                .iter()
+                .zip(&config.metrics)
+                .filter_map(|(event, metric)| match &event.scope {
+                    spec::Scope::SystemWide { pmu, cpus } => {
+                        Some((event.event.clone(), *metric, pmu.clone(), cpus.clone()))
+                    }
+                    spec::Scope::TaskAttached { .. } => None,
+                })
+                .collect();
+            if !system_events.is_empty() {
+                let n = system_events.len();
+                let poll_interval = config.poll_interval;
+                let flush_interval = config.flush_interval;
+                let auto_scale = config.multiplexing_auto_scale;
+                let add_source_in_pause_state = config.add_source_in_pause_state;
+                drop(config);
+
+                let init_source_state = match add_source_in_pause_state {
+                    false => TaskState::Run,
+                    true => TaskState::Pause,
+                };
+
+                match PerfEventSource::build_system_wide(auto_scale, system_events) {
+                    Ok(source) => {
+                        let trigger = TriggerSpec::builder(poll_interval)
+                            .flush_interval(flush_interval)
+                            .build()?;
+                        let request = request::create_one().add_source_with_state(
+                            "source-system-wide",
+                            Box::new(source),
+                            trigger,
+                            init_source_state,
+                        );
+                        runtime_start.block_on(pipeline_control_start.dispatch(request, Duration::from_secs(1)))?;
+                        log::info!("Started system-wide perf source with {n} event(s).");
+                    }
+                    // Not fatal: system-wide PMUs need CAP_PERFMON / perf_event_paranoid < 1, which
+                    // the per-process/cgroup events do not. Keep the rest of the plugin working.
+                    Err(e) => log::warn!(
+                        "could not open system-wide perf events (uncore/power/cstate): {e:#}; continuing without them"
+                    ),
+                }
+            }
+        }
 
         // Listen to start consumer events, starting sources.
         event::start_consumer_measurement().subscribe(move |e| {
@@ -133,9 +195,17 @@ impl AlumetPlugin for PerfPlugin {
                     let config = config_cloned.lock().unwrap();
                     let mut builder = PerfEventSourceBuilder::observe(o, config.multiplexing_auto_scale)?;
                     for (event, metric) in config.events.iter().zip(&config.metrics) {
-                        builder
-                            .add(&event.event, *metric)
-                            .with_context(|| format!("could not configure event {}", event.metric_suffix))?;
+                        match &event.scope {
+                            // System-wide events (uncore, power, cstate…) are not tied to a
+                            // process/cgroup; they will be opened once by a dedicated machine-wide
+                            // source. Skip them here so they don't break this entity source.
+                            spec::Scope::SystemWide { .. } => (),
+                            spec::Scope::TaskAttached { binding } => {
+                                builder
+                                    .add(&event.event, *metric, binding.as_ref())
+                                    .with_context(|| format!("could not configure event {}", event.metric_suffix))?;
+                            }
+                        }
                     }
                     let poll_interval = config.poll_interval;
                     let flush_interval = config.flush_interval;

--- a/plugins/perf/src/multiplexing.rs
+++ b/plugins/perf/src/multiplexing.rs
@@ -36,22 +36,33 @@ pub(crate) enum Interval {
     Multiplexed { running: u128, enabled: u128 },
     /// The entity ran but the group never made it onto the PMU: everything that happened during the
     /// interval was missed, and there is nothing to extrapolate from.
-    /// This can happen for many reasons, such as having too many counters in a single group, or (on
-    /// hybrid CPUs) a group bound to one PMU while the entity runs on the other PMU.
+    /// This can happen for many reasons, such as having too many counters in a single group, or
+    /// tools holding the PMU system-wide.
     Starved,
+    /// The group is pinned to one cluster of a hybrid CPU and the entity spent part (or all) of the
+    /// interval on another cluster.
+    Partial,
 }
 
 /// How faithful a reported (cumulative) value is.
 ///
 /// This describes the whole value reported so far, not the last interval, because the value is a
-/// cumulative counter. It therefore only ever degrades (`exact` -> `extrapolated` -> `underestimated`)
-/// and never improves: a single imperfect interval taints every value reported afterwards. The
-/// variants are ordered from best to worst so that [`Accuracy::max`] keeps the worst seen.
+/// cumulative counter: a single imperfect interval taints every value reported afterwards, so the
+/// accuracy of a group only ever degrades and never improves.
+///
+/// There are in fact **two independent axes**, both starting from `Exact`:
+/// - real multiplexing on a single-PMU event: `Exact` -> `Extrapolated` (with `auto_scale`) or
+///   `Underestimated`;
+/// - a cluster-pinned event on a hybrid CPU: `Exact` -> `Partial` (see [`Interval::Partial`]).
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum Accuracy {
     /// Every interval was counted exactly.
     #[default]
     Exact,
+    /// The value is a per-cluster count from a hybrid CPU: the event is pinned to one cluster and the
+    /// entity also ran on others, so it was on the PMU only part of the time. The value is *not*
+    /// scaled.
+    Partial,
     /// At least one multiplexed interval was extrapolated (only in `auto_scale` mode). The value is
     /// an estimate, which may be slightly above or below the truth.
     Extrapolated,
@@ -65,6 +76,7 @@ impl Accuracy {
     pub fn as_str(self) -> &'static str {
         match self {
             Accuracy::Exact => "exact",
+            Accuracy::Partial => "partial",
             Accuracy::Extrapolated => "extrapolated",
             Accuracy::Underestimated => "underestimated",
         }
@@ -112,10 +124,11 @@ impl GroupCounters {
 
     /// Accounts for a new reading, updating the corrected totals, and returns what happened during
     /// the interval.
-    pub fn account(&mut self, now: Snapshot, auto_scale: bool) -> Interval {
-        let interval = correct_interval(&self.prev, &now, auto_scale, &mut self.corrected);
+    pub fn account(&mut self, now: Snapshot, auto_scale: bool, cluster_pinned: bool) -> Interval {
+        let interval = correct_interval(&self.prev, &now, auto_scale, cluster_pinned, &mut self.corrected);
         let interval_accuracy = match interval {
             Interval::Idle | Interval::Exact => Accuracy::Exact,
+            Interval::Partial => Accuracy::Partial,
             Interval::Multiplexed { .. } if auto_scale => Accuracy::Extrapolated,
             // multiplexed without auto-scaling, or a starved interval that could not be extrapolated
             Interval::Multiplexed { .. } | Interval::Starved => Accuracy::Underestimated,
@@ -128,12 +141,26 @@ impl GroupCounters {
 
 /// Adds the (possibly corrected) contribution of one polling interval to `corrected`, and reports
 /// what happened. See the [module documentation](self) for the rationale.
-fn correct_interval(prev: &Snapshot, now: &Snapshot, auto_scale: bool, corrected: &mut [u64]) -> Interval {
+fn correct_interval(
+    prev: &Snapshot,
+    now: &Snapshot,
+    auto_scale: bool,
+    cluster_pinned: bool,
+    corrected: &mut [u64],
+) -> Interval {
     let d_enabled = now.time_enabled.saturating_sub(prev.time_enabled);
     let d_running = now.time_running.saturating_sub(prev.time_running);
 
     if d_enabled == 0 {
         return Interval::Idle;
+    }
+    if cluster_pinned {
+        add_raw(prev, now, corrected);
+        return if d_running < d_enabled {
+            Interval::Partial
+        } else {
+            Interval::Exact
+        };
     }
     if d_running == 0 {
         // Nothing was counted, so there is nothing to extrapolate from.
@@ -163,6 +190,14 @@ fn correct_interval(prev: &Snapshot, now: &Snapshot, auto_scale: bool, corrected
     }
 }
 
+/// Adds each counter's raw delta to `corrected`, without any scaling.
+fn add_raw(prev: &Snapshot, now: &Snapshot, corrected: &mut [u64]) {
+    for (i, total) in corrected.iter_mut().enumerate() {
+        let delta = u128::from(now.values[i].saturating_sub(prev.values[i]));
+        *total = total.saturating_add(u64::try_from(delta).unwrap_or(u64::MAX));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{Interval, Snapshot, correct_interval};
@@ -182,7 +217,13 @@ mod tests {
     #[test]
     fn first_poll_is_an_interval_like_any_other() {
         let mut corrected = vec![0];
-        let interval = correct_interval(&snap(0, 0, &[0]), &snap(SEC, SEC / 4, &[1000]), true, &mut corrected);
+        let interval = correct_interval(
+            &snap(0, 0, &[0]),
+            &snap(SEC, SEC / 4, &[1000]),
+            true,
+            false,
+            &mut corrected,
+        );
         assert_eq!(
             interval,
             Interval::Multiplexed {
@@ -197,7 +238,48 @@ mod tests {
     #[test]
     fn exact_when_running_equals_enabled() {
         let mut corrected = vec![0];
-        let interval = correct_interval(&snap(0, 0, &[0]), &snap(SEC, SEC, &[1000]), true, &mut corrected);
+        let interval = correct_interval(&snap(0, 0, &[0]), &snap(SEC, SEC, &[1000]), true, false, &mut corrected);
+        assert_eq!(interval, Interval::Exact);
+        assert_eq!(corrected, vec![1000]);
+    }
+
+    /// A cluster-pinned group only ran part of the interval (the entity was on another cluster). Its
+    /// raw delta is exact for this cluster, so it is kept as-is and never scaled.
+    #[test]
+    fn cluster_pinned_group_is_partial_and_not_scaled() {
+        let mut corrected = vec![0];
+        let interval = correct_interval(
+            &snap(0, 0, &[0]),
+            &snap(SEC, SEC / 4, &[1000]),
+            true,
+            true,
+            &mut corrected,
+        );
+        assert_eq!(interval, Interval::Partial);
+        assert_eq!(corrected, vec![1000], "cluster-pinned => raw delta, no rule of three");
+    }
+
+    /// A cluster-pinned group that never ran this interval (the entity stayed on another cluster): it
+    /// counted a genuine zero, so this is partial, not starvation, and the total does not move.
+    #[test]
+    fn cluster_pinned_group_with_no_running_time_is_partial_not_starved() {
+        let mut corrected = vec![5];
+        let interval = correct_interval(
+            &snap(SEC, SEC, &[5]),
+            &snap(2 * SEC, SEC, &[5]),
+            true,
+            true,
+            &mut corrected,
+        );
+        assert_eq!(interval, Interval::Partial);
+        assert_eq!(corrected, vec![5]);
+    }
+
+    /// A cluster-pinned group on the whole interval (the entity never left this cluster) is exact.
+    #[test]
+    fn cluster_pinned_group_fully_on_cluster_is_exact() {
+        let mut corrected = vec![0];
+        let interval = correct_interval(&snap(0, 0, &[0]), &snap(SEC, SEC, &[1000]), true, true, &mut corrected);
         assert_eq!(interval, Interval::Exact);
         assert_eq!(corrected, vec![1000]);
     }
@@ -208,7 +290,7 @@ mod tests {
     fn idle_entity_changes_nothing() {
         let mut corrected = vec![1000];
         let prev = snap(SEC, SEC, &[1000]);
-        let interval = correct_interval(&prev, &prev.clone(), true, &mut corrected);
+        let interval = correct_interval(&prev, &prev.clone(), true, false, &mut corrected);
         assert_eq!(interval, Interval::Idle);
         assert_eq!(corrected, vec![1000]);
     }
@@ -220,7 +302,7 @@ mod tests {
         let mut corrected = vec![1000];
         let prev = snap(SEC, SEC / 4, &[1000]);
         let now = snap(2 * SEC, SEC / 4, &[1000]);
-        let interval = correct_interval(&prev, &now, true, &mut corrected);
+        let interval = correct_interval(&prev, &now, true, false, &mut corrected);
         assert_eq!(interval, Interval::Starved);
         assert_eq!(corrected, vec![1000], "the total must stay flat, not be made up");
     }
@@ -228,7 +310,13 @@ mod tests {
     #[test]
     fn without_auto_scale_the_raw_delta_is_kept() {
         let mut corrected = vec![0];
-        let interval = correct_interval(&snap(0, 0, &[0]), &snap(SEC, SEC / 4, &[1000]), false, &mut corrected);
+        let interval = correct_interval(
+            &snap(0, 0, &[0]),
+            &snap(SEC, SEC / 4, &[1000]),
+            false,
+            false,
+            &mut corrected,
+        );
         assert_eq!(
             interval,
             Interval::Multiplexed {
@@ -247,6 +335,7 @@ mod tests {
             &snap(0, 0, &[0, 0, 0]),
             &snap(SEC, SEC / 2, &[10, 20, 30]),
             true,
+            false,
             &mut corrected,
         );
         assert_eq!(corrected, vec![20, 40, 60]);
@@ -261,22 +350,22 @@ mod tests {
 
         // poll 1: 1000 counted over a quarter of a second of PMU time -> 4000
         let s1 = snap(SEC, SEC / 4, &[1000]);
-        correct_interval(&snap(0, 0, &[0]), &s1, true, &mut corrected);
+        correct_interval(&snap(0, 0, &[0]), &s1, true, false, &mut corrected);
         totals.push(corrected[0]);
 
         // poll 2: +500 counted over another quarter -> +2000
         let s2 = snap(2 * SEC, SEC / 2, &[1500]);
-        correct_interval(&s1, &s2, true, &mut corrected);
+        correct_interval(&s1, &s2, true, false, &mut corrected);
         totals.push(corrected[0]);
 
         // poll 3: the group is starved, nothing is added
         let s3 = snap(3 * SEC, SEC / 2, &[1500]);
-        correct_interval(&s2, &s3, true, &mut corrected);
+        correct_interval(&s2, &s3, true, false, &mut corrected);
         totals.push(corrected[0]);
 
         // poll 4: +200 counted over half a second -> +400
         let s4 = snap(4 * SEC, SEC, &[1700]);
-        correct_interval(&s3, &s4, true, &mut corrected);
+        correct_interval(&s3, &s4, true, false, &mut corrected);
         totals.push(corrected[0]);
 
         assert_eq!(totals, vec![4000, 6000, 6000, 6400]);
@@ -289,15 +378,41 @@ mod tests {
         use super::{Accuracy, GroupCounters, Interval};
         let mut scaling = GroupCounters::new(1);
 
-        assert_eq!(scaling.account(snap(SEC, SEC, &[10]), true), Interval::Exact);
+        assert_eq!(scaling.account(snap(SEC, SEC, &[10]), true, false), Interval::Exact);
         // a starved interval is reported as such every time it happens, without any streak state
-        assert_eq!(scaling.account(snap(2 * SEC, SEC, &[10]), true), Interval::Starved);
-        assert_eq!(scaling.account(snap(3 * SEC, SEC, &[10]), true), Interval::Starved);
+        assert_eq!(
+            scaling.account(snap(2 * SEC, SEC, &[10]), true, false),
+            Interval::Starved
+        );
+        assert_eq!(
+            scaling.account(snap(3 * SEC, SEC, &[10]), true, false),
+            Interval::Starved
+        );
         assert_eq!(
             scaling.accuracy(),
             Accuracy::Underestimated,
             "a starved interval misses data, so the total is underestimated"
         );
+    }
+
+    /// A cluster-pinned group is reported `partial`, never `exact`-degraded-to-underestimated: its
+    /// values stay raw and its accuracy stays `partial` no matter how the entity bounces clusters.
+    #[test]
+    fn cluster_pinned_accuracy_is_partial() {
+        use super::{Accuracy, GroupCounters, Interval};
+        let mut scaling = GroupCounters::new(1);
+
+        assert_eq!(
+            scaling.account(snap(SEC, SEC / 2, &[1000]), true, true),
+            Interval::Partial
+        );
+        // next interval the entity stayed on the other cluster: running frozen, still partial
+        assert_eq!(
+            scaling.account(snap(2 * SEC, SEC / 2, &[1000]), true, true),
+            Interval::Partial
+        );
+        assert_eq!(scaling.accuracy(), Accuracy::Partial);
+        assert_eq!(scaling.corrected(), &[1000]);
     }
 
     /// The accuracy only ever degrades, and a starvation makes it worse than a mere extrapolation.
@@ -308,16 +423,16 @@ mod tests {
         let mut scaling = GroupCounters::new(1);
         assert_eq!(scaling.accuracy(), Accuracy::Exact);
 
-        scaling.account(snap(SEC, SEC, &[10]), true); // exact
+        scaling.account(snap(SEC, SEC, &[10]), true, false); // exact
         assert_eq!(scaling.accuracy(), Accuracy::Exact);
 
-        scaling.account(snap(2 * SEC, SEC + SEC / 2, &[20]), true); // multiplexed, auto-scaled
+        scaling.account(snap(2 * SEC, SEC + SEC / 2, &[20]), true, false); // multiplexed, auto-scaled
         assert_eq!(scaling.accuracy(), Accuracy::Extrapolated);
 
-        scaling.account(snap(3 * SEC, SEC + SEC / 2, &[20]), true); // starved
+        scaling.account(snap(3 * SEC, SEC + SEC / 2, &[20]), true, false); // starved
         assert_eq!(scaling.accuracy(), Accuracy::Underestimated);
 
-        scaling.account(snap(4 * SEC, 2 * SEC + SEC / 2, &[30]), true); // exact again
+        scaling.account(snap(4 * SEC, 2 * SEC + SEC / 2, &[30]), true, false); // exact again
         assert_eq!(scaling.accuracy(), Accuracy::Underestimated, "accuracy never improves");
     }
 
@@ -327,7 +442,7 @@ mod tests {
         use super::{Accuracy, GroupCounters};
 
         let mut scaling = GroupCounters::new(1);
-        scaling.account(snap(SEC, SEC / 2, &[10]), false); // multiplexed, not scaled
+        scaling.account(snap(SEC, SEC / 2, &[10]), false, false); // multiplexed, not scaled
         assert_eq!(scaling.accuracy(), Accuracy::Underestimated);
     }
 }

--- a/plugins/perf/src/native.rs
+++ b/plugins/perf/src/native.rs
@@ -8,6 +8,7 @@ use std::{error::Error, fmt::Display};
 use anyhow::Context;
 use itertools::Itertools;
 use perf_event::events::{self, CacheId, CacheOp, CacheResult};
+use perf_event_open_sys::bindings::{PERF_TYPE_HARDWARE, PERF_TYPE_HW_CACHE, PERF_TYPE_SOFTWARE};
 
 use crate::spec::{EventEncoding, NamedPerfEvent};
 
@@ -37,6 +38,27 @@ pub fn parse(name: &str) -> anyhow::Result<NamedPerfEvent> {
         return Ok(e);
     }
     parse_cache(name)
+}
+
+/// Pin an already-resolved native event to a PMU of numeric type `pmu_type`.
+/// Only hardware and hardware-cache events can be pinned.
+pub(crate) fn pin(base: &NamedPerfEvent, pmu: &str, pmu_type: u32) -> anyhow::Result<EventEncoding> {
+    match base.encoding.type_ {
+        PERF_TYPE_HARDWARE | PERF_TYPE_HW_CACHE => Ok(EventEncoding {
+            config: extended_config(base.encoding.config, pmu_type),
+            ..base.encoding
+        }),
+        PERF_TYPE_SOFTWARE => anyhow::bail!(
+            "software event '{}' is CPU-wide and cannot be pinned to PMU '{pmu}'",
+            base.name
+        ),
+        other => anyhow::bail!("event '{}' (perf type {other}) cannot be pinned to a PMU", base.name),
+    }
+}
+
+/// Pack a PMU's numeric type into the high 32 bits of `config`.
+fn extended_config(config: u64, pmu_type: u32) -> u64 {
+    config | (u64::from(pmu_type) << 32)
 }
 
 /// Returns an hardware perf event from its name.
@@ -190,5 +212,30 @@ mod tests {
     #[test]
     fn unknown_name_is_rejected() {
         assert!(parse("DEFINITELY_NOT_A_REAL_EVENT_XYZ").is_err());
+    }
+
+    #[test]
+    fn extended_config_packs_pmu_type_high() {
+        // (pmu_type << 32) | config. e.g. cpu_core (type 4) + generic INSTRUCTIONS (1).
+        assert_eq!(extended_config(0x1, 4), 0x4_0000_0001);
+        assert_eq!(extended_config(0xc0, 10), 0xa_0000_00c0);
+    }
+
+    #[test]
+    fn software_cannot_be_pinned_to_a_pmu() {
+        // Software events are CPU-wide; the type check rejects them (no sysfs read needed).
+        let base = parse("CONTEXT_SWITCHES").unwrap();
+        let err = pin(&base, "cpu_core", 4).unwrap_err();
+        assert!(format!("{err:#}").contains("CPU-wide"), "got: {err:#}");
+    }
+
+    #[test]
+    fn hardware_pinned_to_pmu_uses_extended_type() {
+        // Pinning is pure: the generic type is preserved and the PMU's numeric type is packed into
+        // config's high bits. cpu_core is type 4 on this ABI.
+        let base = parse("INSTRUCTIONS").unwrap();
+        let e = pin(&base, "cpu_core", 4).unwrap();
+        assert_eq!(e.type_, base.encoding.type_);
+        assert_eq!(e.config, extended_config(base.encoding.config, 4));
     }
 }

--- a/plugins/perf/src/pmu.rs
+++ b/plugins/perf/src/pmu.rs
@@ -1,0 +1,178 @@
+//! sysfs helpers for named PMUs: splitting the `pmu/terms` form, reading a PMU's numeric `type`, its
+//! `cpumask` / `cpus`, and enumerating the task-attachable core PMUs.
+//!
+//! A named PMU (`cpu_core`, `uncore_imc_0`, `power`, …) is addressed by the numeric id in
+//! `/sys/bus/event_source/devices/<pmu>/type`, which goes into `perf_event_attr.type`. Its `cpumask`
+//! (when present) tells the system-wide PMUs apart from the task-attachable core ones, which expose
+//! `cpus` instead.
+
+use std::{fs, io};
+
+use anyhow::Context;
+
+use crate::cpu::parse_cpu_list;
+
+/// Split a `pmu/terms` string into its PMU name and inner term list.
+pub fn split(name: &str) -> Option<(&str, &str)> {
+    let (pmu, terms) = name.split_once('/')?;
+    let terms = terms.strip_suffix('/').unwrap_or(terms);
+    if pmu.is_empty() || terms.is_empty() || terms.contains('/') {
+        return None;
+    }
+    Some((pmu, terms))
+}
+
+/// Read a PMU's numeric perf `type` from sysfs.
+pub fn read_type(pmu: &str) -> anyhow::Result<u32> {
+    let path = format!("/sys/bus/event_source/devices/{pmu}/type");
+    let raw = fs::read_to_string(&path)
+        .with_context(|| format!("cannot read {path}; is '{pmu}' a valid PMU? (see /sys/bus/event_source/devices)"))?;
+    raw.trim()
+        .parse::<u32>()
+        .with_context(|| format!("invalid PMU type in {path}: {:?}", raw.trim()))
+}
+
+/// Read a PMU's `cpumask`.
+pub fn read_cpumask(pmu: &str) -> anyhow::Result<Option<Vec<u32>>> {
+    read_cpu_list_file(pmu, "cpumask")
+}
+
+/// Read a PMU's `cpus`.
+pub fn read_cpus(pmu: &str) -> anyhow::Result<Option<Vec<u32>>> {
+    read_cpu_list_file(pmu, "cpus")
+}
+
+fn read_cpu_list_file(pmu: &str, file: &str) -> anyhow::Result<Option<Vec<u32>>> {
+    let path = format!("/sys/bus/event_source/devices/{pmu}/{file}");
+    match fs::read_to_string(&path) {
+        Ok(list) => Ok(Some(
+            parse_cpu_list(&list).with_context(|| format!("invalid {file} in {path}"))?,
+        )),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e).with_context(|| format!("cannot read {path}")),
+    }
+}
+
+/// A task-attachable core PMU
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CorePmu {
+    pub name: String,
+    pub type_: u32,
+    pub cpus: Vec<u32>,
+    pub package: Option<u32>,
+}
+
+/// Enumerate the task-attachable core PMUs
+pub fn core_pmus() -> anyhow::Result<Vec<CorePmu>> {
+    let mut out = Vec::new();
+    let entries = match fs::read_dir("/sys/bus/event_source/devices") {
+        Ok(e) => e,
+        Err(_) => return Ok(out),
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        // A core PMU has a `cpus` list and no `cpumask` (that would make it system-wide).
+        if !matches!(read_cpumask(&name), Ok(None)) {
+            continue;
+        }
+        let Ok(Some(cpus)) = read_cpus(&name) else { continue };
+        let Ok(type_) = read_type(&name) else { continue };
+        let package = single_package(&cpus);
+        out.push(CorePmu {
+            name,
+            type_,
+            cpus,
+            package,
+        });
+    }
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(out)
+}
+
+/// The package shared by every CPU in `cpus`, or `None` if they span several packages
+pub fn single_package(cpus: &[u32]) -> Option<u32> {
+    let mut packages = cpus.iter().map(|&c| crate::cpu::package_of(c).ok());
+    let first = packages.next().flatten()?;
+    packages.all(|p| p == Some(first)).then_some(first)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_extracts_pmu_and_terms() {
+        assert_eq!(split("uncore_imc_0/r0x1/"), Some(("uncore_imc_0", "r0x1")));
+        assert_eq!(split("cpu_core/INSTRUCTIONS"), Some(("cpu_core", "INSTRUCTIONS"))); // closing / optional
+        assert_eq!(
+            split("cpu/event=0x2e,umask=0x41/"),
+            Some(("cpu", "event=0x2e,umask=0x41"))
+        );
+    }
+
+    #[test]
+    fn split_rejects_other_shapes() {
+        assert_eq!(split("r3c"), None); // no `/` at all
+        assert_eq!(split("cpu_core/"), None); // empty terms
+        assert_eq!(split("/r3c/"), None); // empty PMU
+        assert_eq!(split("a/b/c/"), None); // nested slash
+    }
+
+    #[test]
+    fn read_type_matches_sysfs_for_an_available_pmu() {
+        // Reads a real PMU from sysfs; skips cleanly where /sys is unavailable (e.g. a sandbox).
+        let Some((pmu, expected)) = first_available_pmu() else {
+            eprintln!("skipping read_type_matches_sysfs_for_an_available_pmu: no PMU found in sysfs");
+            return;
+        };
+        assert_eq!(read_type(&pmu).unwrap(), expected);
+    }
+
+    #[test]
+    fn read_type_rejects_unknown_pmu() {
+        assert!(read_type("definitely_not_a_pmu_xyz").is_err());
+    }
+
+    #[test]
+    fn cpumask_absent_reads_as_none() {
+        // A PMU with no `cpumask` file (here: a non-existent one) is treated as task-attachable, so
+        // the classification is `None` rather than an error.
+        assert_eq!(read_cpumask("definitely_not_a_pmu_xyz").unwrap(), None);
+    }
+
+    #[test]
+    fn cpumask_present_reads_as_some() {
+        // Finds a real system-wide PMU (uncore, power, cstate…) and checks its cpumask is non-empty.
+        // Skips cleanly if /sys has none (e.g. a sandbox, or a machine with no such PMU).
+        let Some(pmu) = first_pmu_with_cpumask() else {
+            eprintln!("skipping cpumask_present_reads_as_some: no system-wide PMU found in sysfs");
+            return;
+        };
+        let cpus = read_cpumask(&pmu).unwrap().expect("cpumask file exists");
+        assert!(!cpus.is_empty(), "cpumask of {pmu} should list at least one CPU");
+    }
+
+    /// Find any PMU exposing a `cpumask` in sysfs (a system-wide PMU), returning its name.
+    fn first_pmu_with_cpumask() -> Option<String> {
+        let entries = std::fs::read_dir("/sys/bus/event_source/devices").ok()?;
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if matches!(read_cpumask(&name), Ok(Some(_))) {
+                return Some(name);
+            }
+        }
+        None
+    }
+
+    /// Find any PMU exposing a numeric `type` in sysfs, returning its name and type.
+    fn first_available_pmu() -> Option<(String, u32)> {
+        let entries = std::fs::read_dir("/sys/bus/event_source/devices").ok()?;
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if let Ok(t) = read_type(&name) {
+                return Some((name, t));
+            }
+        }
+        None
+    }
+}

--- a/plugins/perf/src/raw.rs
+++ b/plugins/perf/src/raw.rs
@@ -1,19 +1,30 @@
 //! Raw perf events, in the style of `perf stat -e`.
 //!
-//! One form is accepted:
-//! - **`rN`** — a raw event code `N` (hexadecimal) on the default raw PMU (`PERF_TYPE_RAW`), e.g.
+//! Two forms are accepted:
+//! - **`rN`**: a raw event code `N` (hexadecimal) on the default raw PMU (`PERF_TYPE_RAW`), e.g.
 //!   `r3c` or `r0x412e`. `N` is written verbatim into `config`.
+//! - **`pmu/rN`**: the same raw code, but on a specific PMU whose numeric `type` is read from sysfs,
+//!   e.g. `uncore_imc_0/r0x1`. This is the only way to reach a PMU (uncore, `power`, …) that has no
+//!   generic namespace.
 
 use perf_event_open_sys::bindings::PERF_TYPE_RAW;
 
+use crate::pmu;
 use crate::spec::{EventEncoding, NamedPerfEvent, sanitize};
 
 /// Try to parse `name` as a raw-hex event.
 ///
-/// Returns `None` if `name` is not the raw form.
+/// Returns `None` if `name` is neither `rN` nor `pmu/rN`.
+/// Returns `Some(Err(_))` when the form matched but the PMU `type` could not be read.
 pub fn parse(name: &str) -> Option<anyhow::Result<NamedPerfEvent>> {
+    // `pmu/rN`: a raw code on a specific PMU.
+    if let Some((pmu, term)) = pmu::split(name) {
+        let config = raw_config(term)?;
+        return Some(build(Some(pmu), config, name));
+    }
+    // `rN`: a raw code on the default raw PMU.
     let config = raw_config(name)?;
-    Some(Ok(build(config, name)))
+    Some(build(None, config, name))
 }
 
 /// Parse a raw code token `r<hex>` (with an optional `0x` prefix) into its `config` value.
@@ -27,17 +38,21 @@ fn raw_config(token: &str) -> Option<u64> {
     u64::from_str_radix(digits, 16).ok()
 }
 
-fn build(config: u64, original: &str) -> NamedPerfEvent {
-    NamedPerfEvent {
+fn build(pmu: Option<&str>, config: u64, original: &str) -> anyhow::Result<NamedPerfEvent> {
+    let (type_, description) = match pmu {
+        Some(pmu) => (pmu::read_type(pmu)?, format!("raw event {config:#x} on PMU {pmu}")),
+        None => (PERF_TYPE_RAW, format!("raw event {config:#x}")),
+    };
+    Ok(NamedPerfEvent {
         name: sanitize(original),
-        description: format!("raw event {config:#x}"),
+        description,
         encoding: EventEncoding {
-            type_: PERF_TYPE_RAW,
+            type_,
             config,
             config1: 0,
             config2: 0,
         },
-    }
+    })
 }
 
 #[cfg(test)]
@@ -79,6 +94,42 @@ mod tests {
     #[test]
     fn non_raw_name_is_not_recognised() {
         assert!(parse("INSTRUCTIONS").is_none());
-        assert!(parse("cpu/config=0x3c/").is_none());
+        assert!(parse("cpu/config=0x3c/").is_none()); // pmu-named term, not `rN`
+        assert!(parse("cpu_core/INSTRUCTIONS").is_none()); // native-on-pmu, not `rN`
+    }
+
+    #[test]
+    fn pmu_raw_uses_the_pmu_type() {
+        // `pmu/rN` encodes on that PMU's numeric `type` (read from sysfs). Uses a real PMU so the
+        // encoding reflects it; skips cleanly if /sys is unavailable (e.g. a sandbox).
+        let Some((pmu, expected_type)) = first_available_pmu() else {
+            eprintln!("skipping pmu_raw_uses_the_pmu_type: no PMU found in sysfs");
+            return;
+        };
+        let name = format!("{pmu}/r0x1/");
+        let e = parse(&name).expect("recognised as raw").expect("valid");
+        assert_eq!(e.encoding.type_, expected_type);
+        assert_eq!(e.encoding.config, 0x1);
+        assert_eq!(e.name, sanitize(&name));
+    }
+
+    #[test]
+    fn pmu_raw_with_unknown_pmu_errors() {
+        // The `pmu/rN` shape matched, but the PMU does not exist: this must surface as an error,
+        // not as "not recognised".
+        let result = parse("definitely_not_a_pmu_xyz/r0x1").expect("recognised as pmu/rN");
+        assert!(result.is_err());
+    }
+
+    /// Find any PMU exposing a numeric `type` in sysfs, returning its name and type.
+    fn first_available_pmu() -> Option<(String, u32)> {
+        let entries = std::fs::read_dir("/sys/bus/event_source/devices").ok()?;
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if let Ok(t) = pmu::read_type(&name) {
+                return Some((name, t));
+            }
+        }
+        None
     }
 }

--- a/plugins/perf/src/source.rs
+++ b/plugins/perf/src/source.rs
@@ -12,7 +12,7 @@ use itertools::Itertools;
 
 use crate::cpu;
 use crate::multiplexing::{GroupCounters, Snapshot};
-use crate::spec::ConfiguredEvent;
+use crate::spec::{ConfiguredEvent, CoreBinding};
 
 #[derive(Debug)]
 pub enum Observable {
@@ -37,6 +37,10 @@ struct EventGroup {
     observed_resource: Resource,
     observed_consumer: ResourceConsumer,
     cpu_id: Option<u32>,
+    /// The PMU key shared by this group's events.
+    group_key: u64,
+    pmu_attr: Option<String>,
+    cluster_pinned: bool,
     counters: Vec<(perf_event::Counter, TypedMetricId<u64>)>,
     scaling: GroupCounters,
     /// Whether the previous poll found the group starved, so that we only warn on the transition
@@ -64,13 +68,13 @@ impl EventGroup {
             values: self.counters.iter().map(|(counter, _)| counts[counter]).collect(),
         };
 
-        let interval = self.scaling.account(now, auto_scale);
+        let interval = self.scaling.account(now, auto_scale, self.cluster_pinned);
         // Only warn on the transition: starvation can last for the whole lifetime of the source.
         let starved = interval == Interval::Starved;
         let just_starved = starved && !self.starved;
         self.starved = starved;
         match interval {
-            Interval::Idle | Interval::Exact => (),
+            Interval::Idle | Interval::Exact | Interval::Partial => (),
             Interval::Multiplexed { running, enabled } => {
                 log::debug!(
                     "perf group of {:?} (cpu {:?}) was only on the PMU {:.1}% of the time, its values are {}",
@@ -83,9 +87,8 @@ impl EventGroup {
             Interval::Starved if just_starved => {
                 log::warn!(
                     "perf group of {:?} (cpu {:?}) ran but never made it onto the PMU, its counters are stalled. \
-                     Possible causes: more events configured than the CPU has hardware counters, another tool \
-                     using the PMU system-wide, or a CPU whose PMU does not provide these events (on hybrid CPUs, \
-                     generic events are only available on some cores).",
+                     Possible causes: more events configured in one group than the CPU has hardware counters, or \
+                     tools holding the PMU system-wide.",
                     self.observed_consumer,
                     self.cpu_id,
                 );
@@ -110,10 +113,13 @@ impl Source for PerfEventSource {
 
             // for each counter, push its value (the two vecs are in the same order by construction)
             for ((_, alumet_metric), value) in group.counters.iter().zip(group.scaling.corrected()) {
-                measurements.push(
+                let mut point =
                     MeasurementPoint::new(timestamp, *alumet_metric, resource.clone(), consumer.clone(), *value)
-                        .with_attr("accuracy", accuracy),
-                )
+                        .with_attr("accuracy", accuracy);
+                if let Some(pmu) = &group.pmu_attr {
+                    point = point.with_attr("pmu", pmu.clone());
+                }
+                measurements.push(point)
             }
         }
         Ok(())
@@ -142,118 +148,65 @@ impl PerfEventSourceBuilder {
         })
     }
 
-    pub fn add(&mut self, event: &ConfiguredEvent, alumet_metric: TypedMetricId<u64>) -> anyhow::Result<&mut Self> {
-        // Returns a new [`perf_event::Builder`] configured to build a group of perf events.
-        fn new_group_builder<'a>() -> perf_event::Builder<'a> {
-            use perf_event::ReadFormat;
+    pub fn add(
+        &mut self,
+        event: &ConfiguredEvent,
+        alumet_metric: TypedMetricId<u64>,
+        binding: Option<&CoreBinding>,
+    ) -> anyhow::Result<&mut Self> {
+        let key = event.pmu_group_key();
+        let pmu_attr = binding.map(|b| b.pmu.clone());
 
-            // use the DUMMY event for the group leader, because its value is not included in the result of Group::read
-            let mut builder = perf_event::Builder::new(perf_event::events::Software::DUMMY);
-            builder.read_format(
-                ReadFormat::GROUP | ReadFormat::TOTAL_TIME_ENABLED | ReadFormat::TOTAL_TIME_RUNNING | ReadFormat::ID,
-            );
-            builder
-        }
+        let Self {
+            observable,
+            groups,
+            online_cpus,
+            ..
+        } = self;
 
-        if self.groups.is_empty() {
-            // create the group(s)
-            match &self.observable {
-                Observable::Process { pid } => {
-                    // Observe the process on any cpu.
-
-                    // build group
-                    let mut perf_group = new_group_builder()
-                        .observe_pid(*pid)
-                        .any_cpu()
-                        .build_group()
-                        .with_context(|| format!("build_group with observe_pid({pid}).any_cpu()"))?;
-
-                    // add event (the params must be the same)
-                    let mut event_builder = perf_event::Builder::new(event.encoding());
-                    event_builder.observe_pid(*pid).any_cpu();
-                    event.configure(&mut event_builder);
-                    let counter = perf_group
-                        .add(&event_builder)
-                        .with_context(|| format!("perf_group.add with observe_pid({pid}).any_cpu()"))?;
-
-                    // add metadata
-                    let group_with_info = EventGroup {
-                        perf_group,
-                        observed_resource: Resource::LocalMachine,
-                        observed_consumer: ResourceConsumer::Process {
-                            pid: u32::try_from(*pid).unwrap(),
-                        },
-                        cpu_id: None,
-                        counters: vec![(counter, alumet_metric)],
-                        scaling: GroupCounters::default(),
-                        starved: false,
-                    };
-
-                    // done
-                    self.groups = vec![group_with_info];
-                }
-                Observable::Cgroup { path, fd } => {
-                    // Observe the cgroup on each cpu separately (this is a restriction of perf_event_open).
-
-                    // build one group per cpu
-                    let mut groups = Vec::new();
-                    for cpu_id in &self.online_cpus {
-                        let cpu_id = *cpu_id as usize;
-
-                        // build group
-                        let mut perf_group = new_group_builder()
-                            .observe_cgroup(fd)
-                            .one_cpu(cpu_id)
-                            .build_group()
-                            .with_context(|| format!("build_group with observe_cgroup({path}).one_cpu({cpu_id})"))?;
-
-                        // add event (the params must be the same)
-                        let mut event_builder = perf_event::Builder::new(event.encoding());
-                        event_builder.observe_cgroup(fd).one_cpu(cpu_id);
-                        event.configure(&mut event_builder);
-                        let counter = perf_group
-                            .add(&event_builder)
-                            .with_context(|| format!("perf_group.add with observe_cgroup({path}).one_cpu({cpu_id})"))?;
-
-                        let group_with_info = EventGroup {
-                            perf_group,
-                            observed_resource: Resource::CpuCore { id: cpu_id as u32 },
-                            observed_consumer: ResourceConsumer::ControlGroup {
-                                path: path.to_owned().into(),
-                            },
-                            cpu_id: Some(cpu_id as u32),
-                            counters: vec![(counter, alumet_metric)],
-                            scaling: GroupCounters::default(),
-                            starved: false,
-                        };
-                        groups.push(group_with_info);
-                    }
-                    self.groups = groups;
-                }
+        match &*observable {
+            Observable::Process { pid } => {
+                let pid = *pid;
+                let consumer = ResourceConsumer::Process {
+                    pid: u32::try_from(pid).unwrap(),
+                };
+                let resource = binding.map_or(Resource::LocalMachine, |b| b.resource.clone());
+                let cluster_pinned = binding.is_some_and(|b| b.cpus.len() < online_cpus.len());
+                ensure_group_and_add(
+                    groups,
+                    observable,
+                    key,
+                    None,
+                    resource,
+                    consumer,
+                    pmu_attr,
+                    cluster_pinned,
+                    event,
+                    alumet_metric,
+                )?;
             }
-        } else {
-            // add to the group(s)
-            for group in &mut self.groups {
-                let mut event_builder = perf_event::Builder::new(event.encoding());
-
-                // Compute the event params to be the same as the group's params.
-                match &self.observable {
-                    Observable::Process { pid } => {
-                        event_builder.observe_pid(*pid).any_cpu();
-                    }
-                    Observable::Cgroup { path: _, fd } => {
-                        event_builder.observe_cgroup(fd).one_cpu(group.cpu_id.unwrap() as usize);
-                    }
+            Observable::Cgroup { path, .. } => {
+                let path = path.clone();
+                let cpus = binding.map_or(online_cpus.as_slice(), |b| b.cpus.as_slice());
+                for cpu in cpus.iter().copied() {
+                    let consumer = ResourceConsumer::ControlGroup {
+                        path: path.clone().into(),
+                    };
+                    ensure_group_and_add(
+                        groups,
+                        observable,
+                        key,
+                        Some(cpu),
+                        Resource::CpuCore { id: cpu },
+                        consumer,
+                        pmu_attr.clone(),
+                        // A cgroup is opened per-cpu, one cpu per group: the cluster-coverage
+                        // reasoning does not apply, so keep the standard accounting.
+                        false,
+                        event,
+                        alumet_metric,
+                    )?;
                 }
-                event.configure(&mut event_builder);
-
-                let counter = group.perf_group.add(&event_builder).with_context(|| {
-                    format!(
-                        "existing perf_group.add(event_builder), group resource={:?}, consumer={:?}, cpu={:?}",
-                        group.observed_resource, group.observed_consumer, group.cpu_id
-                    )
-                })?;
-                group.counters.push((counter, alumet_metric))
             }
         }
         Ok(self)
@@ -280,5 +233,194 @@ impl PerfEventSourceBuilder {
             event_groups: self.groups,
             multiplexing_auto_scale: self.multiplexing_auto_scale,
         })
+    }
+}
+
+/// A new group leader builder: a `DUMMY` software event (its value is excluded from `Group::read`,
+/// it just anchors the group and carries the read format shared by every counter of the group).
+fn new_group_builder<'a>() -> perf_event::Builder<'a> {
+    use perf_event::ReadFormat;
+
+    let mut builder = perf_event::Builder::new(perf_event::events::Software::DUMMY);
+    builder.read_format(
+        ReadFormat::GROUP | ReadFormat::TOTAL_TIME_ENABLED | ReadFormat::TOTAL_TIME_RUNNING | ReadFormat::ID,
+    );
+    builder
+}
+
+/// Attach the counter to an observed entity (leader and members must share these settings).
+fn attach_to<'o>(builder: &mut perf_event::Builder<'o>, observable: &'o Observable, cpu_id: Option<u32>) {
+    match observable {
+        Observable::Process { pid } => {
+            builder.observe_pid(*pid).any_cpu();
+        }
+        Observable::Cgroup { fd, .. } => {
+            builder
+                .observe_cgroup(fd)
+                .one_cpu(cpu_id.expect("a cgroup group is always bound to a specific cpu") as usize);
+        }
+    }
+}
+
+/// Add `event` to the group matching `(cpu_id, key)`, creating that group (a fresh `DUMMY` leader)
+/// if none exists yet.
+#[allow(clippy::too_many_arguments)]
+fn ensure_group_and_add(
+    groups: &mut Vec<EventGroup>,
+    observable: &Observable,
+    key: u64,
+    cpu_id: Option<u32>,
+    resource: Resource,
+    consumer: ResourceConsumer,
+    pmu_attr: Option<String>,
+    cluster_pinned: bool,
+    event: &ConfiguredEvent,
+    metric: TypedMetricId<u64>,
+) -> anyhow::Result<()> {
+    if let Some(group) = groups.iter_mut().find(|g| g.cpu_id == cpu_id && g.group_key == key) {
+        let mut event_builder = perf_event::Builder::new(event.encoding());
+        attach_to(&mut event_builder, observable, cpu_id);
+        event.configure(&mut event_builder);
+        let counter = group
+            .perf_group
+            .add(&event_builder)
+            .with_context(|| format!("adding event to group (cpu={cpu_id:?}, pmu_key={key:#x})"))?;
+        group.counters.push((counter, metric));
+    } else {
+        let mut leader = new_group_builder();
+        attach_to(&mut leader, observable, cpu_id);
+        let mut perf_group = leader
+            .build_group()
+            .with_context(|| format!("building perf group (cpu={cpu_id:?}, pmu_key={key:#x})"))?;
+
+        let mut event_builder = perf_event::Builder::new(event.encoding());
+        attach_to(&mut event_builder, observable, cpu_id);
+        event.configure(&mut event_builder);
+        let counter = perf_group
+            .add(&event_builder)
+            .with_context(|| format!("adding first event to group (cpu={cpu_id:?}, pmu_key={key:#x})"))?;
+
+        groups.push(EventGroup {
+            perf_group,
+            observed_resource: resource,
+            observed_consumer: consumer,
+            cpu_id,
+            group_key: key,
+            pmu_attr,
+            cluster_pinned,
+            counters: vec![(counter, metric)],
+            scaling: GroupCounters::default(),
+            starved: false,
+        });
+    }
+    Ok(())
+}
+
+impl PerfEventSource {
+    /// Build a machine-wide source for system-wide PMUs (uncore, `power`, `cstate_*`, …).
+    pub fn build_system_wide(
+        multiplexing_auto_scale: bool,
+        events: impl IntoIterator<Item = (ConfiguredEvent, TypedMetricId<u64>, String, Vec<u32>)>,
+    ) -> anyhow::Result<Self> {
+        let mut groups = Vec::new();
+        for (event, metric, pmu, cpus) in events {
+            let key = event.pmu_group_key();
+            for cpu in cpus {
+                let cpu_idx = cpu as usize;
+
+                // System-wide PMUs (RAPL/uncore/cstate) reject the `exclude_*` domain bits, and the
+                // domain modifiers (`#u`/`#k`/`#h`) are meaningless for them anyway. So we clear the
+                // excludes and do *not* apply the event's modifiers, on both leader and member.
+                let mut leader = new_group_builder();
+                leader
+                    .exclude_user(false)
+                    .exclude_kernel(false)
+                    .exclude_hv(false)
+                    .any_pid()
+                    .one_cpu(cpu_idx);
+                let mut perf_group = leader
+                    .build_group()
+                    .with_context(|| format!("build_group system-wide on cpu {cpu}"))?;
+
+                let mut event_builder = perf_event::Builder::new(event.encoding());
+                event_builder
+                    .exclude_user(false)
+                    .exclude_kernel(false)
+                    .exclude_hv(false)
+                    .any_pid()
+                    .one_cpu(cpu_idx);
+                let counter = perf_group
+                    .add(&event_builder)
+                    .with_context(|| format!("adding system-wide event on cpu {cpu}"))?;
+
+                groups.push(EventGroup {
+                    perf_group,
+                    observed_resource: resource_of(&pmu, cpu),
+                    observed_consumer: ResourceConsumer::LocalMachine,
+                    cpu_id: Some(cpu),
+                    group_key: key,
+                    pmu_attr: None,
+                    cluster_pinned: false,
+                    counters: vec![(counter, metric)],
+                    scaling: GroupCounters::new(1),
+                    starved: false,
+                });
+            }
+        }
+        for group in &mut groups {
+            group.perf_group.enable().context("enabling system-wide group")?;
+        }
+        Ok(PerfEventSource {
+            event_groups: groups,
+            multiplexing_auto_scale,
+        })
+    }
+}
+
+/// Map a system-wide PMU to the Alumet Resource.
+fn resource_of(pmu: &str, cpu: u32) -> Resource {
+    let package = cpu::package_of(cpu).ok();
+    match (pmu, package) {
+        // per-core PMU: the reader CPU *is* the physical core.
+        ("cstate_core", _) => Resource::CpuCore { id: cpu },
+        // memory controllers: the RAM of the reader's package.
+        (p, Some(pkg)) if p.starts_with("uncore_imc") => Resource::Dram { pkg_id: pkg },
+        // package-scoped PMUs we know: RAPL and package C-states.
+        (p, Some(pkg)) if p == "power" || p.starts_with("cstate_pkg") => Resource::CpuPackage { id: pkg },
+        // anything else (other uncore boxes, unknown PMUs): explicit rather than guessed.
+        _ => Resource::Custom {
+            kind: pmu.to_owned().into(),
+            id: cpu.to_string().into(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resource_of_maps_core_and_unknown_pmus() {
+        // cstate_core: the reader CPU is the physical core (no topology lookup needed).
+        assert_eq!(resource_of("cstate_core", 2), Resource::CpuCore { id: 2 });
+        // An unknown PMU: explicit Custom, collision-free (id = the reader CPU).
+        assert_eq!(
+            resource_of("uncore_cbox_0", 5),
+            Resource::Custom {
+                kind: "uncore_cbox_0".to_owned().into(),
+                id: "5".to_owned().into(),
+            }
+        );
+    }
+
+    #[test]
+    fn resource_of_maps_package_pmus_when_topology_is_available() {
+        // power -> package, uncore_imc -> that package's DRAM. Needs sysfs topology; skip if absent.
+        let Ok(pkg) = cpu::package_of(0) else {
+            eprintln!("skipping resource_of_maps_package_pmus_when_topology_is_available: no topology");
+            return;
+        };
+        assert_eq!(resource_of("power", 0), Resource::CpuPackage { id: pkg });
+        assert_eq!(resource_of("uncore_imc_0", 0), Resource::Dram { pkg_id: pkg });
     }
 }

--- a/plugins/perf/src/spec.rs
+++ b/plugins/perf/src/spec.rs
@@ -2,26 +2,37 @@
 //!
 //! An event is written `<event>[#<modifiers>]`.
 //!
-//! `<event>` can take one of five forms (a bit like `perf stat -e`). We support a subset for
-//! now and *recognise* the rest so the syntax stays stable across releases:
+//! `<event>` can take one of these forms (a bit like `perf stat -e`):
 //!
 //! - **native** : a symbolic event name (`INSTRUCTIONS`, `LL_READ_MISS`), encoded from the native
-//!   kernel tables (hardware/software/cache). **Supported**.
+//!   kernel tables (hardware/software/cache). On a hybrid CPU, a generic
+//!   hardware/cache event is counted on *every* core PMU (`cpu_core` + `cpu_atom`), like `perf stat`
+//!   does; the resulting measurements share the metric name and carry a `pmu` attribute.
+//! - **native on a PMU** : a native name pinned to a PMU, `pmu/NAME` (e.g. `cpu_core/INSTRUCTIONS`).
 //! - **libpfm** : any other name, optionally with unit masks (e.g. `RESOURCE_STALLS:ANY`), resolved
-//!   through libpfm (per-CPU encoding tables). This is the fallback when the native tables don't
-//!   know the name. **Supported**.
-//! - **raw-hex** : a raw code `rN` (hex register encoding) on the default raw PMU. Layout from
-//!   `/sys/bus/event_source/devices/<pmu>/format/*`. **Supported**.
+//!   through libpfm (per-CPU encoding tables). The fallback when the native tables don't know the
+//!   name.
+//! - **raw-hex** : a raw code `rN` (hex register encoding) on the default raw PMU.
+//! - **raw on a PMU** : `pmu/rN`, the same code on a named PMU.
+//! - **pmu-named** : `pmu/event=M,umask=N,…/`, using the named fields from
+//!   `/sys/bus/event_source/devices/<pmu>/format/*`. **Not yet supported** (rejected with a clear
+//!   "planned for a future release" error).
 //!
-//! A not-yet-supported form is rejected there with an explicit "planned for a future release" error.
+//! An event's [`Scope`] (task-attached vs system-wide) is then derived from the PMU it targets; see
+//! [`Scope`] and [`crate::source`].
 
+use alumet::resources::Resource;
 use anyhow::Context;
 use perf_event::events::Event;
-use perf_event_open_sys::bindings::perf_event_attr;
+use perf_event_open_sys::bindings::{
+    PERF_TYPE_HARDWARE, PERF_TYPE_HW_CACHE, PERF_TYPE_RAW, PERF_TYPE_SOFTWARE, perf_event_attr,
+};
 use serde::{Deserialize, Serialize};
 
+use crate::cpu;
 use crate::native;
 use crate::pfm;
+use crate::pmu;
 use crate::raw;
 
 /// One entry of the `events` config list: a bare string, or a table with a metric `rename`.
@@ -78,6 +89,10 @@ impl Modifiers {
             }
         }
         Ok(m)
+    }
+
+    fn any(&self) -> bool {
+        self.user || self.kernel || self.hv || self.host || self.guest || self.idle_only
     }
 
     /// The `exclude_*` bits these modifiers produce.
@@ -179,12 +194,28 @@ pub struct ConfiguredEvent {
     modifiers: Modifiers,
 }
 
+/// How an event must be opened, decided by the PMU it targets.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Scope {
+    TaskAttached { binding: Option<CoreBinding> },
+    SystemWide { pmu: String, cpus: Vec<u32> },
+}
+
+/// The core PMU a task-attached event is bound to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoreBinding {
+    pub pmu: String,
+    pub cpus: Vec<u32>,
+    pub resource: Resource,
+}
+
 /// A parsed config event: the metric name suffix (after `perf_`), a description and the event.
 /// This is what's used by Alumet to setup metrics.
 #[derive(Debug)]
 pub struct ParsedEvent {
     pub metric_suffix: String,
     pub description: String,
+    pub scope: Scope,
     pub event: ConfiguredEvent,
 }
 
@@ -195,6 +226,20 @@ impl ConfiguredEvent {
         self.encoding
     }
 
+    /// The key identifying which perf group this event may share. A perf group cannot span two
+    /// different hardware PMUs, so [`crate::source`] groups events by this key.
+    pub(crate) fn pmu_group_key(&self) -> u64 {
+        let core = u64::from(PERF_TYPE_RAW);
+        match self.encoding.type_ {
+            PERF_TYPE_HARDWARE | PERF_TYPE_HW_CACHE => {
+                let extended = self.encoding.config >> 32; // extended hardware type (hybrid pinning)
+                if extended != 0 { extended } else { core }
+            }
+            PERF_TYPE_SOFTWARE => core, // software events can share any hardware group
+            other => u64::from(other),  // RAW (== core), or a named PMU's dynamic type (raw-on-pmu)
+        }
+    }
+
     /// Apply this event's modifiers to a freshly-created builder. Must run *after*
     /// [`perf_event::Builder::new`], which forces its own `exclude_kernel`/`exclude_hv` defaults;
     /// this sets every bit explicitly so the result never depends on that ordering.
@@ -203,56 +248,176 @@ impl ConfiguredEvent {
     }
 }
 
-/// Parse one config entry into a [`ParsedEvent`].
-pub fn parse(entry: &EventEntry) -> anyhow::Result<ParsedEvent> {
+/// Parse one config entry into one or more [`ParsedEvent`]s.
+pub fn parse(entry: &EventEntry) -> anyhow::Result<Vec<ParsedEvent>> {
     let (input, rename) = entry.parts();
     // The `#` delimiter separates the encoder name from the plugin's modifiers.
     let (name, mods_str) = input.split_once('#').unwrap_or((input, ""));
     if name.is_empty() {
         anyhow::bail!("empty event name in '{input}'");
     }
-
     let modifiers = Modifiers::parse(mods_str).with_context(|| format!("invalid event '{input}'"))?;
-    let resolved = resolve_event(name).with_context(|| format!("invalid event '{input}'"))?;
 
-    let metric_suffix = match rename {
-        Some(r) => r,
-        None => &resolved.name,
-    };
+    // A named PMU exposing a `cpumask` (uncore, power, cstate) is opened system-wide.
+    if let Some((pmu_name, cpus)) = detect_system_wide(name).with_context(|| format!("invalid event '{input}'"))? {
+        if modifiers.any() {
+            anyhow::bail!(
+                "invalid event '{input}': modifiers do not apply to system-wide events (uncore/power/cstate)"
+            );
+        }
+        let (base, _) = resolve_base(name).with_context(|| format!("invalid event '{input}'"))?;
+        return Ok(vec![ParsedEvent {
+            metric_suffix: sanitize(rename.unwrap_or(&base.name)),
+            description: base.description,
+            scope: Scope::SystemWide { pmu: pmu_name, cpus },
+            event: ConfiguredEvent {
+                encoding: base.encoding,
+                modifiers,
+            },
+        }]);
+    }
 
-    Ok(ParsedEvent {
-        metric_suffix: sanitize(metric_suffix),
-        description: resolved.description,
-        event: ConfiguredEvent {
-            encoding: resolved.encoding,
-            modifiers,
-        },
-    })
+    resolve_task_attached(name, rename, modifiers).with_context(|| format!("invalid event '{input}'"))
 }
 
-/// Resolve an event name (no modifiers) into a [`NamedPerfEvent`]. Each encoder builds the `NamedPerfEvent`
-/// in its own module; this only dispatches to them. See the module docs for the recognised forms.
-fn resolve_event(name: &str) -> anyhow::Result<NamedPerfEvent> {
-    // raw-hex route: `rN`, a raw code on the default raw PMU.
-    if let Some(result) = raw::parse(name) {
-        return result;
+fn detect_system_wide(name: &str) -> anyhow::Result<Option<(String, Vec<u32>)>> {
+    match pmu::split(name) {
+        Some((pmu, _terms)) => Ok(pmu::read_cpumask(pmu)?.map(|cpus| (pmu.to_owned(), cpus))),
+        None => Ok(None),
     }
-    // any `pmu/…/` form (native-on-PMU, raw-on-PMU, pmu-named, pmu-raw): recognised, but not
-    // encoded yet. The whole PMU machinery is planned for a future release.
-    if name.contains('/') {
+}
+
+fn resolve_task_attached(name: &str, rename: Option<&str>, modifiers: Modifiers) -> anyhow::Result<Vec<ParsedEvent>> {
+    let (base, placement) = resolve_base(name)?;
+    let suffix = sanitize(rename.unwrap_or(&base.name));
+
+    let make = |encoding: EventEncoding, binding: Option<CoreBinding>| ParsedEvent {
+        metric_suffix: suffix.clone(),
+        description: base.description.clone(),
+        scope: Scope::TaskAttached { binding },
+        event: ConfiguredEvent { encoding, modifiers },
+    };
+
+    match placement {
+        // A raw code (`rN`), a software event, or a libpfm event: no specific PMU.
+        Placement::Unpinned => Ok(vec![make(base.encoding, None)]),
+        // An explicit `pmu/…`: bound to that one core PMU (its encoding is already pinned).
+        Placement::PmuPinned(pmu) => Ok(vec![make(base.encoding, Some(core_binding(&pmu)?))]),
+        // A bare generic event: counted on every core PMU (both clusters of a hybrid CPU).
+        Placement::CoreGeneric => core_targets()?
+            .into_iter()
+            .map(|t| {
+                let encoding = match t.pmu_type {
+                    Some(pmu_type) => native::pin(&base, &t.binding.pmu, pmu_type)?,
+                    None => base.encoding,
+                };
+                Ok(make(encoding, Some(t.binding)))
+            })
+            .collect(),
+    }
+}
+
+/// How a task-attached event places onto the core PMU(s).
+enum Placement {
+    /// No specific PMU (raw code, software, or libpfm).
+    Unpinned,
+    /// An explicit core PMU.
+    PmuPinned(String),
+    /// A bare native hardware/cache event, to be counted on every core PMU.
+    CoreGeneric,
+}
+
+/// Resolve an event name (no modifiers) into its encoding and how it places onto the core PMU(s).
+/// Each encoder builds the [`NamedPerfEvent`] in its own module; this dispatches to them.
+fn resolve_base(name: &str) -> anyhow::Result<(NamedPerfEvent, Placement)> {
+    // `pmu/…`: a raw code or a native event pinned to that PMU (`cpu_core/INSTRUCTIONS`).
+    if let Some((pmu_name, term)) = pmu::split(name) {
+        if let Some(result) = raw::parse(name) {
+            return Ok((result?, Placement::PmuPinned(pmu_name.to_owned())));
+        }
+        if let Ok(base) = native::parse(term) {
+            let pmu_type = pmu::read_type(pmu_name)?;
+            let encoding = native::pin(&base, pmu_name, pmu_type)?;
+            return Ok((
+                NamedPerfEvent { encoding, ..base },
+                Placement::PmuPinned(pmu_name.to_owned()),
+            ));
+        }
         anyhow::bail!(
-            "pmu-named / pmu-raw events (`{name}`) are not supported yet; this is planned for a future release"
+            "PMU events with named fields (`{name}`, i.e. `pmu/event=,umask=/`) are not supported yet; this is planned for a future release"
         );
     }
 
-    // native route: try the built-in kernel tables first.
-    if let Ok(e) = native::parse(name) {
-        return Ok(e);
+    // `rN`: a raw code on the default raw PMU.
+    if let Some(result) = raw::parse(name) {
+        return Ok((result?, Placement::Unpinned));
     }
-
+    // Built-in kernel tables. Only generic hardware/cache events fan out; software events are
+    // CPU-wide and stay unpinned.
+    if let Ok(base) = native::parse(name) {
+        use perf_event_open_sys::bindings::{PERF_TYPE_HARDWARE, PERF_TYPE_HW_CACHE};
+        let placement = match base.encoding.type_ {
+            PERF_TYPE_HARDWARE | PERF_TYPE_HW_CACHE => Placement::CoreGeneric,
+            _ => Placement::Unpinned,
+        };
+        return Ok((base, placement));
+    }
     // Fall back to libpfm.
-    pfm::encode(name)
-        .with_context(|| format!("unknown event '{name}': not a native event, and libpfm could not encode it"))
+    let base = pfm::encode(name)
+        .with_context(|| format!("unknown event '{name}': not a native event, and libpfm could not encode it"))?;
+    Ok((base, Placement::Unpinned))
+}
+
+struct CoreTarget {
+    pmu_type: Option<u32>,
+    binding: CoreBinding,
+}
+
+fn core_targets() -> anyhow::Result<Vec<CoreTarget>> {
+    let cores = pmu::core_pmus()?;
+    if cores.is_empty() {
+        let cpus = cpu::online_cpus()?;
+        let resource = package_resource(pmu::single_package(&cpus));
+        return Ok(vec![CoreTarget {
+            pmu_type: None,
+            binding: CoreBinding {
+                pmu: "cpu".to_owned(),
+                cpus,
+                resource,
+            },
+        }]);
+    }
+    Ok(cores
+        .into_iter()
+        .map(|c| CoreTarget {
+            pmu_type: Some(c.type_),
+            binding: CoreBinding {
+                pmu: c.name,
+                resource: package_resource(c.package),
+                cpus: c.cpus,
+            },
+        })
+        .collect())
+}
+
+fn core_binding(pmu: &str) -> anyhow::Result<CoreBinding> {
+    let cpus = match pmu::read_cpus(pmu)? {
+        Some(cpus) => cpus,
+        None => cpu::online_cpus()?,
+    };
+    let resource = package_resource(pmu::single_package(&cpus));
+    Ok(CoreBinding {
+        pmu: pmu.to_owned(),
+        cpus,
+        resource,
+    })
+}
+
+fn package_resource(package: Option<u32>) -> Resource {
+    match package {
+        Some(id) => Resource::CpuPackage { id },
+        None => Resource::LocalMachine,
+    }
 }
 
 /// Turn a string into a metric-name-safe suffix: letters are lowercased, non-alphanumeric
@@ -277,42 +442,70 @@ mod tests {
 
     use super::*;
 
-    fn parse_simple(s: &str) -> ParsedEvent {
+    fn parse_all(s: &str) -> Vec<ParsedEvent> {
         parse(&EventEntry::Simple(s.to_owned())).unwrap()
+    }
+
+    fn parse_one(s: &str) -> ParsedEvent {
+        let mut evs = parse_all(s);
+        assert_eq!(evs.len(), 1, "expected a single event for '{s}', got {}", evs.len());
+        evs.pop().unwrap()
+    }
+
+    fn parse_first(s: &str) -> ParsedEvent {
+        parse_all(s).into_iter().next().expect("at least one event")
+    }
+
+    fn is_hybrid() -> bool {
+        pmu::read_type("cpu_core").is_ok() && pmu::read_type("cpu_atom").is_ok()
+    }
+
+    fn assert_generic(enc: &EventEncoding, base: &EventEncoding) {
+        assert_eq!(enc.type_, base.type_);
+        assert_eq!(enc.config & 0xffff_ffff, base.config & 0xffff_ffff);
+        assert_eq!(enc.config1, base.config1);
+        assert_eq!(enc.config2, base.config2);
     }
 
     #[test]
     fn native_hardware() {
-        let e = parse_simple("REF_CPU_CYCLES");
-        assert_eq!(e.metric_suffix, "ref_cpu_cycles");
-        assert_eq!(e.event.encoding, EventEncoding::from_event(Hardware::REF_CPU_CYCLES));
+        let base = EventEncoding::from_event(Hardware::REF_CPU_CYCLES);
+        let evs = parse_all("REF_CPU_CYCLES");
+        assert!(!evs.is_empty());
+        for e in &evs {
+            assert_eq!(e.metric_suffix, "ref_cpu_cycles");
+            assert!(matches!(e.scope, Scope::TaskAttached { .. }));
+            assert_generic(&e.event.encoding, &base);
+        }
     }
 
     #[test]
     fn native_software() {
-        let e = parse_simple("CONTEXT_SWITCHES");
+        let e = parse_one("CONTEXT_SWITCHES");
         assert_eq!(e.metric_suffix, "context_switches");
         assert_eq!(e.event.encoding, EventEncoding::from_event(Software::CONTEXT_SWITCHES));
+        assert_eq!(e.scope, Scope::TaskAttached { binding: None });
     }
 
     #[test]
     fn native_cache() {
-        let e = parse_simple("LL_READ_MISS");
-        assert_eq!(e.metric_suffix, "ll_read_miss");
-        assert_eq!(
-            e.event.encoding,
-            EventEncoding::from_event(Cache {
-                which: CacheId::LL,
-                operation: CacheOp::READ,
-                result: CacheResult::MISS,
-            })
-        );
+        let base = EventEncoding::from_event(Cache {
+            which: CacheId::LL,
+            operation: CacheOp::READ,
+            result: CacheResult::MISS,
+        });
+        let evs = parse_all("LL_READ_MISS");
+        assert!(!evs.is_empty());
+        for e in &evs {
+            assert_eq!(e.metric_suffix, "ll_read_miss");
+            assert_generic(&e.event.encoding, &base);
+        }
     }
 
     #[test]
     fn no_modifier_is_user_space_only() {
         // The default must match the original plugin: user space only (kernel + hv excluded).
-        let e = parse_simple("INSTRUCTIONS");
+        let e = parse_first("INSTRUCTIONS");
         assert_eq!(e.metric_suffix, "instructions");
         assert_eq!(
             e.event.modifiers.excludes(),
@@ -329,14 +522,14 @@ mod tests {
 
     #[test]
     fn user_modifier_matches_default() {
-        let x = parse_simple("INSTRUCTIONS#u").event.modifiers.excludes();
+        let x = parse_first("INSTRUCTIONS#u").event.modifiers.excludes();
         assert!(!x.user && x.kernel && x.hv);
     }
 
     #[test]
     fn user_and_kernel_modifier() {
         // `#u:k` measures user and kernel, but still excludes the hypervisor.
-        let x = parse_simple("INSTRUCTIONS#u:k").event.modifiers.excludes();
+        let x = parse_first("INSTRUCTIONS#u:k").event.modifiers.excludes();
         assert!(!x.user);
         assert!(!x.kernel);
         assert!(x.hv);
@@ -346,14 +539,14 @@ mod tests {
     fn modifiers_must_be_colon_separated() {
         // Modifiers are `:`-separated tokens; the grouped form `#uk` is rejected.
         assert!(parse(&EventEntry::Simple("INSTRUCTIONS#uk".to_owned())).is_err());
-        let x = parse_simple("INSTRUCTIONS#u:k").event.modifiers.excludes();
+        let x = parse_first("INSTRUCTIONS#u:k").event.modifiers.excludes();
         assert!(!x.user && !x.kernel && x.hv);
     }
 
     #[test]
     fn kernel_only_modifier() {
         // `#k` measures kernel only: user is excluded, kernel is counted.
-        let x = parse_simple("INSTRUCTIONS#k").event.modifiers.excludes();
+        let x = parse_first("INSTRUCTIONS#k").event.modifiers.excludes();
         assert!(x.user);
         assert!(!x.kernel);
         assert!(x.hv);
@@ -361,7 +554,7 @@ mod tests {
 
     #[test]
     fn host_and_idle_modifiers() {
-        let x = parse_simple("INSTRUCTIONS#H:I").event.modifiers.excludes();
+        let x = parse_first("INSTRUCTIONS#H:I").event.modifiers.excludes();
         assert!(x.guest); // host only -> exclude guest
         assert!(!x.host);
         assert!(x.idle); // exclude idle
@@ -378,9 +571,10 @@ mod tests {
     fn hash_is_the_modifier_delimiter() {
         // Only what follows `#` is parsed as modifiers; the name is resolved untouched. The `#` is
         // stripped and never becomes part of the metric name.
-        let e = parse_simple("INSTRUCTIONS#u");
+        let base = EventEncoding::from_event(Hardware::INSTRUCTIONS);
+        let e = parse_first("INSTRUCTIONS#u");
         assert_eq!(e.metric_suffix, "instructions");
-        assert_eq!(e.event.encoding, EventEncoding::from_event(Hardware::INSTRUCTIONS));
+        assert_generic(&e.event.encoding, &base);
         assert!(!e.event.modifiers.excludes().user);
     }
 
@@ -391,14 +585,82 @@ mod tests {
             rename: Some("my llc miss".to_owned()),
         })
         .unwrap();
-        assert_eq!(e.metric_suffix, "my_llc_miss");
+        for parsed in &e {
+            assert_eq!(parsed.metric_suffix, "my_llc_miss");
+        }
+    }
+
+    #[test]
+    fn events_without_a_pmu_are_task_attached() {
+        assert!(
+            parse_all("INSTRUCTIONS")
+                .iter()
+                .all(|e| matches!(e.scope, Scope::TaskAttached { .. }))
+        );
+        assert_eq!(parse_one("r0x412e").scope, Scope::TaskAttached { binding: None });
+    }
+
+    #[test]
+    fn a_bare_generic_event_fans_out_on_a_hybrid_cpu() {
+        if !is_hybrid() {
+            eprintln!("skipping a_bare_generic_event_fans_out_on_a_hybrid_cpu: not a hybrid CPU");
+            return;
+        }
+        let base = EventEncoding::from_event(Hardware::INSTRUCTIONS);
+        let evs = parse_all("INSTRUCTIONS");
+        let pmus: Vec<&str> = evs
+            .iter()
+            .map(|e| match &e.scope {
+                Scope::TaskAttached { binding: Some(b) } => b.pmu.as_str(),
+                other => panic!("expected a bound task-attached event, got {other:?}"),
+            })
+            .collect();
+        assert!(pmus.contains(&"cpu_core") && pmus.contains(&"cpu_atom"), "got {pmus:?}");
+        for e in &evs {
+            assert_eq!(e.metric_suffix, "instructions");
+            assert_generic(&e.event.encoding, &base);
+            // Pinned to a specific cluster => the extended hardware type is set.
+            assert_ne!(e.event.encoding.config >> 32, 0);
+        }
+    }
+
+    #[test]
+    fn distinct_core_pmus_get_distinct_group_keys() {
+        if !is_hybrid() {
+            eprintln!("skipping distinct_core_pmus_get_distinct_group_keys: not a hybrid CPU");
+            return;
+        }
+        let core = parse_one("cpu_core/r0x1").event.pmu_group_key();
+        let atom = parse_one("cpu_atom/r0x1").event.pmu_group_key();
+        assert_ne!(core, atom);
+    }
+
+    #[test]
+    fn a_system_wide_pmu_event_is_scoped_system_wide() {
+        let Some((pmu, cpus)) = first_system_wide_pmu() else {
+            eprintln!("skipping a_system_wide_pmu_event_is_scoped_system_wide: no system-wide PMU found");
+            return;
+        };
+        let e = parse_one(&format!("{pmu}/r0x1"));
+        assert_eq!(e.scope, Scope::SystemWide { pmu, cpus });
+    }
+
+    /// Find any PMU exposing a `cpumask` in sysfs (a system-wide PMU), returning its name and cpus.
+    fn first_system_wide_pmu() -> Option<(String, Vec<u32>)> {
+        let entries = std::fs::read_dir("/sys/bus/event_source/devices").ok()?;
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if let Ok(Some(cpus)) = pmu::read_cpumask(&name) {
+                return Some((name, cpus));
+            }
+        }
+        None
     }
 
     #[test]
     fn raw_hex_event() {
         use perf_event_open_sys::bindings::PERF_TYPE_RAW;
-        // `rN` encodes a raw code on the default raw PMU, and modifiers still apply.
-        let e = parse_simple("r0x412e#u:k");
+        let e = parse_one("r0x412e#u:k");
         assert_eq!(e.metric_suffix, "r0x412e");
         assert_eq!(
             e.event.encoding(),
@@ -433,9 +695,9 @@ mod tests {
             eprintln!("skipping libpfm_event_resolves_when_available: libpfm is not available");
             return;
         }
-        // A generic name unknown to the native tables is resolved through libpfm, and produces the
-        // same encoding as calling libpfm directly.
-        let e = parse_simple("PERF_COUNT_HW_INSTRUCTIONS");
+        // A generic name unknown to the native tables is resolved through libpfm (unpinned, never
+        // fanned), and produces the same encoding as calling libpfm directly.
+        let e = parse_one("PERF_COUNT_HW_INSTRUCTIONS");
         assert_eq!(e.metric_suffix, "perf_count_hw_instructions");
         assert_eq!(
             e.event.encoding,


### PR DESCRIPTION
- support of system-wide counters
- target a single PMU
- automatically count of all PMU if no specific PMU configured (for hybrid cpu)